### PR TITLE
feat(daemon): bot prompt context header (session + intent)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,7 +23,19 @@ export interface StopPayload {
   stop_hook_active?: boolean;
 }
 
-export type HookPayload = NotificationPayload | PreToolUsePayload | StopPayload;
+export interface UserPromptSubmitPayload {
+  session_id: string;
+  transcript_path?: string;
+  cwd?: string;
+  hook_event_name: 'UserPromptSubmit';
+  prompt?: string;
+}
+
+export type HookPayload =
+  | NotificationPayload
+  | PreToolUsePayload
+  | StopPayload
+  | UserPromptSubmitPayload;
 
 export type Decision =
   | { decision: 'allow'; reason?: string; remember?: boolean }

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,4 +1,5 @@
 import fsp from 'node:fs/promises';
+import os from 'node:os';
 import { type Server } from 'node:http';
 import { spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
 import type { Channel } from '../channels/Channel.js';
@@ -79,6 +80,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     state,
     logger,
     startedAt: Date.now(),
+    hostname: os.hostname(),
   };
   const app = createServer(ctx);
   const server: Server = await new Promise((resolve, reject) => {

--- a/src/daemon/promptFormat.ts
+++ b/src/daemon/promptFormat.ts
@@ -1,0 +1,86 @@
+import path from 'node:path';
+import type { PreToolUsePayload, NotificationPayload } from '../core/types.js';
+import type { SleepingSnapshot } from './sleeping.js';
+import { readFirstUserMessage, readLastAssistantText } from './transcript.js';
+
+export interface PromptFormatContext {
+  hostname: string;
+  sleeping: SleepingSnapshot;
+}
+
+const FIRST_USER_MAX = 60;
+const ASSISTANT_TEXT_MAX = 200;
+const TOOL_SUMMARY_MAX = 200;
+
+export async function formatPermissionPrompt(
+  p: PreToolUsePayload,
+  ctx: PromptFormatContext,
+): Promise<string> {
+  const header = await buildHeader(p.cwd, p.transcript_path, ctx);
+  const intent = await buildIntentLine(p.transcript_path);
+  const summary = summarizeToolInput(p.tool_name, p.tool_input);
+  return `${header}${intent}\n\nPode rodar?\n${p.tool_name}: ${summary}`;
+}
+
+export async function formatNotification(
+  p: NotificationPayload,
+  ctx: PromptFormatContext,
+): Promise<string> {
+  const header = await buildHeader(p.cwd, p.transcript_path, ctx);
+  const intent = await buildIntentLine(p.transcript_path);
+  const body = p.message ?? 'Claude Code precisa de atenção.';
+  return `${header}${intent}\n\n${body}`;
+}
+
+async function buildHeader(
+  cwd: string | undefined,
+  transcriptPath: string | undefined,
+  ctx: PromptFormatContext,
+): Promise<string> {
+  if (ctx.sleeping.active && cwd && samePath(cwd, ctx.sleeping.worktreePath)) {
+    return `[${ctx.hostname} / 💤 ${stripSlugSuffix(ctx.sleeping.slug)}]`;
+  }
+  const parts = [ctx.hostname];
+  const folder = projectName(cwd);
+  if (folder) parts.push(folder);
+  if (transcriptPath) {
+    const firstUser = await readFirstUserMessage(transcriptPath);
+    if (firstUser) parts.push(`"${truncate(firstUser, FIRST_USER_MAX)}"`);
+  }
+  return `[${parts.join(' / ')}]`;
+}
+
+async function buildIntentLine(transcriptPath: string | undefined): Promise<string> {
+  if (!transcriptPath) return '';
+  const text = await readLastAssistantText(transcriptPath);
+  if (!text) return '';
+  return `\n💭 ${truncate(text, ASSISTANT_TEXT_MAX)}`;
+}
+
+function projectName(cwd: string | undefined): string | null {
+  if (!cwd) return null;
+  const parts = cwd.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? null;
+}
+
+function samePath(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
+
+function stripSlugSuffix(slug: string): string {
+  return slug.replace(/-[a-z0-9]{6}$/, '');
+}
+
+function summarizeToolInput(tool: string, input: Record<string, unknown>): string {
+  if (tool === 'Bash' && typeof input.command === 'string') {
+    return truncate(input.command, TOOL_SUMMARY_MAX);
+  }
+  if ((tool === 'Edit' || tool === 'Write') && typeof input.file_path === 'string') {
+    return input.file_path;
+  }
+  return truncate(JSON.stringify(input), TOOL_SUMMARY_MAX);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + '…';
+}

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -9,8 +9,14 @@ import { saveMode, type Mode } from './state.js';
 import { computeAllowMatcher, addProjectAllow } from './allowlist.js';
 import { loadAllowlist, matchAny } from './allowlistMatch.js';
 import { appendAudit } from './audit.js';
+import { formatPermissionPrompt, formatNotification, type PromptFormatContext } from './promptFormat.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
+  const fmtCtx = (): PromptFormatContext => ({
+    hostname: ctx.hostname,
+    sleeping: ctx.state.sleeping.snapshot(),
+  });
+
   app.get('/v1/health', (_req, res) => {
     res.json({
       ok: true,
@@ -147,13 +153,15 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
       hasMessage: typeof payload.message === 'string',
     });
     if (delayMs <= 0) {
-      ctx.channel.sendNotification(formatNotification(payload))
+      formatNotification(payload, fmtCtx())
+        .then((text) => ctx.channel.sendNotification(text))
         .then(() => ctx.logger.info('notify sent (immediate)'))
         .catch((e) => ctx.logger.warn('sendNotification failed', { err: (e as Error).message }));
     } else {
       ctx.pendingNotifications.arm(payload, delayMs, (p) => {
         ctx.logger.info('notify timer fired, sending');
-        ctx.channel.sendNotification(formatNotification(p))
+        formatNotification(p, fmtCtx())
+          .then((text) => ctx.channel.sendNotification(text))
           .then(() => ctx.logger.info('notify sent (delayed)'))
           .catch((e) => ctx.logger.warn('sendNotification (delayed) failed', { err: (e as Error).message }));
       });
@@ -176,7 +184,8 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
         source: 'gaming',
         remember: false,
       }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
-      ctx.channel.sendNotification(`🎮 ${formatPermissionPrompt(payload)}`)
+      formatPermissionPrompt(payload, fmtCtx())
+        .then((text) => ctx.channel.sendNotification(`🎮 ${text}`))
         .catch((e) => ctx.logger.warn('gaming notify failed', { err: (e as Error).message }));
       res.json(decision);
       return;
@@ -229,9 +238,10 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
 
     const { requestId, promise } = ctx.pending.create(ctx.config.policy.permissionTimeoutMs);
     try {
+      const text = await formatPermissionPrompt(payload, fmtCtx());
       await ctx.channel.sendPrompt({
         requestId,
-        text: formatPermissionPrompt(payload),
+        text,
         buttons: [
           { label: '✅ Allow', action: 'allow' },
           { label: '🔓 Allow & remember', action: 'allow_remember' },
@@ -271,39 +281,6 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
     const { remember: _r, ...stripped } = decision as { remember?: boolean } & Decision;
     res.json(stripped);
   });
-}
-
-function projectName(cwd: string | undefined): string {
-  if (!cwd) return 'unknown';
-  const parts = cwd.split(/[\\/]/).filter(Boolean);
-  return parts[parts.length - 1] ?? 'unknown';
-}
-
-function formatNotification(p: NotificationPayload): string {
-  const folder = projectName(p.cwd);
-  const msg = p.message ?? 'Claude Code precisa de atenção.';
-  return `[${folder}] ${msg}`;
-}
-
-function formatPermissionPrompt(p: PreToolUsePayload): string {
-  const folder = projectName(p.cwd);
-  const summary = summarizeToolInput(p.tool_name, p.tool_input);
-  return `[${folder}] Pode rodar?\n\n${p.tool_name}: ${summary}`;
-}
-
-function summarizeToolInput(tool: string, input: Record<string, unknown>): string {
-  if (tool === 'Bash' && typeof input.command === 'string') {
-    return truncate(input.command, 200);
-  }
-  if ((tool === 'Edit' || tool === 'Write') && typeof input.file_path === 'string') {
-    return input.file_path;
-  }
-  const json = JSON.stringify(input);
-  return truncate(json, 200);
-}
-
-function truncate(s: string, max: number): string {
-  return s.length <= max ? s : s.slice(0, max - 1) + '…';
 }
 
 function deriveSource(d: Decision): string {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -17,6 +17,7 @@ export interface DaemonContext {
   state: { mode: Mode; gaming: GamingState; sleeping: SleepingOrchestrator };
   logger: Logger;
   startedAt: number;
+  hostname: string;
 }
 
 export function createServer(ctx: DaemonContext): Express {

--- a/src/daemon/transcript.ts
+++ b/src/daemon/transcript.ts
@@ -1,0 +1,64 @@
+import fsp from 'node:fs/promises';
+
+interface TranscriptLine {
+  role?: string;
+  content?: unknown;
+}
+
+interface ContentBlock {
+  type?: string;
+  text?: string;
+}
+
+async function readLines(path: string): Promise<TranscriptLine[]> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(path, 'utf-8');
+  } catch {
+    return [];
+  }
+  const out: TranscriptLine[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      out.push(JSON.parse(line) as TranscriptLine);
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content as ContentBlock[]) {
+    if (block?.type === 'text' && typeof block.text === 'string') {
+      parts.push(block.text);
+    }
+  }
+  return parts.join('\n').trim();
+}
+
+export async function readFirstUserMessage(transcriptPath: string): Promise<string | null> {
+  const lines = await readLines(transcriptPath);
+  for (const l of lines) {
+    if (l.role === 'user') {
+      const t = extractText(l.content);
+      if (t) return t;
+    }
+  }
+  return null;
+}
+
+export async function readLastAssistantText(transcriptPath: string): Promise<string | null> {
+  const lines = await readLines(transcriptPath);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].role === 'assistant') {
+      const t = extractText(lines[i].content);
+      if (t) return t;
+    }
+  }
+  return null;
+}

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -62,6 +62,7 @@ function makeContext(overrides: Overrides = {}): { ctx: DaemonContext; channel: 
     state: { mode: overrides.mode ?? 'here', gaming, sleeping },
     logger: noopLogger,
     startedAt: Date.now(),
+    hostname: 'test-host',
   };
   channel.on('decision', (e) => pending.resolve(e.requestId, e.decision));
   return { ctx, channel };

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -522,3 +522,84 @@ describe('allowlist match (daemon-side)', () => {
     expect(channel.sentPrompts.length).toBe(0);
   });
 });
+
+describe('prompt context header (session + intent)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-promptctx-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeTranscript(name: string, lines: unknown[]): Promise<string> {
+    const file = path.join(tmpDir, name);
+    await fsp.writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n'));
+    return file;
+  }
+
+  it('interactive: prompt header has hostname / folder / first user msg + 💭 intent', async () => {
+    const transcript = await writeTranscript('t.jsonl', [
+      { role: 'user', content: 'fix the bot UX' },
+      { role: 'assistant', content: "I'll start by reading the routes file" },
+    ]);
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    const app = createServer(ctx);
+    const pending = request(app)
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'cat src/daemon/routes.ts' },
+        cwd: '/x/kuroboto',
+        transcript_path: transcript,
+      })
+      .then((r) => r);
+    await waitFor(() => channel.sentPrompts.length === 1);
+    const text = channel.sentPrompts[0].text;
+    expect(text).toContain('[test-host / kuroboto / "fix the bot UX"]');
+    expect(text).toContain("💭 I'll start by reading the routes file");
+    expect(text).toContain('Pode rodar?');
+    expect(text).toContain('Bash: cat src/daemon/routes.ts');
+    channel.emitDecision(channel.sentPrompts[0].requestId, { decision: 'allow' });
+    await pending;
+  });
+
+  it('sleep mode: prompt header uses 💤 slug-without-suffix and skips first-user-msg', async () => {
+    const transcript = await writeTranscript('s.jsonl', [
+      { role: 'user', content: 'PLAN_INTRO boilerplate that should not surface' },
+      { role: 'assistant', content: 'Working on step 1' },
+    ]);
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    const worktreePath = path.join(tmpDir, 'work', 'fix-the-bot-ux-abc123');
+    vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
+      active: true,
+      slug: 'fix-the-bot-ux-abc123',
+      branch: 'sleep/fix-the-bot-ux-abc123',
+      worktreePath,
+      startedAt: Date.now(),
+      expectedEndAt: Date.now() + 60_000,
+    });
+    const app = createServer(ctx);
+    const pending = request(app)
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        cwd: worktreePath,
+        transcript_path: transcript,
+      })
+      .then((r) => r);
+    await waitFor(() => channel.sentPrompts.length === 1);
+    const text = channel.sentPrompts[0].text;
+    expect(text).toContain('[test-host / 💤 fix-the-bot-ux]');
+    expect(text).not.toContain('PLAN_INTRO');
+    expect(text).toContain('💭 Working on step 1');
+    channel.emitDecision(channel.sentPrompts[0].requestId, { decision: 'allow' });
+    await pending;
+  });
+});

