### PR TITLE
fix: sleep mode bugfixes (Windows ENOENT + slug suffix + gaming timer + base branch + cancel race)

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,6 +1,6 @@
 import fsp from 'node:fs/promises';
 import { type Server } from 'node:http';
-import { spawn } from 'node:child_process';
+import { spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
 import type { Channel } from '../channels/Channel.js';
 import type { ConfigT } from '../config/schema.js';
 import { TelegramChannel } from '../channels/telegram/TelegramChannel.js';
@@ -35,8 +35,10 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   const pendingNotifications = new PendingNotifications();
   const initialMode: Mode = await loadMode();
   const gaming = new GamingState();
+  const claudeSpawn = (cmd: string, args: string[], opts?: SpawnOptions): ReturnType<typeof nodeSpawn> =>
+    nodeSpawn(cmd, args, { ...opts, shell: true });
   const sleeping = new SleepingOrchestrator({
-    spawn,
+    spawn: claudeSpawn,
     gaming,
     notify: (msg) => channel.sendNotification(msg),
     audit: async () => {}, // skip audit at daemon level; sleep events go to Telegram
@@ -46,7 +48,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
       finishSleep(session, {
         exec: async (cmd, args, opts) => {
           return new Promise((resolve) => {
-            const child = spawn(cmd, args, { cwd: opts?.cwd, shell: false });
+            const child = nodeSpawn(cmd, args, { cwd: opts?.cwd, shell: true });
             let stdout = '';
             let stderr = '';
             child.stdout?.on('data', (b) => (stdout += b.toString()));

--- a/src/daemon/sleepFinish.ts
+++ b/src/daemon/sleepFinish.ts
@@ -56,12 +56,22 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
     return;
   }
 
-  // 2. Create PR via gh
+  // 2. Query the repo's default branch
+  let baseBranch = 'main';
+  const view = await deps.exec('gh', ['repo', 'view', '--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name'], {
+    cwd: session.worktreePath,
+  });
+  if (view.code === 0) {
+    const trimmed = view.stdout.trim();
+    if (trimmed) baseBranch = trimmed;
+  }
+
+  // 3. Create PR via gh
   const title = humanise(session.slug);
   const body = buildBody(session);
   const create = await deps.exec(
     'gh',
-    ['pr', 'create', '--base', 'main', '--head', session.branch, '--title', title, '--body', body],
+    ['pr', 'create', '--base', baseBranch, '--head', session.branch, '--title', title, '--body', body],
     { cwd: session.worktreePath },
   );
   if (create.code !== 0) {

--- a/src/daemon/sleeping.ts
+++ b/src/daemon/sleeping.ts
@@ -140,7 +140,19 @@ export class SleepingOrchestrator {
     if (session.terminated) return false;
     session.terminated = true;
     clearTimeout(session.maxDurationTimer);
-    session.child.kill('SIGTERM');
+    // Race kill with a 5s timeout to avoid hanging on a stuck child
+    await new Promise<void>((resolve) => {
+      let resolved = false;
+      const done = () => {
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      };
+      session.child.once('exit', done);
+      session.child.kill('SIGTERM');
+      setTimeout(done, 5_000);
+    });
     void this.deps.notify(`\u{1F6D1} sleep cancelled. log: ${session.worktreePath}/.kuroboto-sleep.log`);
     this.restoreGaming(session.gamingPriorSnapshot);
     this.session = null;

--- a/src/daemon/sleeping.ts
+++ b/src/daemon/sleeping.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
-import { GamingState } from './gaming.js';
+import { GamingState, type GamingSnapshot } from './gaming.js';
 import { slugify } from './worktree.js';
 
 export type SpawnFn = (cmd: string, args: string[], opts: SpawnOptions) => ChildProcess;
@@ -46,7 +46,7 @@ export type SleepingSnapshot =
 interface InternalSession extends SleepingSession {
   child: ChildProcess;
   maxDurationTimer: NodeJS.Timeout;
-  gamingPriorActive: boolean;
+  gamingPriorSnapshot: GamingSnapshot;
   terminated: boolean;
 }
 
@@ -83,8 +83,8 @@ export class SleepingOrchestrator {
 
     await this.deps.createWorktree(req.repo, branch, worktreePath);
 
-    const gamingPriorActive = this.deps.gaming.snapshot().active;
-    if (!gamingPriorActive) this.deps.gaming.arm();
+    const gamingPriorSnapshot = this.deps.gaming.snapshot();
+    if (!gamingPriorSnapshot.active) this.deps.gaming.arm();
 
     const startedAt = Date.now();
     const expectedEndAt = startedAt + req.maxDurationMs;
@@ -105,7 +105,7 @@ export class SleepingOrchestrator {
       repo: req.repo,
       child,
       maxDurationTimer,
-      gamingPriorActive,
+      gamingPriorSnapshot,
       terminated: false,
     };
     this.session = session;
@@ -142,16 +142,12 @@ export class SleepingOrchestrator {
     clearTimeout(session.maxDurationTimer);
     session.child.kill('SIGTERM');
     void this.deps.notify(`\u{1F6D1} sleep cancelled. log: ${session.worktreePath}/.kuroboto-sleep.log`);
-    this.restoreGaming(session.gamingPriorActive);
+    this.restoreGaming(session.gamingPriorSnapshot);
     this.session = null;
     return true;
   }
 
-  private handleChildExit(
-    session: InternalSession,
-    code: number | null,
-    signal: NodeJS.Signals | null,
-  ): void {
+  private handleChildExit(session: InternalSession, code: number | null, signal: NodeJS.Signals | null): void {
     if (session.terminated) return;
     session.terminated = true;
     clearTimeout(session.maxDurationTimer);
@@ -168,9 +164,10 @@ export class SleepingOrchestrator {
             repo: session.repo,
           });
         } catch (e) {
-          void this.deps.notify(
-            `⚠️ sleep onSuccess hook failed: ${(e as Error).message}`,
-          );
+          void this.deps.notify(`⚠️ sleep onSuccess hook failed: ${(e as Error).message}`);
+        } finally {
+          this.restoreGaming(session.gamingPriorSnapshot);
+          if (this.session === session) this.session = null;
         }
       })();
     } else {
@@ -178,9 +175,9 @@ export class SleepingOrchestrator {
       void this.deps.notify(
         `❌ sleep failed — ${reason}. log: ${session.worktreePath}/.kuroboto-sleep.log`,
       );
+      this.restoreGaming(session.gamingPriorSnapshot);
+      if (this.session === session) this.session = null;
     }
-    this.restoreGaming(session.gamingPriorActive);
-    if (this.session === session) this.session = null;
   }
 
   private handleTimeout(): void {
@@ -191,13 +188,25 @@ export class SleepingOrchestrator {
     void this.deps.notify(
       `⏰ sleep timed out. log: ${session.worktreePath}/.kuroboto-sleep.log. PR not created.`,
     );
-    this.restoreGaming(session.gamingPriorActive);
+    this.restoreGaming(session.gamingPriorSnapshot);
     this.session = null;
   }
 
-  private restoreGaming(priorActive: boolean): void {
-    if (priorActive) {
+  private restoreGaming(prior: GamingSnapshot): void {
+    if (!prior.active) {
+      this.deps.gaming.cancel();
+      return;
+    }
+    if (prior.until === null) {
+      // Was on with no timer — leave on.
       if (!this.deps.gaming.snapshot().active) this.deps.gaming.arm();
+      return;
+    }
+    // Was on with a timer — re-arm with remaining duration.
+    const remainingMs = prior.until - Date.now();
+    if (remainingMs > 0) {
+      this.deps.gaming.cancel();
+      this.deps.gaming.arm(remainingMs);
     } else {
       this.deps.gaming.cancel();
     }

--- a/src/daemon/worktree.ts
+++ b/src/daemon/worktree.ts
@@ -1,8 +1,20 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 
 const SLUG_MAX = 40;
+const SUFFIX_LEN = 6;
+const SUFFIX_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+function randomSuffix(): string {
+  const bytes = randomBytes(SUFFIX_LEN);
+  let out = '';
+  for (let i = 0; i < SUFFIX_LEN; i++) {
+    out += SUFFIX_ALPHABET[bytes[i] % SUFFIX_ALPHABET.length];
+  }
+  return out;
+}
 
 function runGit(cwd: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
@@ -15,18 +27,25 @@ function runGit(cwd: string, args: string[]): Promise<{ code: number; stdout: st
   });
 }
 
-export function slugify(input: string): string {
+export function slugify(input: string, withSuffix: boolean = true): string {
   const cleaned = input
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '');
-  if (!cleaned) return 'sleep';
-  if (cleaned.length <= SLUG_MAX) return cleaned;
-  // truncate at last dash boundary <= SLUG_MAX
-  const truncated = cleaned.slice(0, SLUG_MAX);
-  const lastDash = truncated.lastIndexOf('-');
-  return lastDash > SLUG_MAX / 2 ? truncated.slice(0, lastDash) : truncated;
+  let slug: string;
+  if (!cleaned) {
+    slug = 'sleep';
+  } else if (cleaned.length <= SLUG_MAX) {
+    slug = cleaned;
+  } else {
+    // truncate at last dash boundary <= SLUG_MAX
+    const truncated = cleaned.slice(0, SLUG_MAX);
+    const lastDash = truncated.lastIndexOf('-');
+    slug = lastDash > SLUG_MAX / 2 ? truncated.slice(0, lastDash) : truncated;
+  }
+  if (!withSuffix) return slug;
+  return `${slug}-${randomSuffix()}`;
 }
 
 export async function worktreeExists(repoRoot: string, dir: string): Promise<boolean> {

--- a/test/unit/sleepFinish.test.ts
+++ b/test/unit/sleepFinish.test.ts
@@ -17,6 +17,9 @@ function makeDeps(prUrl = 'https://github.com/x/y/pull/42'): { deps: FinishDeps;
   const deps: FinishDeps = {
     exec: vi.fn(async (cmd, args, opts) => {
       calls.exec.push({ cmd, args, cwd: opts?.cwd });
+      if (cmd === 'gh' && args[0] === 'repo' && args[1] === 'view') {
+        return { code: 0, stdout: 'main\n', stderr: '' };
+      }
       if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'create') {
         return { code: 0, stdout: prUrl + '\n', stderr: '' };
       }
@@ -33,9 +36,10 @@ describe('finishSleep', () => {
     await finishSleep(SESSION, deps);
     const cmds = calls.exec.map((c) => `${c.cmd} ${c.args.slice(0, 3).join(' ')}`);
     expect(cmds[0]).toContain('git push');
-    expect(cmds[1]).toContain('gh pr create');
+    expect(cmds[1]).toContain('gh repo view');
+    expect(cmds[2]).toContain('gh pr create');
     // gh runs in the worktree dir
-    expect(calls.exec[1].cwd).toBe(SESSION.worktreePath);
+    expect(calls.exec[2].cwd).toBe(SESSION.worktreePath);
     // notification includes the URL
     expect(calls.notify).toHaveLength(1);
     expect(calls.notify[0]).toContain('https://github.com/x/y/pull/42');
@@ -65,7 +69,7 @@ describe('finishSleep', () => {
   it('PR title comes from the slug (humanised)', async () => {
     const { deps, calls } = makeDeps();
     await finishSleep(SESSION, deps);
-    const ghCall = calls.exec.find((c) => c.cmd === 'gh');
+    const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
     expect(ghCall).toBeDefined();
     const title = ghCall!.args[ghCall!.args.indexOf('--title') + 1];
     expect(title.toLowerCase()).toContain('add feature x');
@@ -74,9 +78,30 @@ describe('finishSleep', () => {
   it('PR body includes the prompt and a sleep-mode origin marker', async () => {
     const { deps, calls } = makeDeps();
     await finishSleep(SESSION, deps);
-    const ghCall = calls.exec.find((c) => c.cmd === 'gh');
+    const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
     const body = ghCall!.args[ghCall!.args.indexOf('--body') + 1];
     expect(body).toContain('add feature x');
     expect(body).toMatch(/sleep mode|kuroboto sleeping|automated/i);
+  });
+
+  it('uses the default branch from gh repo view', async () => {
+    const { deps, calls } = makeDeps();
+    // Override the exec to return 'develop' as default branch
+    deps.exec = vi.fn(async (cmd, args) => {
+      if (cmd === 'gh' && args[0] === 'repo' && args[1] === 'view') {
+        return { code: 0, stdout: 'develop\n', stderr: '' };
+      }
+      if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'create') {
+        calls.exec.push({ cmd, args });
+        return { code: 0, stdout: 'https://x/y/pull/1\n', stderr: '' };
+      }
+      if (cmd === 'git') return { code: 0, stdout: '', stderr: '' };
+      return { code: 0, stdout: '', stderr: '' };
+    });
+    await finishSleep(SESSION, deps);
+    const ghPrCreate = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
+    expect(ghPrCreate).toBeDefined();
+    const baseIdx = ghPrCreate!.args.indexOf('--base');
+    expect(ghPrCreate!.args[baseIdx + 1]).toBe('develop');
   });
 });

--- a/test/unit/sleeping.test.ts
+++ b/test/unit/sleeping.test.ts
@@ -66,18 +66,18 @@ describe('SleepingOrchestrator', () => {
       workRoot: '/y/wt',
       maxDurationMs: 60_000,
     });
-    expect(session.slug).toMatch(/^implement-billing-flow$/);
-    expect(session.branch).toBe('sleep/implement-billing-flow');
+    expect(session.slug).toMatch(/^implement-billing-flow-[a-z0-9]{6}$/);
+    expect(session.branch).toMatch(/^sleep\/implement-billing-flow-[a-z0-9]{6}$/);
     expect(state.worktreeCreated).toEqual({
       repo: '/x/repo',
-      branch: 'sleep/implement-billing-flow',
-      dir: '/y/wt/implement-billing-flow',
+      branch: session.branch,
+      dir: `/y/wt/${session.slug}`,
     });
     expect(deps.gaming.snapshot().active).toBe(true);
     expect(state.child).toBeDefined();
     const snap = orch.snapshot();
     expect(snap.active).toBe(true);
-    if (snap.active) expect(snap.slug).toBe('implement-billing-flow');
+    if (snap.active) expect(snap.slug).toMatch(/^implement-billing-flow-[a-z0-9]{6}$/);
   });
 
   it('rejects start when one is already active', async () => {

--- a/test/unit/sleeping.test.ts
+++ b/test/unit/sleeping.test.ts
@@ -134,7 +134,10 @@ describe('SleepingOrchestrator', () => {
     const { deps, state } = makeDeps();
     const orch = new SleepingOrchestrator(deps);
     await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
-    await orch.cancel();
+    const cancelPromise = orch.cancel();
+    // FakeChild.kill() uses setImmediate() to emit exit; advance timers to trigger it
+    vi.advanceTimersByTime(0);
+    await cancelPromise;
     expect(state.child!.killed).toBe(true);
     expect(state.notifications.some((n) => n.toLowerCase().includes('cancel'))).toBe(true);
     expect(orch.snapshot().active).toBe(false);

--- a/test/unit/sleeping.test.ts
+++ b/test/unit/sleeping.test.ts
@@ -97,8 +97,8 @@ describe('SleepingOrchestrator', () => {
     await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
     expect(gaming.snapshot().active).toBe(true);
     state.child!.emit('exit', 0, null);
-    await Promise.resolve();
-    await Promise.resolve();
+    // onSuccess is awaited inside the IIFE — flush microtasks until orchestrator goes idle.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
     expect(deps.onSuccess).toHaveBeenCalledTimes(1);
     expect(gaming.snapshot().active).toBe(false);
     expect(orch.snapshot().active).toBe(false);
@@ -164,8 +164,26 @@ describe('SleepingOrchestrator', () => {
     const orch = new SleepingOrchestrator(deps);
     await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
     state.child!.emit('exit', 0, null);
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let i = 0; i < 10; i++) await Promise.resolve();
     expect(deps.gaming.snapshot().active).toBe(true);
+  });
+
+  it('gaming with prior timer restored to remaining duration after success', async () => {
+    const { deps, state } = makeDeps();
+    // prior gaming on with 1000ms timer
+    deps.gaming.arm(1000);
+    const orch = new SleepingOrchestrator(deps);
+    await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
+    // sleep took 200ms — fast-forward via fake timer
+    vi.advanceTimersByTime(200);
+    state.child!.emit('exit', 0, null);
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    const snap = deps.gaming.snapshot();
+    expect(snap.active).toBe(true);
+    expect(snap.until).not.toBeNull();
+    // Remaining should be roughly 800ms — allow generous tolerance.
+    const remaining = (snap.until ?? 0) - Date.now();
+    expect(remaining).toBeGreaterThan(700);
+    expect(remaining).toBeLessThan(900);
   });
 });

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -28,23 +28,30 @@ async function makeRepo(): Promise<string> {
 
 describe('slugify', () => {
   it('lowercases and replaces non-alphanumeric with dashes', () => {
-    expect(slugify('Implement Billing Flow!')).toMatch(/^implement-billing-flow$/);
+    expect(slugify('Implement Billing Flow!', false)).toMatch(/^implement-billing-flow$/);
   });
   it('collapses multiple dashes', () => {
-    expect(slugify('foo --- bar')).toBe('foo-bar');
+    expect(slugify('foo --- bar', false)).toBe('foo-bar');
   });
   it('trims leading/trailing dashes', () => {
-    expect(slugify('  --foo--  ')).toBe('foo');
+    expect(slugify('  --foo--  ', false)).toBe('foo');
   });
   it('caps length and uses first words', () => {
     const long = 'word '.repeat(50);
-    const slug = slugify(long);
+    const slug = slugify(long, false);
     expect(slug.length).toBeLessThanOrEqual(40);
     expect(slug).toMatch(/^[a-z0-9-]+$/);
   });
   it('handles empty/all-symbols input by returning a fallback', () => {
-    expect(slugify('!!!')).toBe('sleep');
-    expect(slugify('')).toBe('sleep');
+    expect(slugify('!!!', false)).toBe('sleep');
+    expect(slugify('', false)).toBe('sleep');
+  });
+  it('default mode appends a 6-char random suffix', () => {
+    const a = slugify('foo');
+    const b = slugify('foo');
+    expect(a).toMatch(/^foo-[a-z0-9]{6}$/);
+    expect(b).toMatch(/^foo-[a-z0-9]{6}$/);
+    expect(a).not.toBe(b); // randomness
   });
 });
 


### PR DESCRIPTION
## Summary
Five bugfixes for sleep mode found in PR #3 auto-review (one critical, others quality):

1. **Windows ENOENT (critical)** — \`gh\` and \`claude\` are \`.cmd\` shims; \`spawn(...)\` defaulted to \`shell: false\` and failed every time. Fixed: wrap spawns with \`shell: true\` (same fix as commit \`46e4fe3\` for the CLI).
2. **Slug missing random suffix** — spec required 6-char random suffix to prevent retries hitting \"branch already exists\". Fixed: \`slugify\` now appends 6-char alphanumeric suffix by default.
3. **Gaming timer lost on sleep restore** — \`gamingPriorActive: boolean\` discarded the \`until\` field, so a 1h gaming session that sleep ran during would become permanent. Fixed: snapshot full \`{active, until}\` and re-arm with remaining duration.
4. **\`restoreGaming\` ran before \`onSuccess\`** — gaming was disarmed while \`git push\` + \`gh pr create\` were still running. Fixed: moved into \`finally\` after \`await onSuccess\`.
5. **\`--base main\` hardcoded** — failed on repos with default \`master\`/\`develop\`. Fixed: query \`gh repo view --json defaultBranchRef\` first, fall back to \`main\`.
6. **Cancel race** — \`cancel()\` set \`session = null\` synchronously while child still being SIGTERMed. Fixed: \`await\` exit event with 5s timeout fallback.

## Test plan
- [x] All 93 tests passing (was 90 in PR #3, +3 new for the new behaviors)
- [x] Build clean
- [ ] Smoke E2E (manual) — \`kuroboto sleeping start --prompt 'add a comment to README'\` against a small repo on Windows

## Commits
- \`b82e7a6\` shell:true + slug suffix
- \`186ba57\` gaming snapshot full + restoreGaming reorder
- \`e7ad25e\` default branch query + cancel awaits exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)