### PR TITLE
fix: spawn gh/claude with .cmd suffix on Windows (no shell)

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -35,8 +35,16 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   const pendingNotifications = new PendingNotifications();
   const initialMode: Mode = await loadMode();
   const gaming = new GamingState();
+  // On Windows, gh and claude are .cmd shims. shell:true would fix ENOENT
+  // but breaks arg quoting (cmd.exe mangles --body markdown). Resolve the
+  // .cmd suffix explicitly and keep shell:false so args pass verbatim.
+  const resolveBin = (cmd: string): string => {
+    if (process.platform !== 'win32') return cmd;
+    if (cmd === 'gh' || cmd === 'claude') return `${cmd}.cmd`;
+    return cmd;
+  };
   const claudeSpawn = (cmd: string, args: string[], opts?: SpawnOptions): ReturnType<typeof nodeSpawn> =>
-    nodeSpawn(cmd, args, { ...opts, shell: true });
+    nodeSpawn(resolveBin(cmd), args, { ...opts, shell: false });
   const sleeping = new SleepingOrchestrator({
     spawn: claudeSpawn,
     gaming,
@@ -48,7 +56,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
       finishSleep(session, {
         exec: async (cmd, args, opts) => {
           return new Promise((resolve) => {
-            const child = nodeSpawn(cmd, args, { cwd: opts?.cwd, shell: true });
+            const child = nodeSpawn(resolveBin(cmd), args, { cwd: opts?.cwd, shell: false });
             let stdout = '';
             let stderr = '';
             child.stdout?.on('data', (b) => (stdout += b.toString()));


### PR DESCRIPTION
## Summary
Smoke test of sleep mode on Windows revealed that the previous fix (\`shell: true\`) caused \`gh pr create\` to fail with \"unknown arguments\" — cmd.exe was mangling the \`--body\` markdown (newlines, code fences, asterisks).

## Fix
Replace \`shell: true\` with explicit \`.cmd\` suffix resolution on Windows. Args now pass through verbatim to the executable.

\`\`\`ts
const resolveBin = (cmd: string): string => {
  if (process.platform !== 'win32') return cmd;
  if (cmd === 'gh' || cmd === 'claude') return \`\${cmd}.cmd\`;
  return cmd;
};
spawn(resolveBin(cmd), args, { ...opts, shell: false });
\`\`\`

## Verification
- Build clean, 93/93 tests pass
- Real smoke test pending after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)