### PR TITLE
feat(daemon): free-text Q&A via tmux inject

### DIFF
--- a/src/channels/Channel.ts
+++ b/src/channels/Channel.ts
@@ -1,4 +1,9 @@
-import type { PromptRequest, DecisionEvent, FreeTextEvent } from '../core/types.js';
+import type {
+  PromptRequest,
+  QuestionRequest,
+  DecisionEvent,
+  FreeTextEvent,
+} from '../core/types.js';
 
 export type ChannelEventName = 'decision' | 'freeText';
 
@@ -12,5 +17,8 @@ export interface Channel {
   stop(): Promise<void>;
   sendPrompt(req: PromptRequest): Promise<void>;
   sendNotification(text: string): Promise<void>;
+  /** Send a Q&A question that opens a Reply UI; returns the channel-specific
+   *  message id used to correlate the user's reply back to this question. */
+  sendQuestion(req: QuestionRequest): Promise<{ sentMessageId: string }>;
   on<K extends ChannelEventName>(event: K, handler: ChannelEventHandlers[K]): void;
 }

--- a/src/channels/telegram/TelegramChannel.ts
+++ b/src/channels/telegram/TelegramChannel.ts
@@ -1,5 +1,6 @@
 import type {
   PromptRequest,
+  QuestionRequest,
   DecisionEvent,
   FreeTextEvent,
   Decision,
@@ -51,8 +52,15 @@ export class TelegramChannel implements Channel {
 
   async sendPrompt(req: PromptRequest): Promise<void> {
     const keyboard = buildKeyboard(req);
-    const messageId = await this.api.sendMessage(this.opts.chatId, req.text, keyboard);
+    const messageId = await this.api.sendMessage(this.opts.chatId, req.text, { keyboard });
     this.promptMessageIds.set(req.requestId, { messageId, chatId: this.opts.chatId });
+  }
+
+  async sendQuestion(req: QuestionRequest): Promise<{ sentMessageId: string }> {
+    const messageId = await this.api.sendMessage(this.opts.chatId, req.text, {
+      forceReply: req.forceReply ?? true,
+    });
+    return { sentMessageId: String(messageId) };
   }
 
   on<K extends ChannelEventName>(event: K, handler: ChannelEventHandlers[K]): void {
@@ -84,6 +92,17 @@ export class TelegramChannel implements Channel {
     }
     if (update.message?.text) {
       const text = update.message.text.trim();
+      const replyToMessageId = update.message.reply_to_message?.message_id;
+      // A reply_to_message means the user used Telegram's Reply UI — almost
+      // certainly answering a Q&A prompt, so route it as freeText with the
+      // correlation id and skip the deny_note interception (Q&A and deny_note
+      // can be in flight simultaneously, but only Q&A uses replies).
+      if (replyToMessageId !== undefined) {
+        for (const h of this.handlers.freeText) {
+          h({ text, replyToMessageId: String(replyToMessageId) });
+        }
+        return;
+      }
       if (this.awaitingNoteFor) {
         const requestId = this.awaitingNoteFor;
         this.awaitingNoteFor = null;

--- a/src/channels/telegram/api.ts
+++ b/src/channels/telegram/api.ts
@@ -8,6 +8,7 @@ export interface TelegramUpdate {
     chat: { id: number; type: string };
     date: number;
     text?: string;
+    reply_to_message?: { message_id: number };
   };
   callback_query?: {
     id: string;
@@ -49,15 +50,20 @@ export class TelegramApi {
   async sendMessage(
     chatId: number,
     text: string,
-    keyboard?: InlineKeyboardButton[][],
-    timeoutMs = 10_000,
+    opts?: { keyboard?: InlineKeyboardButton[][]; forceReply?: boolean; timeoutMs?: number },
   ): Promise<number> {
+    const timeoutMs = opts?.timeoutMs ?? 10_000;
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     try {
       const body: Record<string, unknown> = { chat_id: chatId, text };
-      if (keyboard) {
-        body.reply_markup = { inline_keyboard: keyboard };
+      if (opts?.keyboard) {
+        body.reply_markup = { inline_keyboard: opts.keyboard };
+      } else if (opts?.forceReply) {
+        // force_reply opens an input box on the user's client with the bot's
+        // message quoted above. Telegram returns the user's reply with
+        // reply_to_message.message_id pointing at this message.
+        body.reply_markup = { force_reply: true };
       }
       const res = await fetch(this.url('sendMessage'), {
         method: 'POST',

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -71,11 +71,31 @@ export async function initCommand(): Promise<void> {
   });
   const port = (portAns.val as number) ?? 47891;
 
+  console.log(chalk.cyan('\nQ&A inject (tmux): permite responder no Telegram quando o Claude pausa pedindo input livre.'));
+  console.log('Requer tmux instalado e o Claude rodando dentro de uma sessão tmux.');
+  const injectAns = await prompts({
+    type: 'confirm',
+    name: 'val',
+    message: 'Habilitar inject via tmux? (default: não)',
+    initial: false,
+  });
+  let inject: ConfigT['inject'] = { enabled: false, replyTimeoutMs: 7_200_000 };
+  if (injectAns.val === true) {
+    const sessionAns = await prompts({
+      type: 'text',
+      name: 'val',
+      message: 'Nome da sessão tmux:',
+      initial: 'claude',
+    });
+    const session = ((sessionAns.val as string) ?? 'claude').trim() || 'claude';
+    inject = { enabled: true, strategy: 'tmux', session, replyTimeoutMs: 7_200_000 };
+  }
+
   const authToken = randomBytes(32).toString('hex');
   const config: ConfigT = {
     channel: { type: 'telegram', token, chatId },
     daemon: { port, authToken },
-    inject: { enabled: false },
+    inject,
     policy: {
       permissionTimeoutMs: 55_000,
       notifyDelayMs: 60_000,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -17,6 +17,7 @@ export const InjectConfig = z.object({
   enabled: z.boolean(),
   strategy: z.enum(['tmux']).optional(),
   session: z.string().optional(),
+  replyTimeoutMs: z.number().int().min(1000).default(7_200_000),
 });
 
 export const PolicyConfig = z.object({

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,6 +48,11 @@ export interface PromptRequest {
   buttons: PromptButton[];
 }
 
+export interface QuestionRequest {
+  text: string;
+  forceReply?: boolean;
+}
+
 export type PromptButtonAction = 'allow' | 'allow_remember' | 'deny' | 'deny_note';
 
 export interface PromptButton {
@@ -62,4 +67,6 @@ export interface DecisionEvent {
 
 export interface FreeTextEvent {
   text: string;
+  /** Telegram `reply_to_message.message_id`, set when the user used the Reply UI. */
+  replyToMessageId?: string;
 }

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -10,12 +10,15 @@ import { CONFIG_DIR, LOG_DIR, PID_FILE } from '../config/paths.js';
 import { DaemonError } from '../core/errors.js';
 import { PendingMap } from './pending.js';
 import { PendingNotifications } from './pendingNotifications.js';
+import { PendingReplies } from './pendingReplies.js';
 import { loadMode, type Mode } from './state.js';
 import { GamingState } from './gaming.js';
 import { SleepingOrchestrator } from './sleeping.js';
 import { createWorktree, removeWorktree } from './worktree.js';
 import { finishSleep } from './sleepFinish.js';
 import { createServer, type DaemonContext } from './server.js';
+import { createInjectStrategy } from '../inject/index.js';
+import { validateTmuxAvailable } from '../inject/validate.js';
 
 export interface RunningDaemon {
   stop(): Promise<void>;
@@ -27,6 +30,10 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
 
   await ensureNoExistingDaemon();
 
+  if (config.inject.enabled) {
+    await validateTmuxAvailable(config.inject.session ?? 'claude');
+  }
+
   const logger = createLogger(LOG_DIR);
   logger.info('daemon starting', { port: config.daemon.port });
 
@@ -34,6 +41,8 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   const pending = new PendingMap();
   pending.startCleanupLoop();
   const pendingNotifications = new PendingNotifications();
+  const pendingReplies = new PendingReplies();
+  const inject = createInjectStrategy(config.inject);
   const initialMode: Mode = await loadMode();
   const gaming = new GamingState();
   // shell:false so --body markdown passes through verbatim. Node 16+ resolves
@@ -70,6 +79,13 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     logger.info('decision received', { requestId: event.requestId, claimed });
   });
 
+  channel.on('freeText', (event) => {
+    if (event.replyToMessageId) {
+      const claimed = pendingReplies.resolveBySentMessageId(event.replyToMessageId, event.text);
+      logger.info('reply received', { sentMessageId: event.replyToMessageId, claimed });
+    }
+  });
+
   await channel.start();
 
   const ctx: DaemonContext = {
@@ -77,6 +93,8 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     channel,
     pending,
     pendingNotifications,
+    pendingReplies,
+    inject,
     state,
     logger,
     startedAt: Date.now(),
@@ -100,6 +118,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     pending.drainAll('shutdown');
     pending.stopCleanupLoop();
     pendingNotifications.cancelAll();
+    pendingReplies.cancelAll();
     await new Promise<void>((resolve) => server.close(() => resolve()));
     try {
       await channel.sendNotification('🔻 kuroboto offline');
@@ -174,3 +193,4 @@ function makeChannel(config: ConfigT, logger: Logger): Channel {
   }
   throw new DaemonError(`unsupported channel type: ${(config.channel as { type: string }).type}`);
 }
+

--- a/src/daemon/notificationDetect.ts
+++ b/src/daemon/notificationDetect.ts
@@ -1,0 +1,11 @@
+// Hardcoded set of known Claude Code Notification messages that mean "Claude
+// is paused waiting for free-text input from the user." Anything else falls
+// through to the regular notification path.
+//
+// Extension = add a string to this array.
+const QA_PATTERNS: readonly string[] = ['Claude is waiting for your input'];
+
+export function isQAPrompt(message: string | undefined | null): boolean {
+  if (typeof message !== 'string') return false;
+  return QA_PATTERNS.includes(message);
+}

--- a/src/daemon/pendingReplies.ts
+++ b/src/daemon/pendingReplies.ts
@@ -1,0 +1,58 @@
+// In-memory tracker for outstanding Q&A prompts awaiting a Telegram reply.
+// Mirrors `pending.ts` (permission requests) but keys by the Telegram
+// `sentMessageId` of the bot's outbound question, since that's what arrives
+// on incoming replies via `reply_to_message.message_id`.
+
+export interface PendingReplyHandle {
+  promise: Promise<string>;
+}
+
+interface Entry {
+  resolve: (text: string) => void;
+  reject: (e: Error) => void;
+  timer: NodeJS.Timeout;
+  createdAt: number;
+}
+
+export class PendingReplies {
+  private readonly entries = new Map<string, Entry>();
+
+  create(sentMessageId: string, timeoutMs: number): PendingReplyHandle {
+    let resolve!: (text: string) => void;
+    let reject!: (e: Error) => void;
+    const promise = new Promise<string>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    const timer = setTimeout(() => {
+      const entry = this.entries.get(sentMessageId);
+      if (entry) {
+        this.entries.delete(sentMessageId);
+        entry.reject(new Error('timeout'));
+      }
+    }, timeoutMs);
+    this.entries.set(sentMessageId, { resolve, reject, timer, createdAt: Date.now() });
+    return { promise };
+  }
+
+  resolveBySentMessageId(sentMessageId: string, text: string): boolean {
+    const entry = this.entries.get(sentMessageId);
+    if (!entry) return false;
+    clearTimeout(entry.timer);
+    this.entries.delete(sentMessageId);
+    entry.resolve(text);
+    return true;
+  }
+
+  cancelAll(): void {
+    for (const entry of this.entries.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error('shutdown'));
+    }
+    this.entries.clear();
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/daemon/promptFormat.ts
+++ b/src/daemon/promptFormat.ts
@@ -32,6 +32,17 @@ export async function formatNotification(
   return `${header}${intent}\n\n${body}`;
 }
 
+const QA_FOOTER = '❓ Claude tá esperando uma resposta. Toque em Reply pra responder.';
+
+export async function formatQAPrompt(
+  p: NotificationPayload,
+  ctx: PromptFormatContext,
+): Promise<string> {
+  const header = await buildHeader(p.cwd, p.transcript_path, ctx);
+  const intent = await buildIntentLine(p.transcript_path);
+  return `${header}${intent}\n\n${QA_FOOTER}`;
+}
+
 async function buildHeader(
   cwd: string | undefined,
   transcriptPath: string | undefined,

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -9,7 +9,13 @@ import { saveMode, type Mode } from './state.js';
 import { computeAllowMatcher, addProjectAllow } from './allowlist.js';
 import { loadAllowlist, matchAny } from './allowlistMatch.js';
 import { appendAudit } from './audit.js';
-import { formatPermissionPrompt, formatNotification, type PromptFormatContext } from './promptFormat.js';
+import {
+  formatPermissionPrompt,
+  formatNotification,
+  formatQAPrompt,
+  type PromptFormatContext,
+} from './promptFormat.js';
+import { isQAPrompt } from './notificationDetect.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
   const fmtCtx = (): PromptFormatContext => ({
@@ -145,6 +151,16 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
 
   app.post('/v1/notify', (req: Request, res: Response) => {
     const payload = req.body as NotificationPayload;
+    if (shouldHandleAsQA(payload, ctx)) {
+      // Fire-and-forget: the Q&A flow runs end-to-end (send question, await
+      // reply, inject, audit) in the background. The hook just gets ack.
+      handleQAPrompt(payload, ctx, fmtCtx()).catch((e) =>
+        ctx.logger.warn('Q&A flow failed', { err: (e as Error).message }),
+      );
+      ctx.logger.info('notify received (Q&A)', { cwd: payload.cwd });
+      res.json({ ok: true, qa: true });
+      return;
+    }
     const delayMs = ctx.state.mode === 'away' ? 0 : ctx.config.policy.notifyDelayMs;
     ctx.logger.info('notify received', {
       mode: ctx.state.mode,
@@ -294,4 +310,105 @@ function expandHome(p: string): string {
     return path.join(os.homedir(), p.slice(2));
   }
   return p;
+}
+
+function shouldHandleAsQA(payload: NotificationPayload, ctx: DaemonContext): boolean {
+  if (!ctx.config.inject.enabled) return false;
+  if (!ctx.inject) return false;
+  if (!isQAPrompt(payload.message)) return false;
+  // Sleep mode is autonomous: if Claude pauses inside a sleep worktree, it's
+  // a stuck session — fall through to the regular notif path so the user can
+  // investigate, rather than waiting indefinitely for a Q&A reply.
+  const snap = ctx.state.sleeping.snapshot();
+  if (snap.active && payload.cwd && samePath(payload.cwd, snap.worktreePath)) return false;
+  return true;
+}
+
+function samePath(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
+
+async function handleQAPrompt(
+  payload: NotificationPayload,
+  ctx: DaemonContext,
+  fmtCtx: PromptFormatContext,
+): Promise<void> {
+  const inject = ctx.inject;
+  if (!inject) return; // already gated upstream, but keeps types honest
+  const text = await formatQAPrompt(payload, fmtCtx);
+  let sentMessageId: string;
+  try {
+    ({ sentMessageId } = await ctx.channel.sendQuestion({ text, forceReply: true }));
+  } catch (e) {
+    ctx.logger.warn('Q&A sendQuestion failed', { err: (e as Error).message });
+    return;
+  }
+  const { promise } = ctx.pendingReplies.create(sentMessageId, ctx.config.inject.replyTimeoutMs);
+  void appendAudit({
+    ts: new Date().toISOString(),
+    requestId: sentMessageId,
+    tool: 'Q&A',
+    cwd: payload.cwd ?? null,
+    decision: 'ask',
+    reason: null,
+    source: 'qa-pending',
+    remember: false,
+  }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
+
+  let reply: string;
+  try {
+    reply = await promise;
+  } catch (e) {
+    const msg = (e as Error).message;
+    if (msg === 'timeout') {
+      void appendAudit({
+        ts: new Date().toISOString(),
+        requestId: sentMessageId,
+        tool: 'Q&A',
+        cwd: payload.cwd ?? null,
+        decision: 'deny',
+        reason: 'timeout',
+        source: 'qa-timeout',
+        remember: false,
+      }).catch((e2) => ctx.logger.warn('audit append failed', { err: (e2 as Error).message }));
+      await ctx.channel
+        .sendNotification('⏱ Q&A expirou (Claude pode ainda estar esperando)')
+        .catch((e2) => ctx.logger.warn('sendNotification (qa-timeout) failed', { err: (e2 as Error).message }));
+      return;
+    }
+    // shutdown / cancelled — silent drop
+    return;
+  }
+
+  try {
+    await inject.inject(reply);
+    void appendAudit({
+      ts: new Date().toISOString(),
+      requestId: sentMessageId,
+      tool: 'Q&A',
+      cwd: payload.cwd ?? null,
+      decision: 'allow',
+      reason: 'injected',
+      source: 'qa-injected',
+      remember: false,
+    }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
+    await ctx.channel
+      .sendNotification('✅ Reply injetada')
+      .catch((e) => ctx.logger.warn('sendNotification (qa-injected) failed', { err: (e as Error).message }));
+  } catch (e) {
+    const errMsg = (e as Error).message;
+    void appendAudit({
+      ts: new Date().toISOString(),
+      requestId: sentMessageId,
+      tool: 'Q&A',
+      cwd: payload.cwd ?? null,
+      decision: 'deny',
+      reason: errMsg,
+      source: 'qa-inject-failed',
+      remember: false,
+    }).catch((e2) => ctx.logger.warn('audit append failed', { err: (e2 as Error).message }));
+    await ctx.channel
+      .sendNotification(`❌ Inject falhou: ${errMsg}\n\nSua reply foi:\n${reply}`)
+      .catch((e2) => ctx.logger.warn('sendNotification (qa-inject-failed) failed', { err: (e2 as Error).message }));
+  }
 }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -2,8 +2,10 @@ import express, { type Express, type Request, type Response, type NextFunction }
 import type { Channel } from '../channels/Channel.js';
 import type { Logger } from '../core/logger.js';
 import type { ConfigT } from '../config/schema.js';
+import type { InjectStrategy } from '../inject/index.js';
 import { PendingMap } from './pending.js';
 import { PendingNotifications } from './pendingNotifications.js';
+import type { PendingReplies } from './pendingReplies.js';
 import type { Mode } from './state.js';
 import { GamingState } from './gaming.js';
 import { SleepingOrchestrator } from './sleeping.js';
@@ -14,6 +16,8 @@ export interface DaemonContext {
   channel: Channel;
   pending: PendingMap;
   pendingNotifications: PendingNotifications;
+  pendingReplies: PendingReplies;
+  inject: InjectStrategy | null;
   state: { mode: Mode; gaming: GamingState; sleeping: SleepingOrchestrator };
   logger: Logger;
   startedAt: number;

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -1,0 +1,11 @@
+import type { ConfigT } from '../config/schema.js';
+import { TmuxInjectStrategy, type InjectStrategy } from './tmux.js';
+
+export function createInjectStrategy(config: ConfigT['inject']): InjectStrategy | null {
+  if (!config.enabled) return null;
+  const session = config.session ?? 'claude';
+  return new TmuxInjectStrategy(session);
+}
+
+export { TmuxInjectStrategy } from './tmux.js';
+export type { InjectStrategy } from './tmux.js';

--- a/src/inject/tmux.ts
+++ b/src/inject/tmux.ts
@@ -1,0 +1,50 @@
+import { spawn, type SpawnOptions } from 'node:child_process';
+
+export interface InjectStrategy {
+  inject(text: string): Promise<void>;
+}
+
+export interface TmuxRunResult {
+  code: number;
+  stderr: string;
+}
+
+export type TmuxRunFn = (args: readonly string[]) => Promise<TmuxRunResult>;
+
+export class TmuxInjectStrategy implements InjectStrategy {
+  constructor(
+    private readonly session: string,
+    private readonly run: TmuxRunFn = defaultRun,
+  ) {}
+
+  async inject(text: string): Promise<void> {
+    // `-l` (literal) writes the bytes verbatim — no key-name parsing — so quotes,
+    // `$`, backticks, and embedded newlines round-trip into the user's terminal
+    // unmodified. A separate `Enter` press submits.
+    await this.runOrThrow(['send-keys', '-t', this.session, '-l', text]);
+    await this.runOrThrow(['send-keys', '-t', this.session, 'Enter']);
+  }
+
+  private async runOrThrow(args: readonly string[]): Promise<void> {
+    const { code, stderr } = await this.run(args);
+    if (code !== 0) {
+      throw new Error(`tmux ${args.join(' ')} exited ${code}: ${stderr.trim()}`);
+    }
+  }
+}
+
+function defaultRun(args: readonly string[]): Promise<TmuxRunResult> {
+  return runTmux(args);
+}
+
+export function runTmux(args: readonly string[], opts?: SpawnOptions): Promise<TmuxRunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('tmux', args as string[], { ...opts, shell: false });
+    let stderr = '';
+    child.stderr?.on('data', (b: Buffer) => {
+      stderr += b.toString();
+    });
+    child.on('error', (e) => reject(e));
+    child.on('close', (code) => resolve({ code: code ?? -1, stderr }));
+  });
+}

--- a/src/inject/validate.ts
+++ b/src/inject/validate.ts
@@ -1,0 +1,40 @@
+import { runTmux, type TmuxRunFn, type TmuxRunResult } from './tmux.js';
+import { DaemonError } from '../core/errors.js';
+
+const defaultRun: TmuxRunFn = (args) => runTmux(args);
+
+export async function validateTmuxAvailable(
+  session: string,
+  run: TmuxRunFn = defaultRun,
+): Promise<void> {
+  const v = await safeRun(run, ['-V'], (e) =>
+    new DaemonError(
+      `tmux not found in PATH; either install tmux or set inject.enabled=false (${e.message})`,
+    ),
+  );
+  if (v.code !== 0) {
+    throw new DaemonError(
+      'tmux not found in PATH; either install tmux or set inject.enabled=false',
+    );
+  }
+  const h = await safeRun(run, ['has-session', '-t', session], (e) =>
+    new DaemonError(`tmux has-session failed for '${session}': ${e.message}`),
+  );
+  if (h.code !== 0) {
+    throw new DaemonError(
+      `tmux session '${session}' not found; create it before starting kuroboto`,
+    );
+  }
+}
+
+async function safeRun(
+  run: TmuxRunFn,
+  args: readonly string[],
+  wrap: (e: Error) => Error,
+): Promise<TmuxRunResult> {
+  try {
+    return await run(args);
+  } catch (e) {
+    throw wrap(e as Error);
+  }
+}

--- a/test/helpers/mockChannel.ts
+++ b/test/helpers/mockChannel.ts
@@ -3,12 +3,15 @@ import type {
   ChannelEventHandlers,
   ChannelEventName,
 } from '../../src/channels/Channel.js';
-import type { PromptRequest, Decision } from '../../src/core/types.js';
+import type { PromptRequest, QuestionRequest, Decision } from '../../src/core/types.js';
 
 export class MockChannel implements Channel {
   public sentNotifications: string[] = [];
   public sentPrompts: PromptRequest[] = [];
+  public sentQuestions: QuestionRequest[] = [];
   public throwOnSendPrompt = false;
+  public throwOnSendQuestion = false;
+  private nextSentMessageId = 1000;
   private handlers: { [K in ChannelEventName]: Array<ChannelEventHandlers[K]> } = {
     decision: [],
     freeText: [],
@@ -26,12 +29,22 @@ export class MockChannel implements Channel {
     this.sentPrompts.push(req);
   }
 
+  async sendQuestion(req: QuestionRequest): Promise<{ sentMessageId: string }> {
+    if (this.throwOnSendQuestion) throw new Error('mock channel error');
+    this.sentQuestions.push(req);
+    return { sentMessageId: String(this.nextSentMessageId++) };
+  }
+
   on<K extends ChannelEventName>(event: K, handler: ChannelEventHandlers[K]): void {
     this.handlers[event].push(handler);
   }
 
   emitDecision(requestId: string, decision: Decision): void {
     for (const h of this.handlers.decision) h({ requestId, decision });
+  }
+
+  emitFreeText(text: string, replyToMessageId?: string): void {
+    for (const h of this.handlers.freeText) h({ text, replyToMessageId });
   }
 }
 

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -617,3 +617,205 @@ describe('prompt context header (session + intent)', () => {
     await pending;
   });
 });
+
+describe('Q&A flow (tmux inject)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-qa-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeTranscript(name: string, lines: unknown[]): Promise<string> {
+    const file = path.join(tmpDir, name);
+    await fsp.writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n'));
+    return file;
+  }
+
+  function makeFakeInject(): { strategy: { inject: (t: string) => Promise<void> }; calls: string[]; failNext: { err: Error | null } } {
+    const calls: string[] = [];
+    const failNext = { err: null as Error | null };
+    return {
+      calls,
+      failNext,
+      strategy: {
+        inject: async (text: string) => {
+          calls.push(text);
+          if (failNext.err) {
+            const e = failNext.err;
+            failNext.err = null;
+            throw e;
+          }
+        },
+      },
+    };
+  }
+
+  it('QA notif + inject enabled → sendQuestion(forceReply), audit qa-pending, then on reply: inject + qa-injected + ✅', async () => {
+    const transcript = await writeTranscript('q.jsonl', [
+      { role: 'user', content: 'fix it' },
+      { role: 'assistant', content: 'Quero rodar A ou B?' },
+    ]);
+    const fake = makeFakeInject();
+    const { ctx, channel, pendingReplies } = makeContext({
+      mode: 'away',
+      inject: { enabled: true, strategy: 'tmux', session: 'claude', replyTimeoutMs: 60_000 },
+      injectStrategy: fake.strategy,
+    });
+    const app = createServer(ctx);
+    const res = await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        message: 'Claude is waiting for your input',
+        cwd: '/x/kuroboto',
+        transcript_path: transcript,
+      });
+    expect(res.body).toEqual({ ok: true, qa: true });
+    await waitFor(() => channel.sentQuestions.length === 1);
+    const q = channel.sentQuestions[0];
+    expect(q.forceReply).toBe(true);
+    expect(q.text).toContain('💭 Quero rodar A ou B?');
+    expect(q.text).toContain('❓ Claude tá esperando uma resposta');
+    expect(q.text).toContain('"fix it"');
+
+    await waitFor(() => pendingReplies.size() === 1);
+    // The mock channel assigns a sequential sentMessageId starting at 1000
+    channel.emitFreeText('A', '1000');
+    await waitFor(() => fake.calls.length === 1);
+    expect(fake.calls).toEqual(['A']);
+    await waitFor(() => channel.sentNotifications.includes('✅ Reply injetada'));
+  });
+
+  it('QA notif + inject fails at runtime → ❌ + reply text echoed back', async () => {
+    const transcript = await writeTranscript('q2.jsonl', [
+      { role: 'user', content: 'help' },
+      { role: 'assistant', content: 'pick one' },
+    ]);
+    const fake = makeFakeInject();
+    fake.failNext.err = new Error('tmux send-keys exited 1: no server');
+    const { ctx, channel, pendingReplies } = makeContext({
+      mode: 'away',
+      inject: { enabled: true, strategy: 'tmux', session: 'claude', replyTimeoutMs: 60_000 },
+      injectStrategy: fake.strategy,
+    });
+    const app = createServer(ctx);
+    await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        message: 'Claude is waiting for your input',
+        cwd: '/x/proj',
+        transcript_path: transcript,
+      });
+    await waitFor(() => channel.sentQuestions.length === 1);
+    await waitFor(() => pendingReplies.size() === 1);
+    channel.emitFreeText('B', '1000');
+    await waitFor(() => channel.sentNotifications.some((n) => n.startsWith('❌ Inject falhou')));
+    const fail = channel.sentNotifications.find((n) => n.startsWith('❌ Inject falhou'))!;
+    expect(fail).toContain('no server');
+    expect(fail).toContain('Sua reply foi:\nB');
+  });
+
+  it('QA notif + reply never arrives → qa-timeout fires after replyTimeoutMs', async () => {
+    const transcript = await writeTranscript('q3.jsonl', [
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: 'continue?' },
+    ]);
+    const fake = makeFakeInject();
+    const { ctx, channel } = makeContext({
+      mode: 'away',
+      inject: { enabled: true, strategy: 'tmux', session: 'claude', replyTimeoutMs: 50 },
+      injectStrategy: fake.strategy,
+    });
+    const app = createServer(ctx);
+    await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        message: 'Claude is waiting for your input',
+        cwd: '/x/proj',
+        transcript_path: transcript,
+      });
+    await waitFor(() => channel.sentQuestions.length === 1);
+    await waitFor(() => channel.sentNotifications.some((n) => n.startsWith('⏱ Q&A expirou')));
+    expect(fake.calls).toEqual([]);
+  });
+
+  it('non-QA notification + inject enabled → existing notif path (no sendQuestion)', async () => {
+    const fake = makeFakeInject();
+    const { ctx, channel } = makeContext({
+      mode: 'away',
+      inject: { enabled: true, strategy: 'tmux', session: 'claude', replyTimeoutMs: 60_000 },
+      injectStrategy: fake.strategy,
+    });
+    const app = createServer(ctx);
+    const res = await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        message: 'something else entirely',
+        cwd: '/x/proj',
+      });
+    expect(res.body).toMatchObject({ ok: true, delayed: false });
+    await new Promise((r) => setImmediate(r));
+    await waitFor(() => channel.sentNotifications.length === 1);
+    expect(channel.sentQuestions.length).toBe(0);
+    expect(fake.calls).toEqual([]);
+  });
+
+  it('QA notification + inject disabled → existing notif path (no sendQuestion)', async () => {
+    const { ctx, channel } = makeContext({
+      mode: 'away',
+      inject: { enabled: false, replyTimeoutMs: 60_000 },
+    });
+    const app = createServer(ctx);
+    const res = await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        message: 'Claude is waiting for your input',
+        cwd: '/x/proj',
+      });
+    expect(res.body).toMatchObject({ ok: true, delayed: false });
+    await waitFor(() => channel.sentNotifications.length === 1);
+    expect(channel.sentQuestions.length).toBe(0);
+  });
+
+  it('QA notification inside an active sleep cwd → existing notif path (no Q&A in sleep)', async () => {
+    const fake = makeFakeInject();
+    const { ctx, channel } = makeContext({
+      mode: 'away',
+      inject: { enabled: true, strategy: 'tmux', session: 'claude', replyTimeoutMs: 60_000 },
+      injectStrategy: fake.strategy,
+    });
+    const worktreePath = path.join(tmpDir, 'sleep-work');
+    vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
+      active: true,
+      slug: 'foo-abc123',
+      branch: 'sleep/foo-abc123',
+      worktreePath,
+      startedAt: Date.now(),
+      expectedEndAt: Date.now() + 60_000,
+    });
+    const app = createServer(ctx);
+    await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        message: 'Claude is waiting for your input',
+        cwd: worktreePath,
+      });
+    await waitFor(() => channel.sentNotifications.length === 1);
+    expect(channel.sentQuestions.length).toBe(0);
+    expect(fake.calls).toEqual([]);
+  });
+});

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -6,11 +6,13 @@ import os from 'node:os';
 import { createServer, type DaemonContext } from '../../src/daemon/server.js';
 import { PendingMap } from '../../src/daemon/pending.js';
 import { PendingNotifications } from '../../src/daemon/pendingNotifications.js';
+import { PendingReplies } from '../../src/daemon/pendingReplies.js';
 import type { ConfigT } from '../../src/config/schema.js';
 import * as stateModule from '../../src/daemon/state.js';
 import type { Mode } from '../../src/daemon/state.js';
 import { GamingState } from '../../src/daemon/gaming.js';
 import { SleepingOrchestrator } from '../../src/daemon/sleeping.js';
+import type { InjectStrategy } from '../../src/inject/index.js';
 import { MockChannel, noopLogger } from '../helpers/mockChannel.js';
 
 // Prevent integration tests from mutating ~/.config/kuroboto/state.json on the host.
@@ -24,14 +26,20 @@ const TEST_TOKEN = 'a'.repeat(64);
 interface Overrides {
   mode?: Mode;
   policy?: Partial<ConfigT['policy']>;
+  inject?: ConfigT['inject'];
+  injectStrategy?: InjectStrategy | null;
 }
 
-function makeContext(overrides: Overrides = {}): { ctx: DaemonContext; channel: MockChannel } {
+function makeContext(overrides: Overrides = {}): {
+  ctx: DaemonContext;
+  channel: MockChannel;
+  pendingReplies: PendingReplies;
+} {
   const channel = new MockChannel();
   const config: ConfigT = {
     channel: { type: 'telegram', token: 'x', chatId: 1 },
     daemon: { port: 47891, authToken: TEST_TOKEN },
-    inject: { enabled: false },
+    inject: overrides.inject ?? { enabled: false, replyTimeoutMs: 7_200_000 },
     policy: {
       permissionTimeoutMs: 1_000,
       notifyDelayMs: 60_000,
@@ -44,6 +52,7 @@ function makeContext(overrides: Overrides = {}): { ctx: DaemonContext; channel: 
   };
   const pending = new PendingMap();
   const pendingNotifications = new PendingNotifications();
+  const pendingReplies = new PendingReplies();
   const gaming = new GamingState();
   const sleeping = new SleepingOrchestrator({
     spawn: () => ({ on: () => {}, kill: () => {}, pid: 0 } as never),
@@ -59,13 +68,18 @@ function makeContext(overrides: Overrides = {}): { ctx: DaemonContext; channel: 
     channel,
     pending,
     pendingNotifications,
+    pendingReplies,
+    inject: overrides.injectStrategy ?? null,
     state: { mode: overrides.mode ?? 'here', gaming, sleeping },
     logger: noopLogger,
     startedAt: Date.now(),
     hostname: 'test-host',
   };
   channel.on('decision', (e) => pending.resolve(e.requestId, e.decision));
-  return { ctx, channel };
+  channel.on('freeText', (e) => {
+    if (e.replyToMessageId) pendingReplies.resolveBySentMessageId(e.replyToMessageId, e.text);
+  });
+  return { ctx, channel, pendingReplies };
 }
 
 async function waitFor(cond: () => boolean, timeoutMs = 1_000): Promise<void> {

--- a/test/unit/notificationDetect.test.ts
+++ b/test/unit/notificationDetect.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { isQAPrompt } from '../../src/daemon/notificationDetect.js';
+
+describe('isQAPrompt', () => {
+  it('returns true for the canonical "Claude is waiting for your input" message', () => {
+    expect(isQAPrompt('Claude is waiting for your input')).toBe(true);
+  });
+
+  it('returns false for an unrelated notification message', () => {
+    expect(isQAPrompt('Task complete')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isQAPrompt('')).toBe(false);
+  });
+
+  it('returns false for undefined (resilient against missing payload field)', () => {
+    expect(isQAPrompt(undefined)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isQAPrompt(null)).toBe(false);
+  });
+
+  it('is case-sensitive: subtle variants do not match', () => {
+    expect(isQAPrompt('claude is waiting for your input')).toBe(false);
+    expect(isQAPrompt('Claude is waiting for your input ')).toBe(false);
+  });
+});

--- a/test/unit/pendingReplies.test.ts
+++ b/test/unit/pendingReplies.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { PendingReplies } from '../../src/daemon/pendingReplies.js';
+
+describe('PendingReplies', () => {
+  it('resolves with the reply text when resolveBySentMessageId fires', async () => {
+    const replies = new PendingReplies();
+    const { promise } = replies.create('msg-1', 5_000);
+    expect(replies.size()).toBe(1);
+    expect(replies.resolveBySentMessageId('msg-1', 'A')).toBe(true);
+    expect(await promise).toBe('A');
+    expect(replies.size()).toBe(0);
+  });
+
+  it('rejects with timeout when no reply arrives in time', async () => {
+    const replies = new PendingReplies();
+    const { promise } = replies.create('msg-2', 30);
+    await expect(promise).rejects.toThrow(/timeout/);
+    expect(replies.size()).toBe(0);
+  });
+
+  it('keeps two pending entries independent', async () => {
+    const replies = new PendingReplies();
+    const a = replies.create('m-a', 5_000);
+    const b = replies.create('m-b', 5_000);
+    expect(replies.size()).toBe(2);
+    replies.resolveBySentMessageId('m-b', 'reply-b');
+    replies.resolveBySentMessageId('m-a', 'reply-a');
+    expect(await a.promise).toBe('reply-a');
+    expect(await b.promise).toBe('reply-b');
+    expect(replies.size()).toBe(0);
+  });
+
+  it('returns false (no throw) when resolving an unknown sentMessageId', () => {
+    const replies = new PendingReplies();
+    expect(replies.resolveBySentMessageId('nope', 'x')).toBe(false);
+  });
+
+  it('cancelAll rejects every pending entry with shutdown', async () => {
+    const replies = new PendingReplies();
+    const a = replies.create('m-a', 5_000);
+    const b = replies.create('m-b', 5_000);
+    replies.cancelAll();
+    await expect(a.promise).rejects.toThrow(/shutdown/);
+    await expect(b.promise).rejects.toThrow(/shutdown/);
+    expect(replies.size()).toBe(0);
+  });
+});

--- a/test/unit/tmuxInject.test.ts
+++ b/test/unit/tmuxInject.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { TmuxInjectStrategy, type TmuxRunFn, type TmuxRunResult } from '../../src/inject/tmux.js';
+
+function makeRunner(result: TmuxRunResult = { code: 0, stderr: '' }): {
+  run: TmuxRunFn;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const run: TmuxRunFn = async (args) => {
+    calls.push([...args]);
+    return result;
+  };
+  return { run, calls };
+}
+
+describe('TmuxInjectStrategy', () => {
+  it('runs send-keys -l <text> then send-keys Enter', async () => {
+    const { run, calls } = makeRunner();
+    const strategy = new TmuxInjectStrategy('claude', run);
+    await strategy.inject('hello');
+    expect(calls).toEqual([
+      ['send-keys', '-t', 'claude', '-l', 'hello'],
+      ['send-keys', '-t', 'claude', 'Enter'],
+    ]);
+  });
+
+  it('preserves quotes verbatim in the args', async () => {
+    const { run, calls } = makeRunner();
+    const strategy = new TmuxInjectStrategy('claude', run);
+    await strategy.inject('he said "hi"');
+    expect(calls[0]).toEqual(['send-keys', '-t', 'claude', '-l', 'he said "hi"']);
+  });
+
+  it('passes shell metacharacters literally (no expansion at our layer)', async () => {
+    const { run, calls } = makeRunner();
+    const strategy = new TmuxInjectStrategy('claude', run);
+    await strategy.inject('echo $HOME `whoami`');
+    expect(calls[0]).toEqual(['send-keys', '-t', 'claude', '-l', 'echo $HOME `whoami`']);
+  });
+
+  it('passes embedded newlines through (multiline replies)', async () => {
+    const { run, calls } = makeRunner();
+    const strategy = new TmuxInjectStrategy('claude', run);
+    await strategy.inject('line one\nline two');
+    expect(calls[0]).toEqual(['send-keys', '-t', 'claude', '-l', 'line one\nline two']);
+    // Single trailing Enter — we don't fragment on \n
+    expect(calls[1]).toEqual(['send-keys', '-t', 'claude', 'Enter']);
+  });
+
+  it('uses the configured session name', async () => {
+    const { run, calls } = makeRunner();
+    const strategy = new TmuxInjectStrategy('my-session', run);
+    await strategy.inject('x');
+    expect(calls[0][2]).toBe('my-session');
+  });
+
+  it('rejects with stderr when tmux exits non-zero', async () => {
+    const { run } = makeRunner({ code: 1, stderr: 'no server running' });
+    const strategy = new TmuxInjectStrategy('claude', run);
+    await expect(strategy.inject('x')).rejects.toThrow(/exited 1.*no server running/);
+  });
+});

--- a/test/unit/tmuxValidate.test.ts
+++ b/test/unit/tmuxValidate.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { validateTmuxAvailable } from '../../src/inject/validate.js';
+import type { TmuxRunFn, TmuxRunResult } from '../../src/inject/tmux.js';
+
+function fakeRunner(map: Record<string, TmuxRunResult | Error>): TmuxRunFn {
+  return async (args) => {
+    const key = args.join(' ');
+    const result = map[key];
+    if (!result) throw new Error(`unexpected runner call: ${key}`);
+    if (result instanceof Error) throw result;
+    return result;
+  };
+}
+
+describe('validateTmuxAvailable', () => {
+  it('passes when tmux -V and has-session both return code 0', async () => {
+    const run = fakeRunner({
+      '-V': { code: 0, stderr: '' },
+      'has-session -t claude': { code: 0, stderr: '' },
+    });
+    await expect(validateTmuxAvailable('claude', run)).resolves.toBeUndefined();
+  });
+
+  it('throws with clear "tmux not found" error when -V exits non-zero', async () => {
+    const run = fakeRunner({
+      '-V': { code: 127, stderr: 'tmux: command not found' },
+    });
+    await expect(validateTmuxAvailable('claude', run)).rejects.toThrow(/tmux not found in PATH/);
+  });
+
+  it('throws with clear error when -V spawn errors (e.g. ENOENT)', async () => {
+    const run = fakeRunner({
+      '-V': new Error('ENOENT'),
+    });
+    await expect(validateTmuxAvailable('claude', run)).rejects.toThrow(/tmux not found in PATH.*ENOENT/);
+  });
+
+  it('throws "session not found" when has-session exits non-zero', async () => {
+    const run = fakeRunner({
+      '-V': { code: 0, stderr: '' },
+      'has-session -t my-session': { code: 1, stderr: "can't find session: my-session" },
+    });
+    await expect(validateTmuxAvailable('my-session', run)).rejects.toThrow(
+      /tmux session 'my-session' not found/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation via `kuroboto sleeping` (sleep mode).

## Original prompt

```
Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.

# Bot prompt free-text Q&A (tmux inject)

> Status: planned for next PR (Spec B of "bot UX overhaul" pair)

## Problem

Today the daemon receives the Claude Code `Notification` hook (e.g. when Claude pauses for free-text input) and forwards a generic line like `[kuroboto] Claude Code precisa de atenção.` to Telegram. The user sees the alert but cannot answer from Telegram — they have to walk back to the desk to type into the Claude session.

The desired UX is: the question Claude asked is forwarded to Telegram, the user types a reply on the phone, and the daemon injects that reply into Claude's input via `tmux send-keys`.

This spec implements that path, scoped to interactive (tmux) sessions only — sleep mode (autonomous Claude as a child process) is out of scope.

## Solution

Pipeline:

```
Claude pauses for input
  └─ Claude Code Notification hook → POST /v1/notification (kuroboto daemon)
        ├─ isQAPrompt(payload.message)?      → no: existing notif path (no change)
        └─ yes (and inject.enabled):
              ├─ readLastAssistantText(transcript_path)         (from src/daemon/transcript.ts)
              ├─ pendingReplies.create({session_id, cwd, ...})  → { id, promise, expiresAt }
              ├─ channel.sendQuestion({ text: header + 💭, forceReply: true, button: "💬 Reply" })
              │     → returns { sentMessageId }; saved on pendingReply
              └─ awaits promise
                    └─ resolved by:
                         ├─ Telegram polling sees a message with reply_to_message.id == sentMessageId
                         │     ├─ pendingReplies.resolveBySentMessageId(id, replyText)
                         │     ├─ injectStrategy.inject(replyText)
                         │     │     ├─ ok    → audit 'qa-injected'; channel.send('✅ Reply injetada')
                         │     │     └─ err   → audit 'qa-inject-failed'; channel.send('❌ inject falhou: <err>\n\nSua reply foi:\n<text>')
                         │     └─ done
                         └─ replyTimeoutMs elapses → audit 'qa-timeout'; channel.send('⏱ Q&A expirou'); drop pendingReply
```

Detection (`isQAPrompt`): hardcoded set of known Notification messages, starting with `'Claude is waiting for your input'`. Anything else is treated as a regular notification (existing path, unchanged). Extension = add a string to the array.

Reply flow uses Telegram's `force_reply` reply markup: when the user taps **💬 Reply**, Telegram opens an input box with the bot's question quoted above. The user's reply carries `reply_to_message.message_id` matching the bot's outbound message — that's how the daemon knows which pending Q&A this reply belongs to. Multi-Q&A disambiguation is automatic (each pending Q&A is its own message).

## Files

**Create:**
- `src/inject/index.ts` — `interface InjectStrategy { inject(text: string): Promise<void> }`, `createInjectStrategy(config)`.
- `src/inject/tmux.ts` — `class TmuxInjectStrategy` running `tmux send-keys -t <session> -l "<text>"` then `tmux send-keys -t <session> Enter` (literal mode `-l` avoids reinterpretation of `$`, quotes, etc).
- `src/daemon/notificationDetect.ts` — `const QA_PATTERNS: readonly string[] = ['Claude is waiting for your input']`, `isQAPrompt(message)`.
- `src/daemon/pendingReplies.ts` — in-memory manager: `create()`, `resolveBySentMessageId()`, timeout cleanup. Mirror of `pending.ts` (existing) but keyed by Telegram `sentMessageId` instead of internal `requestId`.
- `src/daemon/transcript.ts` — **identical to Spec A**, code reproduced below verbatim. Both PRs land identical content; git's 3-way merge dedups.
- `test/unit/notificationDetect.test.ts`
- `test/unit/tmuxInject.test.ts`
- `test/unit/pendingReplies.test.ts`
- `test/unit/transcript.test.ts` — same cases as Spec A (also dedups).

**Modify:**
- `src/channels/Channel.ts` — extend interface:
  ```ts
  sendQuestion(req: QuestionRequest): Promise<{ sentMessageId: string }>;
  onFreeText(handler: (msg: { text: string; replyToMessageId?: string }) => void): void;
  ```
- `src/channels/telegram/TelegramChannel.ts` — implement `sendQuestion` (sets `reply_markup: { force_reply: true }`); polling recognizes `reply_to_message`, dispatches to handler.
- `src/daemon/routes.ts` — `/v1/notification`: branch on `isQAPrompt(message) && config.inject.enabled`; create pendingReply, call `channel.sendQuestion`, await resolution.
- `src/daemon/server.ts` — startup-time check: if `config.inject.enabled === true`, run `tmux -V` and `tmux has-session -t <inject.session>`; on either failure, refuse to start with a clear error message.
- `src/config/schema.ts` — `InjectConfig`: add `replyTimeoutMs: z.number().int().min(1000).default(7200000)` (default 2h).
- `src/cli/init.ts` — wizard offers tmux opt-in; if accepted, sets `inject.enabled = true`, prompts for `inject.session` (default `'claude'`), `replyTimeoutMs` stays default.
- `test/integration/daemon.test.ts` — Q&A flow cases.

## Shared module — `src/daemon/transcript.ts`

Identical to Spec A. Reproduced here verbatim so the two specs' agents produce byte-identical output and git merges cleanly.

```ts
import fsp from 'node:fs/promises';

interface TranscriptLine {
  role?: string;
  content?: unknown;
}

interface ContentBlock {
  type?: string;
  text?: string;
}

async function readLines(path: string): Promise<TranscriptLine[]> {
  let raw: string;
  try {
    raw = await fsp.readFile(path, 'utf-8');
  } catch {
    return [];
  }
  const out: TranscriptLine[] = [];
  for (const line of raw.split('\n')) {
    if (!line.trim()) continue;
    try {
      out.push(JSON.parse(line) as TranscriptLine);
    } catch {
      continue;
    }
  }
  return out;
}

function extractText(content: unknown): string {
  if (typeof content === 'string') return content;
  if (!Array.isArray(content)) return '';
  const parts: string[] = [];
  for (const block of content as ContentBlock[]) {
    if (block?.type === 'text' && typeof block.text === 'string') {
      parts.push(block.text);
    }
  }
  return parts.join('\n').trim();
}

export async function readFirstUserMessage(transcriptPath: string): Promise<string | null> {
  const lines = await readLines(transcriptPath);
  for (const l of lines) {
    if (l.role === 'user') {
      const t = extractText(l.content);
      if (t) return t;
    }
  }
  return null;
}

export async function readLastAssistantText(transcriptPath: string): Promise<string | null> {
  const lines = await readLines(transcriptPath);
  for (let i = lines.length - 1; i >= 0; i--) {
    if (lines[i].role === 'assistant') {
      const t = extractText(lines[i].content);
      if (t) return t;
    }
  }
  return null;
}
```

## Message format

**Q&A prompt (outbound to Telegram):**

```
[<host> / <folder> / "<first user msg>"]
💭 <last assistant text>

❓ Claude tá esperando uma resposta. Toque em Reply pra responder.
```

The header is produced by Spec A's `formatNotification` (Spec B does not modify formatters; it consumes them). The 💭 line carries the actual question Claude asked (from `readLastAssistantText`). The footer line is added by Spec B's Q&A path so the user knows it's an interactive notif vs a passive one.

Inline button: `[💬 Reply]`. Reply markup includes `force_reply: true` so tapping the button (or just replying to the message) opens an input box with the question quoted.

**Inject success FYI:**
```
✅ Reply injetada
```

**Inject failure (fallback):**
```
❌ Inject falhou: <error>

Sua reply foi:
<text>
```
The user can then paste the text into the tmux session manually.

**Reply timeout:**
```
⏱ Q&A expirou (Claude pode ainda estar esperando)
```

## Behavior details

- **Detection is conservative.** Anything not in `QA_PATTERNS` falls through to the existing notification path, unchanged. No regression risk for non-QA notifications.
- **Inject is opt-in.** `inject.enabled = false` by default. The Q&A branch is skipped entirely when disabled, regardless of Notification message — falls through to existing notif path.
- **Startup validation is hard-fail.** If `inject.enabled = true` but tmux isn't available or the session doesn't exist, the daemon refuses to start with a clear error. Reason: silent runtime failures here are worse than failed startup; user is meant to set this up consciously.
- **Inject uses literal mode (`-l`).** `tmux send-keys -l "<text>"` writes the bytes directly without parsing key names. Then a separate `tmux send-keys Enter` submits. This preserves quotes, `$`, backticks, newlines, etc., in the user's reply.
- **Multiline replies:** the reply is sent as-is via `-l` (tmux's literal mode preserves embedded newlines), followed by a single trailing `tmux send-keys Enter` to submit. No splitting on `\n` in our code.
- **One pending Q&A per Notification.** The daemon doesn't dedupe across `session_id` — if Claude sends multiple Notifications quickly, each gets its own pending entry and Telegram message. User picks which to answer.
- **No Q&A in sleep mode.** The `/v1/notification` Q&A branch checks the sleep snapshot first and skips Q&A if the cwd matches an active sleep worktree (sleep is autonomous; if Claude pauses there, it's a stuck session — should fall through to plain notif so the user can investigate).

## Failure modes

| Failure | Behavior |
|---|---|
| `inject.enabled=true`, tmux not installed | daemon refuses startup with `tmux not found in PATH; either install tmux or set inject.enabled=false` |
| `inject.enabled=true`, tmux session doesn't exist | daemon refuses startup with `tmux session '<name>' not found; create it before starting kuroboto` |
| `tmux send-keys` returns non-zero at runtime (session died mid-flight) | audit `qa-inject-failed`; channel sends fallback message with the user's text (option A above) |
| `transcript_path` missing or unreadable | `readLastAssistantText` returns null; the 💭 line is omitted; Q&A still triggers (footer still asks user to reply) |
| Telegram polling drops connection | existing channel-error path (Q&A inherits, no special handling) |
| User never replies | `replyTimeoutMs` (default 2h) → audit `qa-timeout` + FYI message; pendingReply state dropped |

## Audit

New `source` values in `audit.jsonl`:

- `qa-pending` — Q&A prompt sent to Telegram, awaiting reply
- `qa-injected` — reply received and injected successfully
- `qa-inject-failed` — reply received but inject failed
- `qa-timeout` — no reply within `replyTimeoutMs`

Existing values unchanged.

## Out of scope (follow-ups, see `docs/specs-backlog.md`)

- Multi-Claude tmux mapping (per-cwd injection target).
- Telegram supergroup forum-mode threads (one topic per `session_id`) — orthogonal UX shift.
- PTY-based injection (drops the tmux dependency).
- Configurable `QA_PATTERNS` via config — wait until a real pattern shows up that's worth user-tunable behavior.
- Inject for sleep mode (would require child_process stdin write, different mechanism).

## Test plan

**Unit (`notificationDetect.test.ts`):**
- `isQAPrompt('Claude is waiting for your input')` → true
- `isQAPrompt('Task complete')` → false
- `isQAPrompt('')` → false
- `isQAPrompt(undefined)` → false (resilient)

**Unit (`tmuxInject.test.ts`):** (use a mocked `child_process.spawn`)
- `inject('hello')` → spawn called with `tmux send-keys -t <session> -l hello` then `tmux send-keys -t <session> Enter`
- `inject('he said "hi"')` → quotes preserved (mock captures argv unchanged)
- `inject('echo $HOME')` → `$HOME` not expanded (literal flag works)
- spawn exits non-zero → `inject` rejects with stderr in error

**Unit (`pendingReplies.test.ts`):**
- `create()` returns `{ id, promise }`; promise pending initially
- `resolveBySentMessageId(id, 'reply')` → promise resolves with 'reply'
- timeout fires → promise rejects, entry removed
- two pending entries don't interfere
- `resolveBySentMessageId('unknown')` → no-op (no throw)

**Unit (`transcript.test.ts`):** identical to Spec A.

**Integration (`daemon.test.ts`):**
- `inject.enabled=true` + Notification message `'Claude is waiting for your input'` + cwd with mock transcript → mock channel receives `sendQuestion` with `forceReply: true`, audit entry `qa-pending`
- Mock channel emits free-text reply matching the `sentMessageId` → mock `tmuxInject.inject` is called with the reply text, audit `qa-injected`, channel receives '✅ Reply injetada'
- Mock `tmuxInject.inject` rejects → channel receives '❌ inject falhou' with the user's text, audit `qa-inject-failed`
- Notification with non-QA message + `inject.enabled=true` → existing notif path (no `sendQuestion`)
- Notification with QA message + `inject.enabled=false` → existing notif path (no `sendQuestion`)
- Notification with QA message + cwd is in sleep snapshot → existing notif path (no Q&A in sleep)

**Integration (startup, `daemon.test.ts` or new `startup.test.ts`):**
- `inject.enabled=true` + mock `tmux -V` returns non-zero → daemon throws with clear error
- `inject.enabled=true` + mock `tmux has-session` returns non-zero → daemon throws with session-not-found error
- `inject.enabled=false` → no tmux check (passes regardless of tmux availability)

**Smoke (post-merge):**
1. `tmux new -s claude` in a terminal
2. Inside, run `claude code` and start any task that will pause for input ("escolha entre A e B")
3. In another terminal, `kuroboto start` (with `inject.enabled=true`, `inject.session='claude'`)
4. Wait for the Telegram notif with the question + 💬 Reply button
5. Tap Reply, type `A`, send
6. Verify in the tmux pane that `A` appeared and Enter was pressed
7. Verify Telegram receives `✅ Reply injetada`

## Tasks

1. **M1**: Create `src/daemon/transcript.ts` (canonical), `src/daemon/notificationDetect.ts`, `src/daemon/pendingReplies.ts`, `src/inject/{index,tmux}.ts`. Unit tests for all.
2. **M2**: Extend `Channel` interface, implement in `TelegramChannel`. Wire `/v1/notification` Q&A branch. Add startup tmux validation. Add `replyTimeoutMs` to schema + init wizard.
3. **M3**: Integration tests + manual smoke. PR.

```

## Test plan

- [ ] Review the diff against the original prompt
- [ ] Run the test suite locally
- [ ] Smoke-test the new behavior end-to-end

_Generated by kuroboto sleep mode._