### PR TITLE
feat(daemon): desktop notifications on sleep finish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^12.1.0",
         "express": "^4.21.0",
         "minimatch": "^10.2.5",
+        "node-notifier": "^10.0.1",
         "prompts": "^2.4.2",
         "zod": "^3.23.8"
       },
@@ -22,6 +23,7 @@
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/node": "^22.7.0",
+        "@types/node-notifier": "^8.0.5",
         "@types/prompts": "^2.4.9",
         "@types/supertest": "^6.0.2",
         "supertest": "^7.0.0",
@@ -934,6 +936,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-notifier": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.5.tgz",
+      "integrity": "sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/prompts": {
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
@@ -1806,6 +1818,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
+      "license": "MIT"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1892,6 +1910,39 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -2035,6 +2086,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
       }
     },
     "node_modules/object-inspect": {
@@ -2275,6 +2340,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
@@ -2325,6 +2402,12 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2633,6 +2716,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2840,6 +2932,21 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "commander": "^12.1.0",
     "express": "^4.21.0",
     "minimatch": "^10.2.5",
+    "node-notifier": "^10.0.1",
     "prompts": "^2.4.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^22.7.0",
+    "@types/node-notifier": "^8.0.5",
     "@types/prompts": "^2.4.9",
     "@types/supertest": "^6.0.2",
     "supertest": "^7.0.0",

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -91,6 +91,15 @@ export async function initCommand(): Promise<void> {
     inject = { enabled: true, strategy: 'tmux', session, replyTimeoutMs: 7_200_000 };
   }
 
+  console.log(chalk.cyan('\nDesktop notifications: toast nativa do SO quando o sleep mode termina (sucesso, falha ou timeout).'));
+  const desktopAns = await prompts({
+    type: 'confirm',
+    name: 'val',
+    message: 'Habilitar desktop notifications? (default: sim)',
+    initial: true,
+  });
+  const desktopEnabled = desktopAns.val !== false;
+
   const authToken = randomBytes(32).toString('hex');
   const config: ConfigT = {
     channel: { type: 'telegram', token, chatId },
@@ -106,6 +115,7 @@ export async function initCommand(): Promise<void> {
       sleepWorktreeDir: '~/.kuroboto/worktrees',
       failOpen: true,
     },
+    notifications: { desktop: desktopEnabled },
   };
   await saveConfig(config);
   console.log(chalk.green(`✓ config salvo em ${CONFIG_FILE}`));

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -98,7 +98,7 @@ export async function initCommand(): Promise<void> {
     message: 'Habilitar desktop notifications? (default: sim)',
     initial: true,
   });