--- a/test/unit/promptFormat.test.ts
+++ b/test/unit/promptFormat.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { formatPermissionPrompt, formatNotification } from '../../src/daemon/promptFormat.js';
+import type { PreToolUsePayload, NotificationPayload } from '../../src/core/types.js';
+import type { SleepingSnapshot } from '../../src/daemon/sleeping.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-promptfmt-'));
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeTranscript(name: string, lines: unknown[]): Promise<string> {
+  const file = path.join(tmpDir, name);
+  await fsp.writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n'));
+  return file;
+}
+
+const idleSleep: SleepingSnapshot = { active: false };
+
+function permissionPayload(over: Partial<PreToolUsePayload> = {}): PreToolUsePayload {
+  return {
+    session_id: 's1',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command: 'echo hi' },
+    cwd: '/x/kuroboto',
+    ...over,
+  };
+}
+
+function notificationPayload(over: Partial<NotificationPayload> = {}): NotificationPayload {
+  return {
+    session_id: 's1',
+    hook_event_name: 'Notification',
+    cwd: '/x/kuroboto',
+    ...over,
+  };
+}
+
+describe('formatPermissionPrompt — interactive', () => {
+  it('all data present → host / folder / first-user / 💭 intent / body', async () => {
+    const transcript = await writeTranscript('a.jsonl', [
+      { role: 'user', content: 'vamos melhorar a UX do bot' },
+      { role: 'assistant', content: 'Vou limpar os arquivos temporários antes do deploy' },
+    ]);
+    const out = await formatPermissionPrompt(
+      permissionPayload({ transcript_path: transcript, tool_input: { command: 'rm -rf /tmp/foo' } }),
+      { hostname: 'win-juan', sleeping: idleSleep },
+    );
+    expect(out).toBe(
+      '[win-juan / kuroboto / "vamos melhorar a UX do bot"]\n' +
+        '💭 Vou limpar os arquivos temporários antes do deploy\n\n' +
+        'Pode rodar?\nBash: rm -rf /tmp/foo',
+    );
+  });
+
+  it('no transcript path → host / folder, no first-user, no intent', async () => {
+    const out = await formatPermissionPrompt(
+      permissionPayload({ tool_input: { command: 'ls' } }),
+      { hostname: 'win-juan', sleeping: idleSleep },
+    );
+    expect(out).toBe('[win-juan / kuroboto]\n\nPode rodar?\nBash: ls');
+  });
+
+  it('no cwd → host alone', async () => {
+    const out = await formatPermissionPrompt(
+      permissionPayload({ cwd: undefined, tool_input: { command: 'ls' } }),
+      { hostname: 'win-juan', sleeping: idleSleep },
+    );
+    expect(out).toBe('[win-juan]\n\nPode rodar?\nBash: ls');
+  });
+
+  it('transcript missing on disk → header omits "..." segment, no intent', async () => {
+    const out = await formatPermissionPrompt(
+      permissionPayload({
+        transcript_path: path.join(tmpDir, 'nope.jsonl'),
+        tool_input: { command: 'ls' },
+      }),
+      { hostname: 'win-juan', sleeping: idleSleep },
+    );
+    expect(out).toBe('[win-juan / kuroboto]\n\nPode rodar?\nBash: ls');
+  });
+
+  it('first-user-message > 60 chars → truncated with …', async () => {
+    const long = 'a'.repeat(80);
+    const transcript = await writeTranscript('long.jsonl', [{ role: 'user', content: long }]);
+    const out = await formatPermissionPrompt(
+      permissionPayload({ transcript_path: transcript, tool_input: { command: 'ls' } }),
+      { hostname: 'h', sleeping: idleSleep },
+    );
+    expect(out).toContain('"' + 'a'.repeat(59) + '…"');
+  });
+
+  it('assistant-text > 200 chars → truncated with …', async () => {
+    const long = 'b'.repeat(250);
+    const transcript = await writeTranscript('longa.jsonl', [
+      { role: 'user', content: 'q' },
+      { role: 'assistant', content: long },
+    ]);
+    const out = await formatPermissionPrompt(
+      permissionPayload({ transcript_path: transcript, tool_input: { command: 'ls' } }),
+      { hostname: 'h', sleeping: idleSleep },
+    );
+    expect(out).toContain('💭 ' + 'b'.repeat(199) + '…');
+  });
+});
+
+describe('formatPermissionPrompt — sleep mode', () => {
+  it('cwd matches sleeping worktree → host / 💤 slug-no-suffix, skips first-user', async () => {
+    const transcript = await writeTranscript('sleep.jsonl', [
+      { role: 'user', content: 'PLAN_INTRO blah blah do this thing' },
+      { role: 'assistant', content: 'Will start with step 1' },
+    ]);
+    const sleeping: SleepingSnapshot = {
+      active: true,
+      slug: 'fix-the-bot-ux-abc123',
+      branch: 'sleep/fix-the-bot-ux-abc123',
+      worktreePath: '/work/fix-the-bot-ux-abc123',
+      startedAt: 1,
+      expectedEndAt: 2,
+    };
+    const out = await formatPermissionPrompt(
+      permissionPayload({
+        transcript_path: transcript,
+        cwd: '/work/fix-the-bot-ux-abc123',
+        tool_input: { command: 'ls' },
+      }),
+      { hostname: 'win-juan', sleeping },
+    );
+    expect(out).toBe(
+      '[win-juan / 💤 fix-the-bot-ux]\n' +
+        '💭 Will start with step 1\n\n' +
+        'Pode rodar?\nBash: ls',
+    );
+  });
+
+  it('cwd does NOT match worktreePath while sleeping → treated as interactive', async () => {
+    const sleeping: SleepingSnapshot = {
+      active: true,
+      slug: 'foo-abc123',
+      branch: 'sleep/foo-abc123',
+      worktreePath: '/work/foo-abc123',
+      startedAt: 1,
+      expectedEndAt: 2,
+    };
+    const out = await formatPermissionPrompt(
+      permissionPayload({ cwd: '/x/elsewhere', tool_input: { command: 'ls' } }),
+      { hostname: 'h', sleeping },
+    );
+    expect(out).toBe('[h / elsewhere]\n\nPode rodar?\nBash: ls');
+  });
+});
+
+describe('formatNotification', () => {
+  it('default message uses the same header + intent', async () => {
+    const transcript = await writeTranscript('n.jsonl', [
+      { role: 'user', content: 'vamos melhorar a UX do bot' },
+      { role: 'assistant', content: 'Aguardando confirmação antes de rodar a migração' },
+    ]);
+    const out = await formatNotification(
+      notificationPayload({ transcript_path: transcript }),
+      { hostname: 'win-juan', sleeping: idleSleep },
+    );
+    expect(out).toBe(
+      '[win-juan / kuroboto / "vamos melhorar a UX do bot"]\n' +
+        '💭 Aguardando confirmação antes de rodar a migração\n\n' +
+        'Claude Code precisa de atenção.',
+    );
+  });
+
+  it('custom message replaces body but keeps header', async () => {
+    const out = await formatNotification(
+      notificationPayload({ message: 'a custom message' }),
+      { hostname: 'h', sleeping: idleSleep },
+    );
+    expect(out).toBe('[h / kuroboto]\n\na custom message');
+  });
+});

