### PR TITLE
fix: drop .cmd suffix on Windows; rely on PATHEXT

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -35,16 +35,11 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   const pendingNotifications = new PendingNotifications();
   const initialMode: Mode = await loadMode();
   const gaming = new GamingState();
-  // On Windows, gh and claude are .cmd shims. shell:true would fix ENOENT
-  // but breaks arg quoting (cmd.exe mangles --body markdown). Resolve the
-  // .cmd suffix explicitly and keep shell:false so args pass verbatim.
-  const resolveBin = (cmd: string): string => {
-    if (process.platform !== 'win32') return cmd;
-    if (cmd === 'gh' || cmd === 'claude') return `${cmd}.cmd`;
-    return cmd;
-  };
+  // shell:false so --body markdown passes through verbatim. Node 16+ resolves
+  // .exe (and .cmd) via PATHEXT on Windows when shell:false, so we don't need
+  // to suffix manually.
   const claudeSpawn = (cmd: string, args: string[], opts?: SpawnOptions): ReturnType<typeof nodeSpawn> =>
-    nodeSpawn(resolveBin(cmd), args, { ...opts, shell: false });
+    nodeSpawn(cmd, args, { ...opts, shell: false });
   const sleeping = new SleepingOrchestrator({
     spawn: claudeSpawn,
     gaming,
@@ -56,7 +51,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
       finishSleep(session, {
         exec: async (cmd, args, opts) => {
           return new Promise((resolve) => {
-            const child = nodeSpawn(resolveBin(cmd), args, { cwd: opts?.cwd, shell: false });
+            const child = nodeSpawn(cmd, args, { cwd: opts?.cwd, shell: false });
             let stdout = '';
             let stderr = '';
             child.stdout?.on('data', (b) => (stdout += b.toString()));


### PR DESCRIPTION
Previous fix assumed .cmd shims; user's gh/claude are .exe. Caused EINVAL. Removed manual suffix; Node 16+ resolves .exe via PATHEXT with shell:false.