### PR TITLE
feat: daemon-side allowlist match (Allow & remember takes effect immediately)

### DIFF
--- a/docs/specs/allowlist-match.md
+++ b/docs/specs/allowlist-match.md
@@ -1,0 +1,127 @@
+# Daemon-side allowlist match
+
+> Status: planned for next PR
+
+## Problem
+
+The "🔓 Allow & remember" button persists matchers to
+`<cwd>/.claude/settings.local.json` (`permissions.allow[]`). But the kuroboto
+**daemon** never reads that file before deciding whether to prompt — it always
+sends `/v1/permission` requests for `Bash`/`Edit`/`Write` to Telegram in away
+mode.
+
+Concretely: you click 🔓 on a `uv run X` prompt → `Bash(uv:*)` is saved →
+**but the very next `uv run Y` still pings your phone**. The matcher only takes
+effect on Claude's NEXT session (when it reloads `settings.local.json`).
+
+The intended UX is "remember = next time it just runs." This spec closes the gap.
+
+## Solution
+
+Before sending a permission prompt to Telegram, the daemon reads
+`<payload.cwd>/.claude/settings.local.json` and checks whether any pattern in
+`permissions.allow[]` matches the incoming tool call. If yes → return `allow`
+without bothering the user.
+
+```
+/v1/permission flow (after this change):
+  if gaming.active && tool ∉ gamingAlwaysAsk         → allow (gaming)
+  if mode === 'here' || tool ∉ permissionMatchers    → ask
+  if cwd has matching pattern in settings.local.json → allow (allowlist)   ← NEW
+  else                                                → Telegram prompt
+```
+
+The deny list (`permissions.deny[]`) is **also** consulted — a deny-list match
+short-circuits to `deny` directly, no Telegram round-trip.
+
+## Pattern grammar (subset of Claude Code's)
+
+We implement the patterns most commonly seen in real `settings.local.json`
+files. Anything we don't recognize falls through (= prompt as before).
+
+| Pattern | Meaning | Match rule |
+|---|---|---|
+| `Bash` | any Bash call | `tool === 'Bash'` |
+| `Bash(npm:*)` | command first token = `npm` | `Bash` and `command.split(/\s+/)[0] === 'npm'` |
+| `Bash(npm install:*)` | first two tokens = `npm install` | `Bash` and tokens [0,1] match |
+| `Bash(npm install foo)` | exact command (no `:*`) | `Bash` and `command === 'npm install foo'` |
+| `Edit` / `Write` / `Read` | any call | tool name match only |
+| `Edit(/path/to/file.ts)` | exact file path | tool match + `file_path === '/path/to/file.ts'` |
+| `Edit(/src/**)` | glob over file_path | tool match + `minimatch(file_path, '/src/**')` |
+| `Read(//tmp/**)` | glob (note: Claude Code uses double-slash to mean "absolute") | tool match + minimatch |
+| anything else | unrecognized → no match | falls through |
+
+## Files
+
+**Create:**
+- `src/daemon/allowlistMatch.ts` — `loadAllowlist(cwd)`, `matchPattern(toolName, toolInput, pattern): boolean`, `matchAny(toolName, toolInput, patterns)`
+- `test/unit/allowlistMatch.test.ts` — pattern matching cases (Bash prefix, exact, Edit glob, Read glob, mismatched tool, malformed)
+
+**Modify:**
+- `src/daemon/routes.ts` — in `/v1/permission`, before falling into the away-mode prompt path, consult the allowlist (allow first, then deny). Audit with `source: 'allowlist-allow'` / `'allowlist-deny'`.
+- `package.json` — add `minimatch` dep (already very common, ~10KB).
+- `test/integration/daemon.test.ts` — new tests: away mode + matching pattern → instant allow, no `sentPrompts`. Same for deny pattern.
+
+## Behavior details
+
+- **Lookup is per-request, not cached**: each `/v1/permission` reads the file
+  fresh. Cost is one fs read (KB-sized JSON, OS-cached). Avoids stale state if
+  another process (Claude itself, or a manual edit) updates the file mid-session.
+- **Read failure is non-fatal**: if the file doesn't exist, can't be parsed, or
+  has no `permissions.allow`, we fall through to the prompt path (existing
+  behavior). Logged at debug level.
+- **Order**: `permissions.deny[]` is checked first (security-first), then
+  `permissions.allow[]`. If both match (rare but possible), deny wins.
+- **`cwd` missing from payload**: skip the lookup, fall through. Same as today
+  for `Allow & remember` persistence.
+
+## Audit
+
+New `source` values in `audit.jsonl`:
+
+- `allowlist-allow` — short-circuited to allow because a `permissions.allow[]`
+  pattern matched
+- `allowlist-deny` — short-circuited to deny
+
+Existing values (`telegram`, `gaming`, `timeout`, `channel-error`) keep their
+meanings.
+
+## Out of scope (follow-ups)
+
+- Full Claude Code pattern grammar (e.g., `WebFetch(domain:example.com)`,
+  `--allowedTools` precedence, `*.allow` from `~/.claude/settings.json`
+  hierarchy). We only read project-local `<cwd>/.claude/settings.local.json`.
+- Caching the parsed file with mtime invalidation (premature optimization;
+  re-read per request is fine at our scale).
+- A `kuroboto allowlist add <pattern>` CLI for manual matchers (today the user
+  uses 🔓 Allow & remember or edits the JSON directly).
+
+## Test plan
+
+**Unit (`allowlistMatch.test.ts`):**
+- `matchPattern('Bash', { command: 'npm install lodash' }, 'Bash(npm:*)')` → true
+- `matchPattern('Bash', { command: 'npm install lodash' }, 'Bash(npm install:*)')` → true
+- `matchPattern('Bash', { command: 'npm test' }, 'Bash(npm install:*)')` → false
+- `matchPattern('Bash', { command: 'npm install foo' }, 'Bash(npm install foo)')` → true (exact)
+- `matchPattern('Bash', { command: 'npm install foo bar' }, 'Bash(npm install foo)')` → false (exact mismatch)
+- `matchPattern('Edit', { file_path: '/src/a.ts' }, 'Edit(/src/**)')` → true
+- `matchPattern('Read', { file_path: '/tmp/x' }, 'Read(//tmp/**)')` → true
+- `matchPattern('WebFetch', { url: 'x' }, 'WebFetch(domain:example.com)')` → false (out-of-scope grammar)
+- `matchPattern('Edit', { file_path: '/x' }, 'Bash(npm:*)')` → false (tool mismatch)
+- `loadAllowlist('/nonexistent')` → `{ allow: [], deny: [] }` (no throw)
+- `loadAllowlist(<dir-with-malformed-json>)` → `{ allow: [], deny: [] }`
+
+**Integration (`daemon.test.ts`):**
+- away mode + `Bash(echo:*)` in `<tmpdir>/.claude/settings.local.json` + tool `Bash echo hi` → `decision: 'allow'`, no Telegram prompt sent, audit entry with `source: 'allowlist-allow'`
+- away mode + `Bash(rm:*)` in deny → `decision: 'deny'`, no prompt, `source: 'allowlist-deny'`
+- away mode + tool not matching any pattern → falls through to existing prompt flow (sentPrompts.length === 1)
+- away mode + cwd missing from payload → falls through
+
+**Smoke:**
+- After merge, in `/tmp/kbsleep`, click 🔓 Allow & remember on a `Bash` prompt; immediately re-trigger the same Bash command. Expected: no second Telegram prompt, just runs.
+
+## Tasks (subagent-driven, 3 steps)
+
+1. **M1**: Spec done (this doc) + create `allowlistMatch.ts` + unit tests + add minimatch dep.
+2. **M2**: Wire into `routes.ts` `/v1/permission`. Add integration tests. Audit entries.
+3. **M3**: PR + auto-review + smoke validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "express": "^4.21.0",
+        "minimatch": "^10.2.5",
         "prompts": "^2.4.2",
         "zod": "^3.23.8"
       },
