### PR TITLE
feat: permission buttons + auditable allowlist/audit log

### DIFF
--- a/src/channels/telegram/TelegramChannel.ts
+++ b/src/channels/telegram/TelegramChannel.ts
@@ -23,6 +23,7 @@ export class TelegramChannel implements Channel {
     freeText: [] as Array<(event: FreeTextEvent) => void>,
   };
   private readonly promptMessageIds = new Map<string, { messageId: number; chatId: number }>();
+  private awaitingNoteFor: string | null = null;
 
   constructor(private readonly opts: TelegramChannelOptions) {
     this.api = new TelegramApi(opts.token);
@@ -69,6 +70,11 @@ export class TelegramChannel implements Channel {
         this.opts.logger.warn('unparseable callback_data');
         return;
       }
+      if (parsed.action === 'deny_note') {
+        this.awaitingNoteFor = parsed.requestId;
+        this.editKeyboardToAwaitingNote(parsed.requestId);
+        return;
+      }
       const decision = decisionFromAction(parsed.action);
       if (decision) {
         this.clearKeyboard(parsed.requestId);
@@ -78,8 +84,27 @@ export class TelegramChannel implements Channel {
     }
     if (update.message?.text) {
       const text = update.message.text.trim();
+      if (this.awaitingNoteFor) {
+        const requestId = this.awaitingNoteFor;
+        this.awaitingNoteFor = null;
+        this.clearKeyboard(requestId);
+        for (const h of this.handlers.decision) {
+          h({ requestId, decision: { decision: 'deny', reason: text } });
+        }
+        return;
+      }
       for (const h of this.handlers.freeText) h({ text });
     }
+  }
+
+  private editKeyboardToAwaitingNote(requestId: string): void {
+    const ref = this.promptMessageIds.get(requestId);
+    if (!ref) return;
+    this.api.editMessageReplyMarkup(ref.chatId, ref.messageId, [
+      [{ text: '✏️ aguardando justificativa…', callback_data: `${requestId}:noop` }],
+    ]).catch((e) => {
+      this.opts.logger.debug('editMessageReplyMarkup (note) failed', { err: (e as Error).message });
+    });
   }
 
   private clearKeyboard(requestId: string): void {
@@ -112,6 +137,7 @@ function parseCallbackData(data: string): { requestId: string; action: string } 
 
 function decisionFromAction(action: string): Decision | null {
   if (action === 'allow') return { decision: 'allow' };
+  if (action === 'allow_remember') return { decision: 'allow', remember: true };
   if (action === 'deny') return { decision: 'deny' };
   return null;
 }

--- a/src/cli/allowlist.ts
+++ b/src/cli/allowlist.ts
@@ -1,0 +1,40 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import chalk from 'chalk';
+
+interface SettingsShape {
+  permissions?: { allow?: string[]; [k: string]: unknown };
+  [k: string]: unknown;
+}
+
+async function readSettings(dir: string): Promise<SettingsShape | null> {
+  const file = path.join(dir, '.claude', 'settings.local.json');
+  try {
+    return JSON.parse(await fsp.readFile(file, 'utf-8')) as SettingsShape;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw e;
+  }
+}
+
+export async function allowlistList(dir: string): Promise<void> {
+  const target = path.resolve(dir);
+  const settings = await readSettings(target);
+  if (!settings) {
+    console.log(chalk.dim(`(nenhum .claude/settings.local.json em ${target})`));
+    return;
+  }
+  const allow = settings.permissions?.allow ?? [];
+  if (allow.length === 0) {
+    console.log(chalk.dim('(allowlist vazia)'));
+    return;
+  }
+  console.log(chalk.bold(`allowlist em ${target}/.claude/settings.local.json:`));
+  for (const m of allow) console.log(`  ${m}`);
+}
+
+export async function allowlistExport(dir: string): Promise<void> {
+  const target = path.resolve(dir);
+  const settings = await readSettings(target);
+  process.stdout.write(JSON.stringify(settings ?? {}, null, 2) + '\n');
+}

--- a/src/cli/audit.ts
+++ b/src/cli/audit.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk';
+import { readAudit, parseSince, type AuditEntry } from '../daemon/audit.js';
+
+export interface AuditCmdOpts {
+  since?: string;
+  cwd?: string;
+  limit?: string;
+}
+
+function buildFilter(opts: AuditCmdOpts) {
+  return {
+    sinceMs: opts.since ? parseSince(opts.since) : undefined,
+    cwd: opts.cwd,
+    limit: opts.limit ? Number(opts.limit) : undefined,
+  };
+}
+
+function fmtDecision(e: AuditEntry): string {
+  if (e.decision === 'allow') return e.remember ? chalk.green('ALLOW+R') : chalk.green('ALLOW  ');
+  if (e.decision === 'deny') return chalk.red('DENY   ');
+  return chalk.dim('ASK    ');
+}
+
+export async function auditList(opts: AuditCmdOpts): Promise<void> {
+  const entries = await readAudit(buildFilter(opts));
+  if (entries.length === 0) {
+    console.log(chalk.dim('(sem entradas)'));
+    return;
+  }
+  for (const e of entries) {
+    const reason = e.reason ? chalk.dim(` reason="${e.reason}"`) : '';
+    const cwd = e.cwd ? chalk.dim(` cwd=${e.cwd}`) : '';
+    console.log(`${e.ts}  ${fmtDecision(e)}  ${e.tool.padEnd(10)}${cwd}${reason}`);
+  }
+}
+
+export async function auditExport(opts: AuditCmdOpts): Promise<void> {
+  const entries = await readAudit(buildFilter(opts));
+  for (const e of entries) process.stdout.write(JSON.stringify(e) + '\n');
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,8 @@ import { hookCommand } from './hook.js';
 import { claudeCommand } from './claude.js';
 import { hereCommand, awayCommand } from './mode.js';
 import { ohayoCommand } from './ohayo.js';
+import { allowlistList, allowlistExport } from './allowlist.js';
+import { auditList, auditExport } from './audit.js';
 
 // Special-case: `kuroboto claude [...args]` forwards everything raw to Claude Code.
 // Commander would otherwise eat global flags like --version / --help before they
@@ -138,6 +140,60 @@ program
       await hookCommand(type);
     } catch (e) {
       process.stderr.write(`[kuroboto] hook ${type} crashed: ${(e as Error).message}\n`);
+      process.exit(1);
+    }
+  });
+
+const allowlist = program.command('allowlist').description('Inspect the project allowlist (.claude/settings.local.json)');
+allowlist
+  .command('list [dir]')
+  .description('List allow matchers for the given dir (default: cwd)')
+  .action(async (dir?: string) => {
+    try {
+      await allowlistList(dir ?? process.cwd());
+    } catch (e) {
+      console.error(`allowlist list failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  });
+allowlist
+  .command('export [dir]')
+  .description('Print full settings.local.json as JSON')
+  .action(async (dir?: string) => {
+    try {
+      await allowlistExport(dir ?? process.cwd());
+    } catch (e) {
+      console.error(`allowlist export failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+const audit = program.command('audit').description('Inspect the kuroboto decision audit log');
+audit
+  .command('list')
+  .option('--since <duration>', 'e.g. 30s, 5m, 2h, 7d')
+  .option('--cwd <path>', 'filter by cwd')
+  .option('--limit <n>', 'show only the last N entries')
+  .description('Print decisions in human-readable format')
+  .action(async (opts) => {
+    try {
+      await auditList(opts);
+    } catch (e) {
+      console.error(`audit list failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  });
+audit
+  .command('export')
+  .option('--since <duration>', 'e.g. 30s, 5m, 2h, 7d')
+  .option('--cwd <path>', 'filter by cwd')
+  .option('--limit <n>', 'show only the last N entries')
+  .description('Print decisions as raw JSONL (one per line)')
+  .action(async (opts) => {
+    try {
+      await auditExport(opts);
+    } catch (e) {
+      console.error(`audit export failed: ${(e as Error).message}`);
       process.exit(1);
     }
   });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -80,6 +80,7 @@ export async function initCommand(): Promise<void> {
       permissionTimeoutMs: 55_000,
       notifyDelayMs: 60_000,
       permissionMatchers: ['Bash', 'Edit', 'Write'],
+      rememberGranularity: 'tight',
       failOpen: true,
     },
   };

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -5,3 +5,4 @@ export const CONFIG_DIR = path.join(os.homedir(), '.config', 'kuroboto');
 export const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 export const PID_FILE = path.join(CONFIG_DIR, 'daemon.pid');
 export const LOG_DIR = path.join(CONFIG_DIR, 'logs');
+export const AUDIT_FILE = path.join(CONFIG_DIR, 'audit.jsonl');

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -23,6 +23,7 @@ export const PolicyConfig = z.object({
   permissionTimeoutMs: z.number().int().min(1000),
   notifyDelayMs: z.number().int().min(0).default(60_000),
   permissionMatchers: z.array(z.string()).default(['Bash', 'Edit', 'Write']),
+  rememberGranularity: z.enum(['tight', 'permissive']).default('tight'),
   failOpen: z.boolean(),
 });
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -26,7 +26,7 @@ export interface StopPayload {
 export type HookPayload = NotificationPayload | PreToolUsePayload | StopPayload;
 
 export type Decision =
-  | { decision: 'allow'; reason?: string }
+  | { decision: 'allow'; reason?: string; remember?: boolean }
   | { decision: 'deny'; reason?: string }
   | { decision: 'ask'; reason?: string };
 
@@ -36,9 +36,11 @@ export interface PromptRequest {
   buttons: PromptButton[];
 }
 
+export type PromptButtonAction = 'allow' | 'allow_remember' | 'deny' | 'deny_note';
+
 export interface PromptButton {
   label: string;
-  action: 'allow' | 'deny' | 'reply';
+  action: PromptButtonAction;
 }
 
 export interface DecisionEvent {

--- a/src/daemon/allowlist.ts
+++ b/src/daemon/allowlist.ts
@@ -1,0 +1,42 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+export type RememberGranularity = 'tight' | 'permissive';
+
+export function computeAllowMatcher(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  granularity: RememberGranularity,
+): string {
+  if (toolName === 'Bash' && typeof toolInput.command === 'string') {
+    const tokens = toolInput.command.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return 'Bash';
+    const take = granularity === 'permissive' ? 1 : Math.min(2, tokens.length);
+    return `Bash(${tokens.slice(0, take).join(' ')}:*)`;
+  }
+  return toolName;
+}
+
+interface SettingsShape {
+  permissions?: { allow?: string[]; deny?: string[]; [k: string]: unknown };
+  [k: string]: unknown;
+}
+
+export async function addProjectAllow(cwd: string, matcher: string): Promise<void> {
+  const dir = path.join(cwd, '.claude');
+  const file = path.join(dir, 'settings.local.json');
+  await fsp.mkdir(dir, { recursive: true });
+  let json: SettingsShape = {};
+  try {
+    const raw = await fsp.readFile(file, 'utf-8');
+    json = JSON.parse(raw) as SettingsShape;
+    if (typeof json !== 'object' || json === null) json = {};
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+  }
+  const perms = (json.permissions && typeof json.permissions === 'object' ? json.permissions : {}) as NonNullable<SettingsShape['permissions']>;
+  const allow = Array.isArray(perms.allow) ? perms.allow : [];
+  if (!allow.includes(matcher)) allow.push(matcher);
+  json.permissions = { ...perms, allow };
+  await fsp.writeFile(file, JSON.stringify(json, null, 2) + '\n');
+}

--- a/src/daemon/audit.ts
+++ b/src/daemon/audit.ts
@@ -1,0 +1,61 @@
+import fsp from 'node:fs/promises';
+import { AUDIT_FILE, CONFIG_DIR } from '../config/paths.js';
+
+export interface AuditEntry {
+  ts: string;
+  requestId: string;
+  tool: string;
+  cwd: string | null;
+  decision: 'allow' | 'deny' | 'ask';
+  reason: string | null;
+  source: string;
+  remember: boolean;
+}
+
+export interface AuditFilter {
+  sinceMs?: number;
+  cwd?: string;
+  limit?: number;
+}
+
+export async function appendAudit(entry: AuditEntry): Promise<void> {
+  await fsp.mkdir(CONFIG_DIR, { recursive: true });
+  await fsp.appendFile(AUDIT_FILE, JSON.stringify(entry) + '\n');
+}
+
+export async function readAudit(filter: AuditFilter): Promise<AuditEntry[]> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(AUDIT_FILE, 'utf-8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw e;
+  }
+  const cutoff = filter.sinceMs ? Date.now() - filter.sinceMs : null;
+  const lines = raw.split('\n');
+  const out: AuditEntry[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let entry: AuditEntry;
+    try {
+      entry = JSON.parse(line) as AuditEntry;
+    } catch {
+      continue;
+    }
+    if (cutoff !== null && new Date(entry.ts).getTime() < cutoff) continue;
+    if (filter.cwd && entry.cwd !== filter.cwd) continue;
+    out.push(entry);
+  }
+  if (filter.limit && out.length > filter.limit) {
+    return out.slice(out.length - filter.limit);
+  }
+  return out;
+}
+
+export function parseSince(s: string): number {
+  const m = /^(\d+)([smhd])$/.exec(s.trim());
+  if (!m) throw new Error(`invalid --since value: ${s} (use 30s, 5m, 2h, 7d)`);
+  const n = Number(m[1]);
+  const mult = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2] as 's' | 'm' | 'h' | 'd'];
+  return n * mult;
+}

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -3,6 +3,7 @@ import type { DaemonContext } from './server.js';
 import type { PreToolUsePayload, NotificationPayload, Decision } from '../core/types.js';
 import { saveMode, type Mode } from './state.js';
 import { computeAllowMatcher, addProjectAllow } from './allowlist.js';
+import { appendAudit } from './audit.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
   app.get('/v1/health', (_req, res) => {
@@ -107,6 +108,17 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
         ctx.logger.warn('failed to persist allow matcher', { err: (e as Error).message });
       }
     }
+    // Audit log entry — best-effort, never blocks the hook response
+    appendAudit({
+      ts: new Date().toISOString(),
+      requestId,
+      tool: payload.tool_name,
+      cwd: payload.cwd ?? null,
+      decision: decision.decision,
+      reason: decision.reason ?? null,
+      source: deriveSource(decision),
+      remember: decision.decision === 'allow' && !!decision.remember,
+    }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
     const { remember: _r, ...stripped } = decision as { remember?: boolean } & Decision;
     res.json(stripped);
   });
@@ -143,4 +155,10 @@ function summarizeToolInput(tool: string, input: Record<string, unknown>): strin
 
 function truncate(s: string, max: number): string {
   return s.length <= max ? s : s.slice(0, max - 1) + '…';
+}
+
+function deriveSource(d: Decision): string {
+  if (d.decision === 'deny' && d.reason === 'timeout') return 'timeout';
+  if (d.decision === 'ask' && d.reason === 'channel unavailable') return 'channel-error';
+  return 'telegram';
 }

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from 'express';
 import type { DaemonContext } from './server.js';
 import type { PreToolUsePayload, NotificationPayload, Decision } from '../core/types.js';
 import { saveMode, type Mode } from './state.js';
+import { computeAllowMatcher, addProjectAllow } from './allowlist.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
   app.get('/v1/health', (_req, res) => {
@@ -83,7 +84,9 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
         text: formatPermissionPrompt(payload),
         buttons: [
           { label: '✅ Allow', action: 'allow' },
+          { label: '🔓 Allow & remember', action: 'allow_remember' },
           { label: '❌ Deny', action: 'deny' },
+          { label: '💬 Deny with note', action: 'deny_note' },
         ],
       });
     } catch (e) {
@@ -91,7 +94,21 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
       ctx.pending.resolve(requestId, { decision: 'ask', reason: 'channel unavailable' });
     }
     const decision = await promise;
-    res.json(decision);
+    if (decision.decision === 'allow' && decision.remember && payload.cwd) {
+      const matcher = computeAllowMatcher(
+        payload.tool_name,
+        payload.tool_input,
+        ctx.config.policy.rememberGranularity,
+      );
+      try {
+        await addProjectAllow(payload.cwd, matcher);
+        ctx.logger.info('persisted allow matcher', { matcher, cwd: payload.cwd });
+      } catch (e) {
+        ctx.logger.warn('failed to persist allow matcher', { err: (e as Error).message });
+      }
+    }
+    const { remember: _r, ...stripped } = decision as { remember?: boolean } & Decision;
+    res.json(stripped);
   });
 }
 

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import request from 'supertest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
 import { createServer, type DaemonContext } from '../../src/daemon/server.js';
 import { PendingMap } from '../../src/daemon/pending.js';
 import { PendingNotifications } from '../../src/daemon/pendingNotifications.js';
@@ -31,6 +34,7 @@ function makeContext(overrides: Overrides = {}): { ctx: DaemonContext; channel: 
       permissionTimeoutMs: 1_000,
       notifyDelayMs: 60_000,
       permissionMatchers: ['Bash', 'Edit', 'Write'],
+      rememberGranularity: 'tight',
       failOpen: true,
       ...overrides.policy,
     },
@@ -207,5 +211,66 @@ describe('daemon HTTP', () => {
       .set('X-Kuroboto-Token', TEST_TOKEN)
       .send({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: {} });
     expect(res.body).toEqual({ decision: 'ask', reason: 'channel unavailable' });
+  });
+
+  it('POST /v1/permission envia 4 botões para o channel', async () => {
+    ctx.state.mode = 'away';
+    const app = createServer(ctx);
+    const pending = request(app)
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls' }, cwd: '/x' })
+      .then((r) => r);
+    await waitFor(() => channel.sentPrompts.length === 1);
+    expect(channel.sentPrompts[0].buttons.map((b) => b.action))
+      .toEqual(['allow', 'allow_remember', 'deny', 'deny_note']);
+    channel.emitDecision(channel.sentPrompts[0].requestId, { decision: 'deny' });
+    await pending;
+  });
+
+  it('POST /v1/permission persiste matcher quando decision.remember=true', async () => {
+    const tmpCwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-int-'));
+    try {
+      ctx.state.mode = 'away';
+      const app = createServer(ctx);
+      const pending = request(app)
+        .post('/v1/permission')
+        .set('X-Kuroboto-Token', TEST_TOKEN)
+        .send({
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'npm install lodash' },
+          cwd: tmpCwd,
+        })
+        .then((r) => r);
+      await waitFor(() => channel.sentPrompts.length === 1);
+      channel.emitDecision(channel.sentPrompts[0].requestId, { decision: 'allow', remember: true });
+      const res = await pending;
+      // hook não deve receber `remember`
+      expect(res.body).toEqual({ decision: 'allow' });
+      const settings = JSON.parse(
+        await fsp.readFile(path.join(tmpCwd, '.claude', 'settings.local.json'), 'utf-8'),
+      );
+      expect(settings.permissions.allow).toContain('Bash(npm install:*)');
+    } finally {
+      await fsp.rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('POST /v1/permission devolve deny + reason vindo do note flow', async () => {
+    ctx.state.mode = 'away';
+    const app = createServer(ctx);
+    const pending = request(app)
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'rm' }, cwd: '/x' })
+      .then((r) => r);
+    await waitFor(() => channel.sentPrompts.length === 1);
+    channel.emitDecision(channel.sentPrompts[0].requestId, {
+      decision: 'deny',
+      reason: 'não destrua nada',
+    });
+    const res = await pending;
+    expect(res.body).toEqual({ decision: 'deny', reason: 'não destrua nada' });
   });
 });

--- a/test/unit/allowlist.test.ts
+++ b/test/unit/allowlist.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { computeAllowMatcher, addProjectAllow } from '../../src/daemon/allowlist.js';
+
+describe('computeAllowMatcher', () => {
+  it('Bash tight: 2 primeiros tokens + glob', () => {
+    expect(computeAllowMatcher('Bash', { command: 'npm install lodash' }, 'tight'))
+      .toBe('Bash(npm install:*)');
+  });
+  it('Bash tight: 1 token só vira Bash(token:*)', () => {
+    expect(computeAllowMatcher('Bash', { command: 'ls' }, 'tight'))
+      .toBe('Bash(ls:*)');
+  });
+  it('Bash permissive: só primeiro token', () => {
+    expect(computeAllowMatcher('Bash', { command: 'npm install lodash' }, 'permissive'))
+      .toBe('Bash(npm:*)');
+  });
+  it('Bash sem command: fallback toolname puro', () => {
+    expect(computeAllowMatcher('Bash', {}, 'tight')).toBe('Bash');
+  });
+  it('Edit / Write: toolname puro', () => {
+    expect(computeAllowMatcher('Edit', { file_path: '/a.ts' }, 'tight')).toBe('Edit');
+    expect(computeAllowMatcher('Write', { file_path: '/a.ts' }, 'permissive')).toBe('Write');
+  });
+  it('Tool desconhecido: toolname puro', () => {
+    expect(computeAllowMatcher('WebFetch', { url: 'x' }, 'tight')).toBe('WebFetch');
+  });
+});
+
+describe('addProjectAllow', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-allowlist-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('cria .claude/settings.local.json se não existe', async () => {
+    await addProjectAllow(tmpDir, 'Bash(npm install:*)');
+    const raw = await fsp.readFile(path.join(tmpDir, '.claude', 'settings.local.json'), 'utf-8');
+    const json = JSON.parse(raw);
+    expect(json.permissions.allow).toEqual(['Bash(npm install:*)']);
+  });
+
+  it('merge sem duplicar', async () => {
+    const file = path.join(tmpDir, '.claude', 'settings.local.json');
+    await fsp.mkdir(path.dirname(file), { recursive: true });
+    await fsp.writeFile(file, JSON.stringify({ permissions: { allow: ['Edit'] } }));
+    await addProjectAllow(tmpDir, 'Edit');
+    await addProjectAllow(tmpDir, 'Bash(ls:*)');
+    const json = JSON.parse(await fsp.readFile(file, 'utf-8'));
+    expect(json.permissions.allow).toEqual(['Edit', 'Bash(ls:*)']);
+  });
+
+  it('preserva campos não-permissions do JSON existente', async () => {
+    const file = path.join(tmpDir, '.claude', 'settings.local.json');
+    await fsp.mkdir(path.dirname(file), { recursive: true });
+    await fsp.writeFile(file, JSON.stringify({ env: { FOO: 'bar' }, permissions: { deny: ['Bash(rm:*)'] } }));
+    await addProjectAllow(tmpDir, 'Edit');
+    const json = JSON.parse(await fsp.readFile(file, 'utf-8'));
+    expect(json.env).toEqual({ FOO: 'bar' });
+    expect(json.permissions.deny).toEqual(['Bash(rm:*)']);
+    expect(json.permissions.allow).toEqual(['Edit']);
+  });
+});

--- a/test/unit/audit.test.ts
+++ b/test/unit/audit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('audit log', () => {
+  let tmpDir: string;
+  let auditFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-audit-'));
+    auditFile = path.join(tmpDir, 'audit.jsonl');
+    vi.resetModules();
+    vi.doMock('../../src/config/paths.js', async () => {
+      const real = await vi.importActual<typeof import('../../src/config/paths.js')>(
+        '../../src/config/paths.js',
+      );
+      return { ...real, AUDIT_FILE: auditFile, CONFIG_DIR: tmpDir };
+    });
+  });
+  afterEach(async () => {
+    vi.doUnmock('../../src/config/paths.js');
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('appendAudit writes a JSONL line', async () => {
+    const { appendAudit } = await import('../../src/daemon/audit.js');
+    await appendAudit({
+      ts: '2026-04-28T10:00:00.000Z',
+      requestId: 'req-1',
+      tool: 'Bash',
+      cwd: '/x',
+      decision: 'allow',
+      reason: null,
+      source: 'telegram',
+      remember: false,
+    });
+    const raw = await fsp.readFile(auditFile, 'utf-8');
+    expect(raw.trim().split('\n')).toHaveLength(1);
+    expect(JSON.parse(raw.trim())).toMatchObject({ requestId: 'req-1', decision: 'allow' });
+  });
+
+  it('appendAudit appends multiple lines without overwriting', async () => {
+    const { appendAudit } = await import('../../src/daemon/audit.js');
+    await appendAudit({ ts: 't1', requestId: 'r1', tool: 'Bash', cwd: '/x', decision: 'allow', reason: null, source: 'telegram', remember: false });
+    await appendAudit({ ts: 't2', requestId: 'r2', tool: 'Edit', cwd: '/x', decision: 'deny', reason: 'no', source: 'telegram', remember: false });
+    const lines = (await fsp.readFile(auditFile, 'utf-8')).trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).requestId).toBe('r1');
+    expect(JSON.parse(lines[1]).requestId).toBe('r2');
+  });
+
+  it('readAudit returns parsed entries respecting filters', async () => {
+    const { appendAudit, readAudit } = await import('../../src/daemon/audit.js');
+    const now = Date.now();
+    await appendAudit({ ts: new Date(now - 3600_000).toISOString(), requestId: 'old', tool: 'Bash', cwd: '/a', decision: 'allow', reason: null, source: 'telegram', remember: false });
+    await appendAudit({ ts: new Date(now - 60_000).toISOString(),   requestId: 'mid', tool: 'Bash', cwd: '/a', decision: 'deny',  reason: null, source: 'telegram', remember: false });
+    await appendAudit({ ts: new Date(now).toISOString(),            requestId: 'new', tool: 'Edit', cwd: '/b', decision: 'allow', reason: null, source: 'telegram', remember: false });
+
+    const all = await readAudit({});
+    expect(all.map((e) => e.requestId)).toEqual(['old', 'mid', 'new']);
+
+    const last5min = await readAudit({ sinceMs: 5 * 60 * 1000 });
+    expect(last5min.map((e) => e.requestId)).toEqual(['mid', 'new']);
+
+    const onlyB = await readAudit({ cwd: '/b' });
+    expect(onlyB.map((e) => e.requestId)).toEqual(['new']);
+  });
+
+  it('readAudit returns [] when file does not exist', async () => {
+    const { readAudit } = await import('../../src/daemon/audit.js');
+    expect(await readAudit({})).toEqual([]);
+  });
+
+  it('readAudit skips malformed lines without throwing', async () => {
+    await fsp.writeFile(auditFile, '{"ts":"t","requestId":"ok","tool":"Bash","cwd":null,"decision":"allow","reason":null,"source":"telegram","remember":false}\nthis is garbage\n');
+    const { readAudit } = await import('../../src/daemon/audit.js');
+    const entries = await readAudit({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].requestId).toBe('ok');
+  });
+});

--- a/test/unit/telegramChannel.test.ts
+++ b/test/unit/telegramChannel.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TelegramChannel } from '../../src/channels/telegram/TelegramChannel.js';
+import type { Decision } from '../../src/core/types.js';
+import { noopLogger } from '../helpers/mockChannel.js';
+
+class FakeApi {
+  public messages: Array<{ chatId: number; text: string; keyboard?: unknown }> = [];
+  public callbacksAnswered: string[] = [];
+  public editKeyboardCalls: Array<{ messageId: number; keyboard: unknown }> = [];
+  private nextMessageId = 100;
+  async sendMessage(chatId: number, text: string, keyboard?: unknown): Promise<number> {
+    this.messages.push({ chatId, text, keyboard });
+    return this.nextMessageId++;
+  }
+  async answerCallbackQuery(id: string): Promise<void> {
+    this.callbacksAnswered.push(id);
+  }
+  async editMessageReplyMarkup(_chat: number, messageId: number, keyboard: unknown): Promise<void> {
+    this.editKeyboardCalls.push({ messageId, keyboard });
+  }
+  async getUpdates(): Promise<never[]> { return []; }
+}
+
+function makeChannel(api: FakeApi) {
+  const ch = new TelegramChannel({ token: 't', chatId: 1, logger: noopLogger });
+  // surgically swap the internal api with our fake
+  (ch as unknown as { api: unknown }).api = api;
+  return ch;
+}
+
+describe('TelegramChannel callbacks', () => {
+  let api: FakeApi;
+  let ch: TelegramChannel;
+  let decisions: Array<{ requestId: string; decision: Decision }>;
+
+  beforeEach(async () => {
+    api = new FakeApi();
+    ch = makeChannel(api);
+    decisions = [];
+    ch.on('decision', (e) => decisions.push(e));
+    await ch.sendPrompt({
+      requestId: 'req-1',
+      text: 'pode rodar?',
+      buttons: [
+        { label: '✅', action: 'allow' },
+        { label: '🔓', action: 'allow_remember' },
+        { label: '❌', action: 'deny' },
+        { label: '💬', action: 'deny_note' },
+      ],
+    });
+  });
+
+  function callback(action: string, requestId = 'req-1') {
+    (ch as unknown as { handleUpdate(u: unknown): void }).handleUpdate({
+      callback_query: { id: 'cb', from: { id: 1 }, message: { message_id: 100, chat: { id: 1 } }, data: `${requestId}:${action}` },
+    });
+  }
+  function text(t: string) {
+    (ch as unknown as { handleUpdate(u: unknown): void }).handleUpdate({
+      message: { message_id: 1, from: { id: 1 }, chat: { id: 1, type: 'private' }, date: 0, text: t },
+    });
+  }
+
+  it('allow → emit { decision: allow }', async () => {
+    callback('allow');
+    await new Promise((r) => setImmediate(r));
+    expect(decisions).toEqual([{ requestId: 'req-1', decision: { decision: 'allow' } }]);
+  });
+
+  it('allow_remember → emit { decision: allow, remember: true }', async () => {
+    callback('allow_remember');
+    await new Promise((r) => setImmediate(r));
+    expect(decisions).toEqual([{ requestId: 'req-1', decision: { decision: 'allow', remember: true } }]);
+  });
+
+  it('deny → emit { decision: deny }', async () => {
+    callback('deny');
+    await new Promise((r) => setImmediate(r));
+    expect(decisions).toEqual([{ requestId: 'req-1', decision: { decision: 'deny' } }]);
+  });
+
+  it('deny_note → não emit imediato; próximo texto vira reason', async () => {
+    callback('deny_note');
+    await new Promise((r) => setImmediate(r));
+    expect(decisions).toEqual([]);
+    // edit pra mostrar prompt de "aguardando texto"
+    expect(api.editKeyboardCalls.length).toBeGreaterThan(0);
+    text('porque o comando faz X que eu não quero');
+    expect(decisions).toEqual([{
+      requestId: 'req-1',
+      decision: { decision: 'deny', reason: 'porque o comando faz X que eu não quero' },
+    }]);
+  });
+
+  it('texto sem deny_note pendente → emit freeText (comportamento legado)', async () => {
+    const free: string[] = [];
+    ch.on('freeText', (e) => free.push(e.text));
+    text('hello');
+    expect(decisions).toEqual([]);
+    expect(free).toEqual(['hello']);
+  });
+});


### PR DESCRIPTION
## Summary
- 2 novos botões no prompt de permissão: 🔓 Allow & remember, 💬 Deny with note
- **Allow & remember** persiste o matcher em `<cwd>/.claude/settings.local.json` (allowlist do projeto)
- **Deny with note** captura o próximo texto livre como `permissionDecisionReason`
- Nova config `policy.rememberGranularity` (`tight`|`permissive`, default `tight`) controla precisão do Bash matcher
- Audit log de toda decisão em `~/.config/kuroboto/audit.jsonl` (append-only JSONL — auditável com `jq`)
- Comandos novos:
  - `kuroboto allowlist list|export [<dir>]`
  - `kuroboto audit list|export [--since <dur>] [--cwd <path>] [--limit N]`

## Por que
Reproduzir as opções extra do terminal do Claude Code via Telegram, e tornar o que o kuroboto persiste **acessível, exportável, testável e auditável** — alinhado com o espírito free software do projeto.

## Test plan
- [x] Unit: \`allowlist.test.ts\` (9), \`audit.test.ts\` (5), \`telegramChannel.test.ts\` (5)
- [x] Integration: \`daemon.test.ts\` (15) — cobre 4 botões + persistência + note flow
- [x] Smoke CLI: 6 comandos validados em \`/tmp/kbsmoke\`
- [ ] Smoke E2E manual no Telegram (pendente — feito após merge)

## Out of scope
- \`yes (plan) / no (plan) / yes with suggestion (Shift+Tab)\` — não passam pelo hook \`PreToolUse\` (UI interna do Claude Code)
- Bug do \`kuroboto ohayo\` (\`[server exited unexpectedly]\`) — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)