-  const desktopEnabled = desktopAns.val !== false;
+  const desktopEnabled = desktopAns.val === true;
 
   const authToken = randomBytes(32).toString('hex');
   const config: ConfigT = {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -20,6 +20,10 @@ export const InjectConfig = z.object({
   replyTimeoutMs: z.number().int().min(1000).default(7_200_000),
 });
 
+export const NotificationsConfig = z.object({
+  desktop: z.boolean().default(false),
+});
+
 export const PolicyConfig = z.object({
   permissionTimeoutMs: z.number().int().min(1000),
   notifyDelayMs: z.number().int().min(0).default(60_000),
@@ -36,6 +40,7 @@ export const Config = z.object({
   daemon: DaemonConfig,
   inject: InjectConfig,
   policy: PolicyConfig,
+  notifications: NotificationsConfig.default({ desktop: false }),
 });
 
 export type ConfigT = z.infer<typeof Config>;

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -16,6 +16,7 @@ import { GamingState } from './gaming.js';
 import { SleepingOrchestrator } from './sleeping.js';
 import { createWorktree, removeWorktree } from './worktree.js';
 import { finishSleep } from './sleepFinish.js';
+import { notifyDesktop, type DesktopNotifyOpts } from '../notify/desktop.js';
 import { createServer, type DaemonContext } from './server.js';
 import { createInjectStrategy } from '../inject/index.js';
 import { validateTmuxAvailable } from '../inject/validate.js';
@@ -50,6 +51,13 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   // to suffix manually.
   const claudeSpawn = (cmd: string, args: string[], opts?: SpawnOptions): ReturnType<typeof nodeSpawn> =>
     nodeSpawn(cmd, args, { ...opts, shell: false });
+  const desktopNotifyDep: ((opts: DesktopNotifyOpts) => Promise<void>) | undefined =
+    config.notifications.desktop
+      ? (opts) =>
+          notifyDesktop(opts, {
+            log: (msg, fields) => logger.debug(msg, fields),
+          })
+      : undefined;
   const sleeping = new SleepingOrchestrator({
     spawn: claudeSpawn,
     gaming,
@@ -57,6 +65,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     audit: async () => {}, // skip audit at daemon level; sleep events go to Telegram
     createWorktree,
     removeWorktree,
+    notifyDesktop: desktopNotifyDep,
     onSuccess: (session) =>
       finishSleep(session, {
         exec: async (cmd, args, opts) => {
@@ -70,6 +79,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
           });
         },
         notify: (msg) => channel.sendNotification(msg),
+        notifyDesktop: desktopNotifyDep,
       }),
   });
   const state = { mode: initialMode, gaming, sleeping };

--- a/src/daemon/sleepFinish.ts
+++ b/src/daemon/sleepFinish.ts
@@ -1,4 +1,5 @@
 import type { SleepingSession } from './sleeping.js';
+import type { DesktopNotifyOpts } from '../notify/desktop.js';
 
 export interface ExecResult {
   code: number;
@@ -15,6 +16,7 @@ export type ExecFn = (
 export interface FinishDeps {
   exec: ExecFn;
   notify: (msg: string) => Promise<void>;
+  notifyDesktop?: (opts: DesktopNotifyOpts) => Promise<void>;
 }
 
 function humanise(slug: string): string {
@@ -53,6 +55,13 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
       `❌ sleep finalize failed — push failed: ${push.stderr.trim() || 'unknown'}. ` +
         `worktree: ${session.worktreePath}`,
     );
+    if (deps.notifyDesktop) {
+      await deps.notifyDesktop({
+        title: 'kuroboto: sleep error',
+        body: `${session.slug}: push failed`,
+        level: 'error',
+      });
+    }
     return;
   }
 
@@ -79,6 +88,13 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
       `❌ sleep finalize failed — pr create failed: ${create.stderr.trim() || 'unknown'}. ` +
         `worktree: ${session.worktreePath}`,
     );
+    if (deps.notifyDesktop) {
+      await deps.notifyDesktop({
+        title: 'kuroboto: sleep error',
+        body: `${session.slug}: PR create failed`,
+        level: 'error',
+      });
+    }
     return;
   }
 
@@ -86,4 +102,11 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
   await deps.notify(
     `✅ sleep done — PR: ${url}\n\nTest plan in the PR body. Worktree: ${session.worktreePath}`,
   );
+  if (deps.notifyDesktop) {
+    await deps.notifyDesktop({
+      title: 'kuroboto: sleep done',
+      body: `${session.slug} → ${url}`,
+      level: 'success',
+    });
+  }
 }

--- a/src/daemon/sleeping.ts
+++ b/src/daemon/sleeping.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { GamingState, type GamingSnapshot } from './gaming.js';
 import { slugify } from './worktree.js';
+import type { DesktopNotifyOpts } from '../notify/desktop.js';
 
 export type SpawnFn = (cmd: string, args: string[], opts: SpawnOptions) => ChildProcess;
 