@@ -1171,6 +1172,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
@@ -1208,6 +1218,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -1964,6 +1986,21 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "express": "^4.21.0",
+    "minimatch": "^10.2.5",
     "prompts": "^2.4.2",
     "zod": "^3.23.8"
   },

--- a/src/daemon/allowlistMatch.ts
+++ b/src/daemon/allowlistMatch.ts
@@ -41,7 +41,9 @@ function matchFilePath(filePath: string, inner: string): boolean {
   // absolute paths we leave them as-is (drive letter prefix).
   const normalized = inner.startsWith('//') ? inner.slice(1) : inner;
   if (filePath === inner || filePath === normalized) return true;
-  return minimatch(filePath, normalized);
+  // dot:true so deny patterns like Edit(/home/user/**) cover hidden files
+  // (.bashrc, .ssh/**) — Claude Code's glob behavior matches dotfiles too.
+  return minimatch(filePath, normalized, { dot: true });
 }
 
 export function matchPattern(toolName: string, toolInput: Record<string, unknown>, pattern: string): boolean {

--- a/src/daemon/allowlistMatch.ts
+++ b/src/daemon/allowlistMatch.ts
@@ -1,0 +1,98 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { minimatch } from 'minimatch';
+
+export interface AllowlistData {
+  allow: string[];
+  deny: string[];
+}
+
+const TOOLS_WITH_FILE_PATH = new Set(['Edit', 'Write', 'Read']);
+
+interface ParsedPattern {
+  tool: string;
+  inner: string | null; // null = plain `ToolName` (any call)
+}
+
+function parsePattern(pattern: string): ParsedPattern | null {
+  const m = /^([A-Za-z][A-Za-z0-9_]*)(?:\((.*)\))?$/.exec(pattern.trim());
+  if (!m) return null;
+  return { tool: m[1], inner: m[2] === undefined ? null : m[2] };
+}
+
+function matchBash(command: string, inner: string): boolean {
+  if (inner.endsWith(':*')) {
+    const prefix = inner.slice(0, -2).trim();
+    if (!prefix) return false;
+    const prefixTokens = prefix.split(/\s+/);
+    const cmdTokens = command.trim().split(/\s+/);
+    if (cmdTokens.length < prefixTokens.length) return false;
+    for (let i = 0; i < prefixTokens.length; i++) {
+      if (cmdTokens[i] !== prefixTokens[i]) return false;
+    }
+    return true;
+  }
+  return command === inner;
+}
+
+function matchFilePath(filePath: string, inner: string): boolean {
+  // Claude Code uses //path for absolute on Unix-like; minimatch handles it
+  // when we collapse leading double-slash to a single slash. For Windows-style
+  // absolute paths we leave them as-is (drive letter prefix).
+  const normalized = inner.startsWith('//') ? inner.slice(1) : inner;
+  if (filePath === inner || filePath === normalized) return true;
+  return minimatch(filePath, normalized);
+}
+
+export function matchPattern(toolName: string, toolInput: Record<string, unknown>, pattern: string): boolean {
+  const parsed = parsePattern(pattern);
+  if (!parsed) return false;
+  if (parsed.tool !== toolName) return false;
+  if (parsed.inner === null) return true; // plain tool name = match any call
+
+  if (toolName === 'Bash') {
+    const command = typeof toolInput.command === 'string' ? toolInput.command : null;
+    if (command === null) return false;
+    return matchBash(command, parsed.inner);
+  }
+  if (TOOLS_WITH_FILE_PATH.has(toolName)) {
+    const filePath = typeof toolInput.file_path === 'string' ? toolInput.file_path : null;
+    if (filePath === null) return false;
+    return matchFilePath(filePath, parsed.inner);
+  }
+  // Unknown tool with parameterized pattern: out of scope, fall through.
+  return false;
+}
+
+export function matchAny(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  patterns: string[],
+): boolean {
+  return patterns.some((p) => matchPattern(toolName, toolInput, p));
+}
+
+export async function loadAllowlist(cwd: string): Promise<AllowlistData> {
+  const file = path.join(cwd, '.claude', 'settings.local.json');
+  let raw: string;
+  try {
+    raw = await fsp.readFile(file, 'utf-8');
+  } catch {
+    return { allow: [], deny: [] };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { allow: [], deny: [] };
+  }
+  if (!parsed || typeof parsed !== 'object') return { allow: [], deny: [] };
+  const perms = (parsed as { permissions?: unknown }).permissions;
+  if (!perms || typeof perms !== 'object') return { allow: [], deny: [] };
+  const allow = (perms as { allow?: unknown }).allow;
+  const deny = (perms as { deny?: unknown }).deny;
+  return {
+    allow: Array.isArray(allow) ? allow.filter((s): s is string => typeof s === 'string') : [],
+    deny: Array.isArray(deny) ? deny.filter((s): s is string => typeof s === 'string') : [],
+  };
+}

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -6,6 +6,7 @@ import type { DaemonContext } from './server.js';
 import type { PreToolUsePayload, NotificationPayload, Decision } from '../core/types.js';
 import { saveMode, type Mode } from './state.js';
 import { computeAllowMatcher, addProjectAllow } from './allowlist.js';
+import { loadAllowlist, matchAny } from './allowlistMatch.js';
 import { appendAudit } from './audit.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
@@ -185,6 +186,47 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
       const decision: Decision = { decision: 'ask' };
       res.json(decision);
       return;
+    }
+
+    // Allowlist match — read project's .claude/settings.local.json and short-circuit
+    // if the tool call matches a deny or allow pattern. Deny wins over allow.
+    if (payload.cwd) {
+      try {
+        const allowlist = await loadAllowlist(payload.cwd);
+        if (matchAny(payload.tool_name, payload.tool_input, allowlist.deny)) {
+          const decision: Decision = { decision: 'deny', reason: 'allowlist' };
+          appendAudit({
+            ts: new Date().toISOString(),
+            requestId: 'allowlist',
+            tool: payload.tool_name,
+            cwd: payload.cwd,
+            decision: 'deny',
+            reason: 'allowlist',
+            source: 'allowlist-deny',
+            remember: false,
+          }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
+          res.json(decision);
+          return;
+        }
+        if (matchAny(payload.tool_name, payload.tool_input, allowlist.allow)) {
+          const decision: Decision = { decision: 'allow', reason: 'allowlist' };
+          appendAudit({
+            ts: new Date().toISOString(),
+            requestId: 'allowlist',
+            tool: payload.tool_name,
+            cwd: payload.cwd,
+            decision: 'allow',
+            reason: 'allowlist',
+            source: 'allowlist-allow',
+            remember: false,
+          }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
+          res.json(decision);
+          return;
+        }
+      } catch (e) {
+        ctx.logger.debug('allowlist match read failed', { err: (e as Error).message });
+        // fall through to Telegram prompt
+      }
     }
 
     const { requestId, promise } = ctx.pending.create(ctx.config.policy.permissionTimeoutMs);

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -1,6 +1,7 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
+import { randomUUID } from 'node:crypto';
 import type { Express, Request, Response } from 'express';
 import type { DaemonContext } from './server.js';
 import type { PreToolUsePayload, NotificationPayload, Decision } from '../core/types.js';
@@ -190,42 +191,39 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
 
     // Allowlist match — read project's .claude/settings.local.json and short-circuit
     // if the tool call matches a deny or allow pattern. Deny wins over allow.
+    // loadAllowlist swallows read/parse errors internally and returns empty arrays;
+    // no outer try/catch needed.
     if (payload.cwd) {
-      try {
-        const allowlist = await loadAllowlist(payload.cwd);
-        if (matchAny(payload.tool_name, payload.tool_input, allowlist.deny)) {
-          const decision: Decision = { decision: 'deny', reason: 'allowlist' };
-          appendAudit({
-            ts: new Date().toISOString(),
-            requestId: 'allowlist',
-            tool: payload.tool_name,
-            cwd: payload.cwd,
-            decision: 'deny',
-            reason: 'allowlist',
-            source: 'allowlist-deny',
-            remember: false,
-          }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
-          res.json(decision);
-          return;
-        }
-        if (matchAny(payload.tool_name, payload.tool_input, allowlist.allow)) {
-          const decision: Decision = { decision: 'allow', reason: 'allowlist' };
-          appendAudit({
-            ts: new Date().toISOString(),
-            requestId: 'allowlist',
-            tool: payload.tool_name,
-            cwd: payload.cwd,
-            decision: 'allow',
-            reason: 'allowlist',
-            source: 'allowlist-allow',
-            remember: false,
-          }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
-          res.json(decision);
-          return;
-        }
-      } catch (e) {
-        ctx.logger.debug('allowlist match read failed', { err: (e as Error).message });
-        // fall through to Telegram prompt
+      const allowlist = await loadAllowlist(payload.cwd);
+      if (matchAny(payload.tool_name, payload.tool_input, allowlist.deny)) {
+        const decision: Decision = { decision: 'deny', reason: 'allowlist' };
+        appendAudit({
+          ts: new Date().toISOString(),
+          requestId: randomUUID(),
+          tool: payload.tool_name,
+          cwd: payload.cwd,
+          decision: 'deny',
+          reason: 'allowlist',
+          source: 'allowlist-deny',
+          remember: false,
+        }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
+        res.json(decision);
+        return;
+      }
+      if (matchAny(payload.tool_name, payload.tool_input, allowlist.allow)) {
+        const decision: Decision = { decision: 'allow', reason: 'allowlist' };
+        appendAudit({
+          ts: new Date().toISOString(),
+          requestId: randomUUID(),
+          tool: payload.tool_name,
+          cwd: payload.cwd,
+          decision: 'allow',
+          reason: 'allowlist',
+          source: 'allowlist-allow',
+          remember: false,
+        }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
+        res.json(decision);
+        return;
       }
     }
 

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import request from 'supertest';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
@@ -409,5 +409,115 @@ describe('sleep mode endpoints', () => {
       .delete('/v1/sleeping')
       .set('X-Kuroboto-Token', TEST_TOKEN);
     expect(res.body).toEqual({ ok: true, cancelled: false, reason: 'idle' });
+  });
+});
+
+describe('allowlist match (daemon-side)', () => {
+  let tmpRepo: string;
+
+  beforeEach(async () => {
+    tmpRepo = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-allowmatch-int-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpRepo, { recursive: true, force: true });
+  });
+
+  async function writeSettings(repo: string, perms: { allow?: string[]; deny?: string[] }): Promise<void> {
+    const dir = path.join(repo, '.claude');
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(path.join(dir, 'settings.local.json'), JSON.stringify({ permissions: perms }));
+  }
+
+  it('allow match short-circuits to allow without Telegram prompt', async () => {
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    await writeSettings(tmpRepo, { allow: ['Bash(echo:*)'] });
+    const res = await request(createServer(ctx))
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hello' },
+        cwd: tmpRepo,
+      });
+    expect(res.body).toEqual({ decision: 'allow', reason: 'allowlist' });
+    expect(channel.sentPrompts.length).toBe(0);
+  });
+
+  it('deny match short-circuits to deny without Telegram prompt', async () => {
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    await writeSettings(tmpRepo, { deny: ['Bash(rm:*)'] });
+    const res = await request(createServer(ctx))
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /' },
+        cwd: tmpRepo,
+      });
+    expect(res.body).toEqual({ decision: 'deny', reason: 'allowlist' });
+    expect(channel.sentPrompts.length).toBe(0);
+  });
+
+  it('deny wins over allow when both match', async () => {
+    const { ctx } = makeContext({ mode: 'away' });
+    await writeSettings(tmpRepo, { allow: ['Bash'], deny: ['Bash(rm:*)'] });
+    const res = await request(createServer(ctx))
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm foo' },
+        cwd: tmpRepo,
+      });
+    expect(res.body).toEqual({ decision: 'deny', reason: 'allowlist' });
+  });
+
+  it('no match falls through to Telegram prompt', async () => {
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    await writeSettings(tmpRepo, { allow: ['Bash(npm:*)'] });
+    const pending = request(createServer(ctx))
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm foo' },
+        cwd: tmpRepo,
+      })
+      .then((r) => r);
+    await waitFor(() => channel.sentPrompts.length === 1);
+    channel.emitDecision(channel.sentPrompts[0].requestId, { decision: 'deny' });
+    await pending;
+  });
+
+  it('missing cwd falls through to Telegram prompt', async () => {
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    const pending = request(createServer(ctx))
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls' } })
+      .then((r) => r);
+    await waitFor(() => channel.sentPrompts.length === 1);
+    channel.emitDecision(channel.sentPrompts[0].requestId, { decision: 'allow' });
+    await pending;
+  });
+
+  it('here mode bypasses allowlist (returns ask, lets Claude UI decide)', async () => {
+    const { ctx, channel } = makeContext({ mode: 'here' });
+    await writeSettings(tmpRepo, { allow: ['Bash(echo:*)'] });
+    const res = await request(createServer(ctx))
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hello' },
+        cwd: tmpRepo,
+      });
+    expect(res.body).toEqual({ decision: 'ask' });
+    expect(channel.sentPrompts.length).toBe(0);
   });
 });