--- a/test/unit/transcript.test.ts
+++ b/test/unit/transcript.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { readFirstUserMessage, readLastAssistantText } from '../../src/daemon/transcript.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-transcript-'));
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeJsonl(name: string, lines: unknown[]): Promise<string> {
+  const file = path.join(tmpDir, name);
+  const body = lines.map((l) => JSON.stringify(l)).join('\n');
+  await fsp.writeFile(file, body);
+  return file;
+}
+
+describe('readFirstUserMessage', () => {
+  it('returns text from a normal user-led JSONL', async () => {
+    const file = await writeJsonl('t1.jsonl', [
+      { role: 'user', content: 'hello there' },
+      { role: 'assistant', content: 'hi back' },
+    ]);
+    expect(await readFirstUserMessage(file)).toBe('hello there');
+  });
+
+  it('skips system-role lines and returns first user', async () => {
+    const file = await writeJsonl('t2.jsonl', [
+      { role: 'system', content: 'system intro' },
+      { role: 'user', content: 'fix the bot UX' },
+      { role: 'user', content: 'second one' },
+    ]);
+    expect(await readFirstUserMessage(file)).toBe('fix the bot UX');
+  });
+
+  it('returns null when file is missing', async () => {
+    expect(await readFirstUserMessage(path.join(tmpDir, 'missing.jsonl'))).toBeNull();
+  });
+
+  it('skips malformed JSONL lines and returns first valid user', async () => {
+    const file = path.join(tmpDir, 'mixed.jsonl');
+    await fsp.writeFile(
+      file,
+      [
+        '{not json at all',
+        JSON.stringify({ role: 'system', content: 'sys' }),
+        'garbage',
+        JSON.stringify({ role: 'user', content: 'real first' }),
+      ].join('\n'),
+    );
+    expect(await readFirstUserMessage(file)).toBe('real first');
+  });
+
+  it('extracts text from content blocks array', async () => {
+    const file = await writeJsonl('blocks.jsonl', [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'block one' },
+          { type: 'text', text: 'block two' },
+        ],
+      },
+    ]);
+    expect(await readFirstUserMessage(file)).toBe('block one\nblock two');
+  });
+
+  it('returns null on empty user content', async () => {
+    const file = await writeJsonl('empty.jsonl', [
+      { role: 'user', content: '' },
+      { role: 'user', content: 'second' },
+    ]);
+    expect(await readFirstUserMessage(file)).toBe('second');
+  });
+});
+
+describe('readLastAssistantText', () => {
+  it('returns text from latest assistant with text + tool_use blocks', async () => {
+    const file = await writeJsonl('a1.jsonl', [
+      { role: 'user', content: 'go' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will run a command' },
+          { type: 'tool_use', id: 'x', name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    ]);
+    expect(await readLastAssistantText(file)).toBe('I will run a command');
+  });
+
+  it('falls back to previous assistant when latest has only tool_use blocks', async () => {
+    const file = await writeJsonl('a2.jsonl', [
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: 'first thoughts' },
+      { role: 'user', content: 'tool result' },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'y', name: 'Bash', input: {} }],
+      },
+    ]);
+    expect(await readLastAssistantText(file)).toBe('first thoughts');
+  });
+
+  it('returns null when there is no assistant message', async () => {
+    const file = await writeJsonl('a3.jsonl', [{ role: 'user', content: 'just user' }]);
+    expect(await readLastAssistantText(file)).toBeNull();
+  });
+
+  it('returns null on empty file', async () => {
+    const file = path.join(tmpDir, 'empty.jsonl');
+    await fsp.writeFile(file, '');
+    expect(await readLastAssistantText(file)).toBeNull();
+  });
+
+  it('returns null on missing file', async () => {
+    expect(await readLastAssistantText(path.join(tmpDir, 'nope.jsonl'))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Telegram permission prompts and notifications now show **who is asking** (`[hostname / folder / "first user message"]` or `[hostname / 💤 sleep-slug]`) and **why** (`💭 last assistant text`).
- New `src/daemon/transcript.ts` reader for the JSONL transcript that Claude Code passes via the hook payload — extracts the first user message and the last non-empty assistant text. Read-only, swallows errors, returns `null`.
- Formatter logic moved to `src/daemon/promptFormat.ts`; `routes.ts` now passes a `{ hostname, sleeping }` context to it. Hostname is captured via `os.hostname()` once at daemon startup.
- Sleep detection: when the active `SleepingOrchestrator` snapshot's `worktreePath` matches the request `cwd`, the header switches to the 💤 form and the first-user-message segment is skipped (it would just be the `PLAN_INTRO` boilerplate).

Implements [docs/specs/prompt-context.md](docs/specs/prompt-context.md).

## Test Plan
- [x] `npx vitest run` — 150/150 passing (added 23: 11 transcript, 10 promptFormat, 2 daemon integration).
- [x] `npx tsc --noEmit` — clean.
- [ ] Smoke (post-merge, manual): trigger an interactive permission prompt and verify Telegram shows hostname + folder + first prompt + 💭 intent line.
- [ ] Smoke (post-merge, manual): run `kuroboto sleep <repo> --plan <some.md>`, trigger a permission prompt inside the worktree, verify Telegram shows `💤 <slug>` and no first-prompt segment.

## Out of scope (follow-ups)
- Free-text Q&A and inject (Spec B — `prompt-freetext-qa.md`).
- Telegram supergroup forum-mode threads.
- Caching parsed transcripts with mtime invalidation.