@@ -12,6 +13,7 @@ export interface SleepingDeps {
   createWorktree: (repo: string, branch: string, dir: string) => Promise<void>;
   removeWorktree: (repo: string, dir: string) => Promise<void>;
   onSuccess: (session: SleepingSession) => Promise<void>;
+  notifyDesktop?: (opts: DesktopNotifyOpts) => Promise<void>;
 }
 
 export interface SleepingStartRequest {
@@ -187,6 +189,13 @@ export class SleepingOrchestrator {
       void this.deps.notify(
         `❌ sleep failed — ${reason}. log: ${session.worktreePath}/.kuroboto-sleep.log`,
       );
+      if (this.deps.notifyDesktop) {
+        void this.deps.notifyDesktop({
+          title: 'kuroboto: sleep error',
+          body: `${session.slug}: ${reason}`,
+          level: 'error',
+        });
+      }
       this.restoreGaming(session.gamingPriorSnapshot);
       if (this.session === session) this.session = null;
     }
@@ -200,6 +209,13 @@ export class SleepingOrchestrator {
     void this.deps.notify(
       `⏰ sleep timed out. log: ${session.worktreePath}/.kuroboto-sleep.log. PR not created.`,
     );
+    if (this.deps.notifyDesktop) {
+      void this.deps.notifyDesktop({
+        title: 'kuroboto: sleep timeout',
+        body: `${session.slug}: ran past max duration; no PR`,
+        level: 'error',
+      });
+    }
     this.restoreGaming(session.gamingPriorSnapshot);
     this.session = null;
   }

--- a/src/notify/desktop.ts
+++ b/src/notify/desktop.ts
@@ -1,0 +1,44 @@
+import notifier from 'node-notifier';
+
+export type NotifyLevel = 'success' | 'error';
+
+export interface DesktopNotifyOpts {
+  title: string;
+  body: string;
+  level: NotifyLevel;
+}
+
+export interface DesktopNotifyDeps {
+  notify?: (
+    notification: { title: string; message: string; sound: boolean; wait: boolean },
+    callback: (err: Error | null) => void,
+  ) => void;
+  log?: (msg: string, fields?: Record<string, unknown>) => void;
+}
+
+const defaultNotify: NonNullable<DesktopNotifyDeps['notify']> = (notification, callback) => {
+  notifier.notify(notification, callback);
+};
+
+export async function notifyDesktop(
+  opts: DesktopNotifyOpts,
+  deps: DesktopNotifyDeps = {},
+): Promise<void> {
+  const notify = deps.notify ?? defaultNotify;
+  const log = deps.log ?? (() => {});
+  const sound = opts.level === 'error';
+  return new Promise<void>((resolve) => {
+    try {
+      notify(
+        { title: opts.title, message: opts.body, sound, wait: false },
+        (err) => {
+          if (err) log('desktop notify failed', { err: err.message });
+          resolve();
+        },
+      );
+    } catch (e) {
+      log('desktop notify threw', { err: (e as Error).message });
+      resolve();
+    }
+  });
+}

--- a/test/unit/desktopNotify.test.ts
+++ b/test/unit/desktopNotify.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { notifyDesktop, type DesktopNotifyDeps } from '../../src/notify/desktop.js';
+
+interface NotifyCall {
+  title: string;
+  message: string;
+  sound: boolean;
+  wait: boolean;
+}
+
+function makeDeps(behavior: 'ok' | 'error' | 'throw' = 'ok'): {
+  deps: DesktopNotifyDeps;
+  calls: NotifyCall[];
+  logs: Array<{ msg: string; fields?: Record<string, unknown> }>;
+} {
+  const calls: NotifyCall[] = [];
+  const logs: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+  const deps: DesktopNotifyDeps = {
+    notify: vi.fn((notification, callback) => {
+      calls.push(notification);
+      if (behavior === 'throw') {
+        throw new Error('synchronous fail');
+      }
+      const err = behavior === 'error' ? new Error('notif daemon down') : null;
+      setImmediate(() => callback(err));
+    }),
+    log: (msg, fields) => {
+      logs.push({ msg, fields });
+    },
+  };
+  return { deps, calls, logs };
+}
+
+describe('notifyDesktop', () => {
+  it('success level → calls notifier with sound: false', async () => {
+    const { deps, calls } = makeDeps();
+    await notifyDesktop({ title: 't', body: 'b', level: 'success' }, deps);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ title: 't', message: 'b', sound: false, wait: false });
+  });
+
+  it('error level → calls notifier with sound: true', async () => {
+    const { deps, calls } = makeDeps();
+    await notifyDesktop({ title: 't', body: 'b', level: 'error' }, deps);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ title: 't', message: 'b', sound: true, wait: false });
+  });
+
+  it('notifier callback error → resolves silently and logs', async () => {
+    const { deps, logs } = makeDeps('error');
+    await expect(
+      notifyDesktop({ title: 't', body: 'b', level: 'success' }, deps),
+    ).resolves.toBeUndefined();
+    expect(logs.some((l) => l.msg.includes('failed'))).toBe(true);
+  });
+
+  it('notifier throws synchronously → resolves silently and logs', async () => {
+    const { deps, logs } = makeDeps('throw');
+    await expect(
+      notifyDesktop({ title: 't', body: 'b', level: 'error' }, deps),
+    ).resolves.toBeUndefined();
+    expect(logs.some((l) => l.msg.includes('threw'))).toBe(true);
+  });
+
+  it('long body is passed through verbatim (OS truncates)', async () => {
+    const { deps, calls } = makeDeps();
+    const long = 'x'.repeat(500);
+    await notifyDesktop({ title: 't', body: long, level: 'success' }, deps);
+    expect(calls[0].message).toBe(long);
+    expect(calls[0].message.length).toBe(500);
+  });
+});