--- a/test/unit/allowlistMatch.test.ts
+++ b/test/unit/allowlistMatch.test.ts
@@ -61,6 +61,10 @@ describe('matchPattern', () => {
     it('Write glob match', () => {
       expect(matchPattern('Write', { file_path: '/log/a.txt' }, 'Write(/log/**)')).toBe(true);
     });
+    it('** matches dotfiles (deny rule covers hidden files)', () => {
+      expect(matchPattern('Edit', { file_path: '/home/user/.bashrc' }, 'Edit(/home/user/**)')).toBe(true);
+      expect(matchPattern('Read', { file_path: '/etc/.secret/config' }, 'Read(//etc/**)')).toBe(true);
+    });
   });
 
   describe('falls through (out of scope grammar)', () => {

--- a/test/unit/allowlistMatch.test.ts
+++ b/test/unit/allowlistMatch.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { matchPattern, loadAllowlist, matchAny } from '../../src/daemon/allowlistMatch.js';
+
+describe('matchPattern', () => {
+  describe('plain tool name (any call)', () => {
+    it('Bash matches any Bash call', () => {
+      expect(matchPattern('Bash', { command: 'rm -rf /' }, 'Bash')).toBe(true);
+    });
+    it('Edit matches any Edit call', () => {
+      expect(matchPattern('Edit', { file_path: '/x' }, 'Edit')).toBe(true);
+    });
+    it('Bash does not match an Edit pattern', () => {
+      expect(matchPattern('Bash', { command: 'ls' }, 'Edit')).toBe(false);
+    });
+  });
+
+  describe('Bash with prefix:* glob', () => {
+    it('first token match', () => {
+      expect(matchPattern('Bash', { command: 'npm install lodash' }, 'Bash(npm:*)')).toBe(true);
+    });
+    it('first two tokens match', () => {
+      expect(matchPattern('Bash', { command: 'npm install lodash' }, 'Bash(npm install:*)')).toBe(true);
+    });
+    it('mismatch first token', () => {
+      expect(matchPattern('Bash', { command: 'pnpm install' }, 'Bash(npm:*)')).toBe(false);
+    });
+    it('mismatch second token', () => {
+      expect(matchPattern('Bash', { command: 'npm test' }, 'Bash(npm install:*)')).toBe(false);
+    });
+    it('does not require args after prefix', () => {
+      // Bash(npm:*) means "first token is npm, anything (or nothing) after"
+      expect(matchPattern('Bash', { command: 'npm' }, 'Bash(npm:*)')).toBe(true);
+    });
+  });
+
+  describe('Bash exact match (no :*)', () => {
+    it('exact command matches', () => {
+      expect(matchPattern('Bash', { command: 'npm install foo' }, 'Bash(npm install foo)')).toBe(true);
+    });
+    it('different command does not match', () => {
+      expect(matchPattern('Bash', { command: 'npm install foo bar' }, 'Bash(npm install foo)')).toBe(false);
+    });
+  });
+
+  describe('Edit/Write/Read with file_path', () => {
+    it('exact path match', () => {
+      expect(matchPattern('Edit', { file_path: '/src/a.ts' }, 'Edit(/src/a.ts)')).toBe(true);
+    });
+    it('glob match', () => {
+      expect(matchPattern('Edit', { file_path: '/src/foo/bar.ts' }, 'Edit(/src/**)')).toBe(true);
+    });
+    it('glob mismatch', () => {
+      expect(matchPattern('Edit', { file_path: '/other/file.ts' }, 'Edit(/src/**)')).toBe(false);
+    });
+    it('Read with double-slash absolute', () => {
+      expect(matchPattern('Read', { file_path: '/tmp/x' }, 'Read(//tmp/**)')).toBe(true);
+    });
+    it('Write glob match', () => {
+      expect(matchPattern('Write', { file_path: '/log/a.txt' }, 'Write(/log/**)')).toBe(true);
+    });
+  });
+
+  describe('falls through (out of scope grammar)', () => {
+    it('WebFetch domain pattern is not honored', () => {
+      expect(matchPattern('WebFetch', { url: 'https://example.com' }, 'WebFetch(domain:example.com)')).toBe(false);
+    });
+    it('unknown tool with parens does not match', () => {
+      expect(matchPattern('XYZ', { whatever: 1 }, 'XYZ(foo)')).toBe(false);
+    });
+  });
+
+  describe('input edge cases', () => {
+    it('Bash with no command falls back to false for parameterized pattern', () => {
+      expect(matchPattern('Bash', {}, 'Bash(npm:*)')).toBe(false);
+    });
+    it('Bash with no command still matches plain "Bash"', () => {
+      expect(matchPattern('Bash', {}, 'Bash')).toBe(true);
+    });
+    it('Edit with no file_path does not match a path pattern', () => {
+      expect(matchPattern('Edit', {}, 'Edit(/x)')).toBe(false);
+    });
+  });
+});
+
+describe('matchAny', () => {
+  it('returns true if any pattern matches', () => {
+    expect(matchAny('Bash', { command: 'npm install x' }, ['Edit', 'Bash(npm:*)', 'Read(/y/**)'])).toBe(true);
+  });
+  it('returns false if none match', () => {
+    expect(matchAny('Bash', { command: 'rm -rf /' }, ['Edit', 'Bash(npm:*)'])).toBe(false);
+  });
+  it('returns false on empty list', () => {
+    expect(matchAny('Bash', { command: 'x' }, [])).toBe(false);
+  });
+});
+
+describe('loadAllowlist', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-allowmatch-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty arrays when directory has no .claude/settings.local.json', async () => {
+    expect(await loadAllowlist(tmpDir)).toEqual({ allow: [], deny: [] });
+  });
+
+  it('reads allow + deny from settings.local.json', async () => {
+    const file = path.join(tmpDir, '.claude', 'settings.local.json');
+    await fsp.mkdir(path.dirname(file), { recursive: true });
+    await fsp.writeFile(file, JSON.stringify({
+      permissions: { allow: ['Bash(npm:*)'], deny: ['Bash(rm:*)'] },
+    }));
+    expect(await loadAllowlist(tmpDir)).toEqual({
+      allow: ['Bash(npm:*)'],
+      deny: ['Bash(rm:*)'],
+    });
+  });
+
+  it('returns empty when JSON is malformed', async () => {
+    const file = path.join(tmpDir, '.claude', 'settings.local.json');
+    await fsp.mkdir(path.dirname(file), { recursive: true });
+    await fsp.writeFile(file, 'not json {{{');
+    expect(await loadAllowlist(tmpDir)).toEqual({ allow: [], deny: [] });
+  });
+
+  it('returns empty arrays when permissions key is missing', async () => {
+    const file = path.join(tmpDir, '.claude', 'settings.local.json');
+    await fsp.mkdir(path.dirname(file), { recursive: true });
+    await fsp.writeFile(file, JSON.stringify({ env: { FOO: 'bar' } }));
+    expect(await loadAllowlist(tmpDir)).toEqual({ allow: [], deny: [] });
+  });
+});