--- a/test/unit/sleepFinish.test.ts
+++ b/test/unit/sleepFinish.test.ts
@@ -84,6 +84,62 @@ describe('finishSleep', () => {
     expect(body).toMatch(/sleep mode|kuroboto sleeping|automated/i);
   });
 
+  it('success path → notifyDesktop called with level success and slug + URL', async () => {
+    const { deps, calls } = makeDeps();
+    const desktopCalls: Array<{ title: string; body: string; level: string }> = [];
+    deps.notifyDesktop = async (opts) => {
+      desktopCalls.push(opts);
+    };
+    await finishSleep(SESSION, deps);
+    expect(calls.notify).toHaveLength(1); // existing Telegram path still fires
+    expect(desktopCalls).toHaveLength(1);
+    expect(desktopCalls[0].level).toBe('success');
+    expect(desktopCalls[0].body).toContain('add-feature-x');
+    expect(desktopCalls[0].body).toContain('https://github.com/x/y/pull/42');
+  });
+
+  it('push failure → notifyDesktop called with level error', async () => {
+    const { deps, calls } = makeDeps();
+    const desktopCalls: Array<{ title: string; body: string; level: string }> = [];
+    deps.notifyDesktop = async (opts) => {
+      desktopCalls.push(opts);
+    };
+    deps.exec = vi.fn(async (cmd) => {
+      if (cmd === 'git') return { code: 1, stdout: '', stderr: 'no upstream' };
+      return { code: 0, stdout: '', stderr: '' };
+    });
+    await finishSleep(SESSION, deps);
+    expect(calls.notify).toHaveLength(1);
+    expect(desktopCalls).toHaveLength(1);
+    expect(desktopCalls[0].level).toBe('error');
+    expect(desktopCalls[0].body.toLowerCase()).toContain('push');
+  });
+
+  it('pr create failure → notifyDesktop called with level error', async () => {
+    const { deps } = makeDeps();
+    const desktopCalls: Array<{ title: string; body: string; level: string }> = [];
+    deps.notifyDesktop = async (opts) => {
+      desktopCalls.push(opts);
+    };
+    deps.exec = vi.fn(async (cmd, args) => {
+      if (cmd === 'git') return { code: 0, stdout: '', stderr: '' };
+      if (cmd === 'gh' && args.includes('pr')) return { code: 1, stdout: '', stderr: 'no remote' };
+      return { code: 0, stdout: '', stderr: '' };
+    });
+    await finishSleep(SESSION, deps);
+    expect(desktopCalls).toHaveLength(1);
+    expect(desktopCalls[0].level).toBe('error');
+    expect(desktopCalls[0].body.toLowerCase()).toContain('pr');
+  });
+
+  it('notifyDesktop omitted → finish flow still completes (Telegram still sent)', async () => {
+    const { deps, calls } = makeDeps();
+    // notifyDesktop intentionally undefined
+    await finishSleep(SESSION, deps);
+    expect(calls.notify).toHaveLength(1);
+    expect(calls.notify[0]).toContain('https://github.com/x/y/pull/42');
+  });
+
   it('uses the default branch from gh repo view', async () => {
     const { deps, calls } = makeDeps();
     // Override the exec to return 'develop' as default branch

--- a/test/unit/sleeping.test.ts
+++ b/test/unit/sleeping.test.ts
@@ -130,6 +130,51 @@ describe('SleepingOrchestrator', () => {
     expect(orch.snapshot().active).toBe(false);
   });
 
+  it('handleChildExit non-zero → notifyDesktop fires with error level + slug', async () => {
+    const { deps, state } = makeDeps();
+    const desktopCalls: Array<{ title: string; body: string; level: string }> = [];
+    deps.notifyDesktop = async (opts) => {
+      desktopCalls.push(opts);
+    };
+    const orch = new SleepingOrchestrator(deps);
+    const session = await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
+    state.child!.emit('exit', 1, null);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(desktopCalls).toHaveLength(1);
+    expect(desktopCalls[0].level).toBe('error');
+    expect(desktopCalls[0].body).toContain(session.slug);
+  });
+
+  it('handleTimeout → notifyDesktop fires with error level + timeout body', async () => {
+    const { deps, state } = makeDeps();
+    const desktopCalls: Array<{ title: string; body: string; level: string }> = [];
+    deps.notifyDesktop = async (opts) => {
+      desktopCalls.push(opts);
+    };
+    const orch = new SleepingOrchestrator(deps);
+    const session = await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 50 });
+    expect(state.child!.killed).toBe(false);
+    vi.advanceTimersByTime(60);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(desktopCalls).toHaveLength(1);
+    expect(desktopCalls[0].level).toBe('error');
+    expect(desktopCalls[0].title.toLowerCase()).toContain('timeout');
+    expect(desktopCalls[0].body).toContain(session.slug);
+  });
+
+  it('notifyDesktop omitted → child exit failure still notifies via Telegram', async () => {
+    const { deps, state } = makeDeps();
+    // No notifyDesktop wired
+    const orch = new SleepingOrchestrator(deps);
+    await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
+    state.child!.emit('exit', 1, null);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(state.notifications.some((n) => n.includes('failed'))).toBe(true);
+  });
+
   it('cancel() kills child, sends cancelled notification, state idle', async () => {
     const { deps, state } = makeDeps();
     const orch = new SleepingOrchestrator(deps);


### PR DESCRIPTION
## Summary

Implements [`docs/specs/desktop-notifications.md`](docs/specs/desktop-notifications.md). Adds cross-platform OS toast notifications (Windows Toast / macOS NotificationCenter / Linux libnotify via `node-notifier`) that fire when a `kuroboto sleeping` session finishes — success, failure, or timeout. Complements the existing Telegram message; both fire concurrently and independently.

Default is `notifications.desktop: false` in the schema (backwards-safe for existing configs); the init wizard prompts new installs with default Y.

## Implementation notes

- M1 (`4b9ef43`): `src/notify/desktop.ts` — pure DI wrapper around `node-notifier`. Always resolves; never throws. Errors logged via optional `log` dep.
- M2 (`e7b7a44`): wired into `sleepFinish.ts` (success/push-fail/pr-create-fail) and `sleeping.ts` (child-exit non-zero / timeout). Optional `notifyDesktop` dep on both `FinishDeps` and `SleepingDeps` — omit to disable. Lifecycle gates the dep on `config.notifications.desktop`.
- M3 (`f65c85f`): 7 new test cases (4 in `sleepFinish.test.ts`, 3 in `sleeping.test.ts`) verifying level/body/title and the omit-case fallback.

## History note

This branch was originally dispatched via `kuroboto sleeping start` but the autonomous Claude was killed mid-flight when the daemon was restarted at 19:35 UTC (`SIGINT`). M1 was partially complete (file written, no commit). The remaining work was completed manually in the worktree and the partial M1 was salvaged; final result matches the spec.

## Test plan

- [x] `npx vitest run` — 189/189 passing (8 new: 5 desktopNotify, 4 sleepFinish, 3 sleeping; pre-existing all green)
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke (post-merge, manual): `kuroboto init` (or hand-edit `notifications.desktop: true`); dispatch a tiny sleep; confirm Win Toast / macOS banner pops
- [ ] Smoke disable: set `notifications.desktop: false`; dispatch again; confirm no toast

## Out of scope

- Click action (open PR URL) — backlog
- Notif on other events (start, mid-commit) — backlog
- Extensible finish-hooks (Level 2) — already in `docs/specs-backlog.md`