### PR DESCRIPTION
## Summary
The \`🔓 Allow & remember\` button has persisted matchers to \`<cwd>/.claude/settings.local.json\` since PR #1, but the daemon never consulted that file — so the very next call still triggered a Telegram prompt until you restarted the Claude session. This PR closes the gap.

## What changed
- New \`src/daemon/allowlistMatch.ts\` — pattern parser + matcher + loader (\`loadAllowlist\`, \`matchAny\`, \`matchPattern\`)
- \`/v1/permission\` now reads \`<cwd>/.claude/settings.local.json\` after the here/ask branch and before Telegram. Deny first (security-first), then allow.
- New audit \`source\` values: \`allowlist-allow\` / \`allowlist-deny\`
- Added \`minimatch\` dep for path globs

## Pattern grammar (subset of Claude Code's, see [spec](docs/specs/allowlist-match.md))
- \`Bash\`, \`Edit\`, \`Write\`, \`Read\` — match any call
- \`Bash(npm:*)\` / \`Bash(npm install:*)\` — first N tokens
- \`Bash(comando exato)\` — exact match
- \`Edit(/src/**)\` / \`Read(//tmp/**)\` — minimatch globs
- Anything else falls through to existing prompt flow

## Test plan
- [x] Unit: \`allowlistMatch.test.ts\` — 27 tests covering all grammar variants + edge cases
- [x] Integration: \`daemon.test.ts\` — 6 new tests (allow/deny short-circuit, deny wins, no-match fall-through, missing cwd, here mode bypass)
- [x] Build clean, suite 126/126 passing
- [ ] Smoke E2E (manual) after merge

## Resolution order in /v1/permission (after this PR)
\`\`\`
gaming.active && tool ∉ gamingAlwaysAsk         → allow
mode === 'here' || tool ∉ permissionMatchers    → ask
allowlist deny match                            → deny  ← NEW
allowlist allow match                           → allow ← NEW
else                                            → Telegram prompt
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)