### PR TITLE
feat(daemon): parallel sleep sessions (Spec D)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -201,7 +201,7 @@ sleeping
   .command('cancel [slug]')
   .description('Cancel a sleep session (worktree is left intact for inspection)')
   .option('--all', 'cancel every active session')
-  .option('--yes', 'skip confirmation prompts (for non-interactive shells)')
+  .option('--yes', 'skip confirmation prompts; on multi-session without --all or slug, cancels the most recently started one (for non-interactive shells)')
   .action(async (slug: string | undefined, opts: { all?: boolean; yes?: boolean }) => {
     try {
       await sleepingCancelCommand(slug, opts);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -198,11 +198,13 @@ sleeping
     }
   });
 sleeping
-  .command('cancel')
-  .description('Cancel the active sleep session (worktree is left intact for inspection)')
-  .action(async () => {
+  .command('cancel [slug]')
+  .description('Cancel a sleep session (worktree is left intact for inspection)')
+  .option('--all', 'cancel every active session')
+  .option('--yes', 'skip confirmation prompts (for non-interactive shells)')
+  .action(async (slug: string | undefined, opts: { all?: boolean; yes?: boolean }) => {
     try {
-      await sleepingCancelCommand();
+      await sleepingCancelCommand(slug, opts);
     } catch (e) {
       console.error(`sleeping cancel failed: ${(e as Error).message}`);
       process.exit(1);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -105,6 +105,7 @@ export async function initCommand(): Promise<void> {
       gamingAlwaysAsk: [],
       sleepMaxDurationMs: 2 * 60 * 60 * 1000,
       sleepWorktreeDir: '~/.kuroboto/worktrees',
+      maxConcurrentSleeps: 3,
       failOpen: true,
     },
     notifications: { desktop: desktopEnabled },

--- a/src/cli/sleeping.ts
+++ b/src/cli/sleeping.ts
@@ -143,7 +143,7 @@ export async function sleepingCancelCommand(slug: string | undefined, opts: Canc
     }
     const r = await postCancel({ slug });
     if (r.cancelled.length > 0) console.log(chalk.green(`sleep cancelled: ${r.cancelled.join(', ')}`));
-    else console.log(chalk.dim('no sleep cancelled'));
+    else console.log(chalk.dim(`session ${slug} already ended`));
     return;
   }
 

--- a/src/cli/sleeping.ts
+++ b/src/cli/sleeping.ts
@@ -1,6 +1,7 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import chalk from 'chalk';
+import prompts from 'prompts';
 import { loadConfig } from '../config/load.js';
 import { parseDuration } from '../daemon/gaming.js';
 
@@ -9,6 +10,31 @@ interface StartOpts {
   plan?: string;
   repo?: string;
   max?: string;
+  name?: string;
+}
+
+interface CancelOpts {
+  all?: boolean;
+  yes?: boolean;
+}
+
+interface SessionSnap {
+  slug: string;
+  branch: string;
+  worktreePath: string;
+  startedAt: number;
+  expectedEndAt: number;
+}
+
+interface SleepingSnapshot {
+  active: SessionSnap[];
+  capacity: number;
+}
+
+interface CapacityErrorBody {
+  error: string;
+  capacity: number;
+  active: SessionSnap[];
 }
 
 async function postStart(body: { repo: string; prompt?: string; plan?: string; maxDurationMs?: number }) {
@@ -22,29 +48,59 @@ async function postStart(body: { repo: string; prompt?: string; plan?: string; m
     body: JSON.stringify(body),
   });
   if (!res.ok) {
+    if (res.status === 429) {
+      const cap = (await res.json().catch(() => ({}))) as CapacityErrorBody;
+      printCapacityReached(cap);
+      throw new Error('capacity reached');
+    }
     const err = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(err.error ?? `daemon HTTP ${res.status}`);
   }
   return (await res.json()) as { slug: string; branch: string; worktreePath: string };
 }
 
-async function getStatus() {
+async function getStatus(): Promise<SleepingSnapshot> {
   const config = await loadConfig();
   const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/sleeping`, {
     headers: { 'X-Kuroboto-Token': config.daemon.authToken },
   });
   if (!res.ok) throw new Error(`daemon HTTP ${res.status}`);
-  return (await res.json()) as { active: boolean; slug?: string; expectedEndAt?: number; worktreePath?: string };
+  return (await res.json()) as SleepingSnapshot;
 }
 
-async function deleteSession() {
+async function postCancel(body: { slug?: string; all?: boolean }): Promise<{ cancelled: string[] }> {
   const config = await loadConfig();
-  const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/sleeping`, {
-    method: 'DELETE',
-    headers: { 'X-Kuroboto-Token': config.daemon.authToken },
+  const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/sleeping/cancel`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Kuroboto-Token': config.daemon.authToken,
+    },
+    body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`daemon HTTP ${res.status}`);
-  return (await res.json()) as { ok: boolean; cancelled: boolean };
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error ?? `daemon HTTP ${res.status}`);
+  }
+  return (await res.json()) as { cancelled: string[] };
+}
+
+function formatRemaining(snap: SessionSnap): string {
+  const remainingMs = snap.expectedEndAt - Date.now();
+  if (remainingMs <= 0) return 'expiring';
+  const min = Math.ceil(remainingMs / 60_000);
+  if (min < 60) return `${min}m remaining`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m === 0 ? `${h}h remaining` : `${h}h ${m}m remaining`;
+}
+
+function printCapacityReached(body: CapacityErrorBody): void {
+  console.error(chalk.red(`sleep refused: capacity reached (${body.active.length}/${body.capacity} active)`));
+  for (const s of body.active) {
+    console.error(`  • ${s.slug.padEnd(46)} ${formatRemaining(s)}`);
+  }
+  console.error(chalk.dim('\ncancel one with `kuroboto sleeping cancel <slug>` or raise the cap in config (`policy.maxConcurrentSleeps`).'));
 }
 
 export async function sleepingStartCommand(opts: StartOpts): Promise<void> {
@@ -71,22 +127,93 @@ export async function sleepingStartCommand(opts: StartOpts): Promise<void> {
   console.log(chalk.dim('Telegram will notify when done. `kuroboto sleeping cancel` to abort.'));
 }
 
-export async function sleepingCancelCommand(): Promise<void> {
-  const r = await deleteSession();
-  if (r.cancelled) console.log(chalk.green('sleep cancelled'));
-  else console.log(chalk.dim('no active sleep'));
+export async function sleepingCancelCommand(slug: string | undefined, opts: CancelOpts): Promise<void> {
+  const status = await getStatus();
+  if (status.active.length === 0) {
+    console.log(chalk.dim('(no active sleeps)'));
+    return;
+  }
+
+  // 1. Slug given explicitly — cancel without prompt
+  if (slug) {
+    const found = status.active.find((s) => s.slug === slug);
+    if (!found) {
+      console.error(chalk.red(`no active sleep with slug '${slug}'`));
+      process.exit(1);
+    }
+    const r = await postCancel({ slug });
+    if (r.cancelled.length > 0) console.log(chalk.green(`sleep cancelled: ${r.cancelled.join(', ')}`));
+    else console.log(chalk.dim('no sleep cancelled'));
+    return;
+  }
+
+  // 2. --all — confirm with all slugs listed (unless --yes)
+  if (opts.all) {
+    const slugs = status.active.map((s) => s.slug);
+    if (!opts.yes) {
+      const confirm = await prompts({
+        type: 'confirm',
+        name: 'val',
+        message: `cancel all ${slugs.length}: ${slugs.join(', ')}?`,
+        initial: false,
+      });
+      if (confirm.val !== true) {
+        console.log(chalk.dim('aborted'));
+        return;
+      }
+    }
+    const r = await postCancel({ all: true });
+    console.log(chalk.green(`cancelled ${r.cancelled.length} sleeps: ${r.cancelled.join(', ')}`));
+    return;
+  }
+
+  // 3. No slug, no --all
+  if (status.active.length === 1) {
+    const target = status.active[0]!.slug;
+    if (!opts.yes) {
+      const confirm = await prompts({
+        type: 'confirm',
+        name: 'val',
+        message: `cancel ${target}?`,
+        initial: false,
+      });
+      if (confirm.val !== true) {
+        console.log(chalk.dim('aborted'));
+        return;
+      }
+    }
+    const r = await postCancel({ slug: target });
+    if (r.cancelled.length > 0) console.log(chalk.green(`sleep cancelled: ${target}`));
+    return;
+  }
+
+  // Multiple active, no slug → cancel most recent
+  const sortedByStart = [...status.active].sort((a, b) => b.startedAt - a.startedAt);
+  const mostRecent = sortedByStart[0]!.slug;
+  if (!opts.yes) {
+    const confirm = await prompts({
+      type: 'confirm',
+      name: 'val',
+      message: `cancel most recent (${mostRecent})?`,
+      initial: false,
+    });
+    if (confirm.val !== true) {
+      console.log(chalk.dim('aborted'));
+      return;
+    }
+  }
+  const r = await postCancel({ slug: mostRecent });
+  if (r.cancelled.length > 0) console.log(chalk.green(`sleep cancelled: ${mostRecent}`));
 }
 
 export async function sleepingStatusCommand(): Promise<void> {
   const s = await getStatus();
-  if (!s.active) {
-    console.log(chalk.dim('sleep: idle'));
+  if (s.active.length === 0) {
+    console.log(chalk.dim(`sleep: idle (cap ${s.capacity})`));
     return;
   }
-  const remainingMs = (s.expectedEndAt ?? 0) - Date.now();
-  const remaining = remainingMs > 0 ? `${Math.ceil(remainingMs / 60_000)}m remaining` : 'expiring';
-  console.log(chalk.green(`sleep: active`));
-  console.log(`  slug:     ${s.slug}`);
-  console.log(`  worktree: ${s.worktreePath}`);
-  console.log(`  ${remaining}`);
+  console.log(chalk.green(`sleep: ${s.active.length} active (cap ${s.capacity})`));
+  for (const sess of s.active) {
+    console.log(`  • ${sess.slug.padEnd(46)} ${formatRemaining(sess)}`);
+  }
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,7 @@ export const PolicyConfig = z.object({
   gamingAlwaysAsk: z.array(z.string()).default([]),
   sleepMaxDurationMs: z.number().int().min(60_000).default(2 * 60 * 60 * 1000),
   sleepWorktreeDir: z.string().default('~/.kuroboto/worktrees'),
+  maxConcurrentSleeps: z.number().int().min(1).default(3),
   failOpen: z.boolean(),
 });
 

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -71,6 +71,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     createWorktree,
     removeWorktree,
     notifyDesktop: desktopNotifyDep,
+    maxConcurrent: config.policy.maxConcurrentSleeps,
     onSuccess: (session) =>
       finishSleep(session, {
         exec: async (cmd, args, opts) => {

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -142,7 +142,9 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     if (stopped) return;
     stopped = true;
     logger.info('daemon stopping');
-    state.sleeping.cancel().catch(() => {});
+    // cancel({ all: true }) — cancel() no-args throws when multi-session,
+    // which would silently leave orphan children on shutdown.
+    state.sleeping.cancel({ all: true }).catch(() => {});
     pending.drainAll('shutdown');
     pending.stopCleanupLoop();
     pendingNotifications.cancelAll();

--- a/src/daemon/promptFormat.ts
+++ b/src/daemon/promptFormat.ts
@@ -48,8 +48,11 @@ async function buildHeader(
   transcriptPath: string | undefined,
   ctx: PromptFormatContext,
 ): Promise<string> {
-  if (ctx.sleeping.active && cwd && samePath(cwd, ctx.sleeping.worktreePath)) {
-    return `[${ctx.hostname} / 💤 ${stripSlugSuffix(ctx.sleeping.slug)}]`;
+  if (cwd) {
+    const sleepMatch = ctx.sleeping.active.find((s) => samePath(cwd, s.worktreePath));
+    if (sleepMatch) {
+      return `[${ctx.hostname} / 💤 ${stripSlugSuffix(sleepMatch.slug)}]`;
+    }
   }
   const parts = [ctx.hostname];
   const folder = projectName(cwd);

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -17,6 +17,7 @@ import {
 } from './promptFormat.js';
 import { isQAPrompt } from './notificationDetect.js';
 import { injectViaPty } from '../inject/pty.js';
+import type { SessionSnap } from './sleeping.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
   const fmtCtx = (): PromptFormatContext => ({
@@ -112,7 +113,16 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
         expectedEndAt: session.expectedEndAt,
       });
     } catch (e) {
-      const msg = (e as Error).message;
+      const err = e as Error & { capacity?: number; active?: SessionSnap[] };
+      if (err.name === 'CapacityReachedError') {
+        res.status(429).json({
+          error: 'capacity reached',
+          capacity: err.capacity,
+          active: err.active,
+        });
+        return;
+      }
+      const msg = err.message;
       if (msg.includes('already')) {
         res.status(409).json({ error: msg });
       } else {
@@ -121,9 +131,33 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
     }
   });
 
+  app.post('/v1/sleeping/cancel', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as { slug?: unknown; all?: unknown };
+    const opts: { slug?: string; all?: boolean } = {};
+    if (typeof body.slug === 'string' && body.slug) opts.slug = body.slug;
+    if (body.all === true) opts.all = true;
+    try {
+      const result = await ctx.state.sleeping.cancel(opts);
+      res.json({ ok: true, cancelled: result.cancelled });
+    } catch (e) {
+      res.status(400).json({ error: (e as Error).message });
+    }
+  });
+
   app.delete('/v1/sleeping', async (_req, res) => {
-    const cancelled = await ctx.state.sleeping.cancel();
-    res.json({ ok: true, cancelled, reason: cancelled ? 'cancelled' : 'idle' });
+    // Legacy: equivalent to POST /v1/sleeping/cancel with no args (cancel the
+    // single active session, throws if multiple active).
+    try {
+      const result = await ctx.state.sleeping.cancel();
+      res.json({
+        ok: true,
+        cancelled: result.cancelled.length > 0,
+        slugs: result.cancelled,
+        reason: result.cancelled.length > 0 ? 'cancelled' : 'idle',
+      });
+    } catch (e) {
+      res.status(409).json({ error: (e as Error).message });
+    }
   });
 
   app.put('/v1/mode', (req: Request, res: Response) => {
@@ -393,8 +427,11 @@ function shouldHandleAsQA(payload: NotificationPayload, ctx: DaemonContext): boo
   // Sleep mode is autonomous: if Claude pauses inside a sleep worktree, it's
   // a stuck session — fall through to the regular notif path so the user can
   // investigate, rather than waiting indefinitely for a Q&A reply.
-  const snap = ctx.state.sleeping.snapshot();
-  if (snap.active && payload.cwd && samePath(payload.cwd, snap.worktreePath)) return false;
+  if (payload.cwd) {
+    const snap = ctx.state.sleeping.snapshot();
+    const inSleep = snap.active.some((s) => samePath(payload.cwd!, s.worktreePath));
+    if (inSleep) return false;
+  }
   return true;
 }
 

--- a/src/daemon/sleeping.ts
+++ b/src/daemon/sleeping.ts
@@ -118,6 +118,8 @@ export class SleepingOrchestrator {
     const worktreePath = `${req.workRoot}/${slug}`;
     const finalPrompt = req.plan ? PLAN_INTRO + req.plan : (req.prompt as string);
 
+    // createWorktree first — if it fails, we want zero side effects (no
+    // gaming arm leak, no half-state). Throws propagate to the caller.
     await this.deps.createWorktree(req.repo, branch, worktreePath);
 
     // 0 → 1 transition: arm gaming and stash the prior so we can restore on

--- a/src/daemon/sleeping.ts
+++ b/src/daemon/sleeping.ts
@@ -14,6 +14,8 @@ export interface SleepingDeps {
   removeWorktree: (repo: string, dir: string) => Promise<void>;
   onSuccess: (session: SleepingSession) => Promise<void>;
   notifyDesktop?: (opts: DesktopNotifyOpts) => Promise<void>;
+  /** Maximum concurrent sleep sessions. Spec D — defaults to 3 in config. */
+  maxConcurrent: number;
 }
 
 export interface SleepingStartRequest {
@@ -34,21 +36,41 @@ export interface SleepingSession {
   repo: string;
 }
 
-export type SleepingSnapshot =
-  | { active: false }
-  | {
-      active: true;
-      slug: string;
-      branch: string;
-      worktreePath: string;
-      startedAt: number;
-      expectedEndAt: number;
-    };
+export interface SessionSnap {
+  slug: string;
+  branch: string;
+  worktreePath: string;
+  startedAt: number;
+  expectedEndAt: number;
+}
+
+export interface SleepingSnapshot {
+  active: SessionSnap[];
+  capacity: number;
+}
+
+export interface CancelOpts {
+  slug?: string;
+  all?: boolean;
+}
+
+export interface CancelResult {
+  cancelled: string[];
+}
+
+export class CapacityReachedError extends Error {
+  constructor(
+    public readonly capacity: number,
+    public readonly active: SessionSnap[],
+  ) {
+    super(`capacity reached (${active.length}/${capacity})`);
+    this.name = 'CapacityReachedError';
+  }
+}
 
 interface InternalSession extends SleepingSession {
   child: ChildProcess;
   maxDurationTimer: NodeJS.Timeout;
-  gamingPriorSnapshot: GamingSnapshot;
   terminated: boolean;
 }
 
@@ -56,37 +78,54 @@ const PLAN_INTRO =
   'Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.\n\n';
 
 export class SleepingOrchestrator {
-  private session: InternalSession | null = null;
+  private readonly sessions = new Map<string, InternalSession>();
+  /**
+   * Snapshot of gaming state at the moment of the first session start. We arm
+   * gaming on the 0→1 sessions transition and restore from this snapshot on
+   * the N→0 transition. Per-session restore would race when sessions overlap.
+   */
+  private firstSessionGamingPrior: GamingSnapshot | null = null;
 
   constructor(private readonly deps: SleepingDeps) {}
 
   snapshot(): SleepingSnapshot {
-    if (!this.session) return { active: false };
     return {
-      active: true,
-      slug: this.session.slug,
-      branch: this.session.branch,
-      worktreePath: this.session.worktreePath,
-      startedAt: this.session.startedAt,
-      expectedEndAt: this.session.expectedEndAt,
+      active: [...this.sessions.values()].map((s) => ({
+        slug: s.slug,
+        branch: s.branch,
+        worktreePath: s.worktreePath,
+        startedAt: s.startedAt,
+        expectedEndAt: s.expectedEndAt,
+      })),
+      capacity: this.deps.maxConcurrent,
     };
   }
 
   async start(req: SleepingStartRequest): Promise<SleepingSession> {
-    if (this.session) throw new Error('a sleep session is already active');
+    if (this.sessions.size >= this.deps.maxConcurrent) {
+      throw new CapacityReachedError(this.deps.maxConcurrent, this.snapshot().active);
+    }
     if (!req.prompt && !req.plan) throw new Error('prompt or plan required');
     if (req.prompt && req.plan) throw new Error('prompt and plan are mutually exclusive');
 
     const seed = req.prompt ?? req.plan ?? '';
     const slug = slugify(seed);
+    if (this.sessions.has(slug)) {
+      // Random suffix in slugify makes this exceedingly unlikely; defense in depth.
+      throw new Error(`slug "${slug}" already active`);
+    }
     const branch = `sleep/${slug}`;
     const worktreePath = `${req.workRoot}/${slug}`;
     const finalPrompt = req.plan ? PLAN_INTRO + req.plan : (req.prompt as string);
 
     await this.deps.createWorktree(req.repo, branch, worktreePath);
 
-    const gamingPriorSnapshot = this.deps.gaming.snapshot();
-    if (!gamingPriorSnapshot.active) this.deps.gaming.arm();
+    // 0 → 1 transition: arm gaming and stash the prior so we can restore on
+    // N → 0. Subsequent starts (1 → N) leave gaming alone.
+    if (this.sessions.size === 0) {
+      this.firstSessionGamingPrior = this.deps.gaming.snapshot();
+      if (!this.firstSessionGamingPrior.active) this.deps.gaming.arm();
+    }
 
     const startedAt = Date.now();
     const expectedEndAt = startedAt + req.maxDurationMs;
@@ -94,7 +133,7 @@ export class SleepingOrchestrator {
     const child = this.deps.spawn('claude', ['-p', finalPrompt], { cwd: worktreePath });
 
     const maxDurationTimer = setTimeout(() => {
-      this.handleTimeout();
+      this.handleTimeout(slug);
     }, req.maxDurationMs);
 
     const session: InternalSession = {
@@ -107,16 +146,17 @@ export class SleepingOrchestrator {
       repo: req.repo,
       child,
       maxDurationTimer,
-      gamingPriorSnapshot,
       terminated: false,
     };
-    this.session = session;
+    this.sessions.set(slug, session);
 
     child.on('exit', (code, signal) => {
-      this.handleChildExit(session, code, signal);
+      this.handleChildExit(slug, code, signal);
     });
 
-    void this.deps.notify(`\u{1F4A4} sleep started — worktree: ${slug}, max ${formatDuration(req.maxDurationMs)}`);
+    void this.deps.notify(
+      `\u{1F4A4} sleep started — ${slug}, max ${formatDuration(req.maxDurationMs)}`,
+    );
     void this.deps.audit({
       ts: new Date(startedAt).toISOString(),
       kind: 'sleep_start',
@@ -136,16 +176,43 @@ export class SleepingOrchestrator {
     };
   }
 
-  async cancel(): Promise<boolean> {
-    if (!this.session) return false;
-    const session = this.session;
-    if (session.terminated) return false;
+  /**
+   * Cancel one or more sessions. Variants:
+   *   cancel({ slug })       — cancel that specific slug
+   *   cancel({ all: true })  — cancel every active session
+   *   cancel()               — cancel the only active session; throws if multiple
+   */
+  async cancel(opts: CancelOpts = {}): Promise<CancelResult> {
+    if (opts.all) {
+      const slugs = [...this.sessions.keys()];
+      // Cancel in parallel — each cancelOne awaits its child's exit event
+      // independently, so serial would block the second behind the first's
+      // setImmediate (also slow with fake timers in tests).
+      const results = await Promise.all(slugs.map((s) => this.cancelOne(s)));
+      const cancelled = slugs.filter((_, i) => results[i]);
+      return { cancelled };
+    }
+    if (opts.slug !== undefined) {
+      const ok = await this.cancelOne(opts.slug);
+      return { cancelled: ok ? [opts.slug] : [] };
+    }
+    if (this.sessions.size === 0) return { cancelled: [] };
+    if (this.sessions.size > 1) {
+      throw new Error('multiple sleeps active; specify slug or pass all=true');
+    }
+    const onlySlug = [...this.sessions.keys()][0]!;
+    const ok = await this.cancelOne(onlySlug);
+    return { cancelled: ok ? [onlySlug] : [] };
+  }
+
+  private async cancelOne(slug: string): Promise<boolean> {
+    const session = this.sessions.get(slug);
+    if (!session || session.terminated) return false;
     session.terminated = true;
     clearTimeout(session.maxDurationTimer);
-    // Race kill with a 5s timeout to avoid hanging on a stuck child
     await new Promise<void>((resolve) => {
       let resolved = false;
-      const done = () => {
+      const done = (): void => {
         if (!resolved) {
           resolved = true;
           resolve();
@@ -155,14 +222,21 @@ export class SleepingOrchestrator {
       session.child.kill('SIGTERM');
       setTimeout(done, 5_000);
     });
-    void this.deps.notify(`\u{1F6D1} sleep cancelled. log: ${session.worktreePath}/.kuroboto-sleep.log`);
-    this.restoreGaming(session.gamingPriorSnapshot);
-    this.session = null;
+    void this.deps.notify(
+      `\u{1F6D1} sleep cancelled — ${slug}. log: ${session.worktreePath}/.kuroboto-sleep.log`,
+    );
+    this.sessions.delete(slug);
+    this.maybeRestoreGaming();
     return true;
   }
 
-  private handleChildExit(session: InternalSession, code: number | null, signal: NodeJS.Signals | null): void {
-    if (session.terminated) return;
+  private handleChildExit(
+    slug: string,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void {
+    const session = this.sessions.get(slug);
+    if (!session || session.terminated) return;
     session.terminated = true;
     clearTimeout(session.maxDurationTimer);
     if (code === 0) {
@@ -178,49 +252,55 @@ export class SleepingOrchestrator {
             repo: session.repo,
           });
         } catch (e) {
-          void this.deps.notify(`⚠️ sleep onSuccess hook failed: ${(e as Error).message}`);
+          void this.deps.notify(
+            `⚠️ sleep onSuccess hook failed for ${slug}: ${(e as Error).message}`,
+          );
         } finally {
-          this.restoreGaming(session.gamingPriorSnapshot);
-          if (this.session === session) this.session = null;
+          this.sessions.delete(slug);
+          this.maybeRestoreGaming();
         }
       })();
     } else {
       const reason = signal ? `signal ${signal}` : `exit ${code}`;
       void this.deps.notify(
-        `❌ sleep failed — ${reason}. log: ${session.worktreePath}/.kuroboto-sleep.log`,
+        `❌ sleep failed — ${slug} — ${reason}. log: ${session.worktreePath}/.kuroboto-sleep.log`,
       );
       if (this.deps.notifyDesktop) {
         void this.deps.notifyDesktop({
           title: 'kuroboto: sleep error',
-          body: `${session.slug}: ${reason}`,
+          body: `${slug}: ${reason}`,
           level: 'error',
         });
       }
-      this.restoreGaming(session.gamingPriorSnapshot);
-      if (this.session === session) this.session = null;
+      this.sessions.delete(slug);
+      this.maybeRestoreGaming();
     }
   }
 
-  private handleTimeout(): void {
-    if (!this.session || this.session.terminated) return;
-    const session = this.session;
+  private handleTimeout(slug: string): void {
+    const session = this.sessions.get(slug);
+    if (!session || session.terminated) return;
     session.terminated = true;
     session.child.kill('SIGTERM');
     void this.deps.notify(
-      `⏰ sleep timed out. log: ${session.worktreePath}/.kuroboto-sleep.log. PR not created.`,
+      `⏰ sleep timed out — ${slug}. log: ${session.worktreePath}/.kuroboto-sleep.log. PR not created.`,
     );
     if (this.deps.notifyDesktop) {
       void this.deps.notifyDesktop({
         title: 'kuroboto: sleep timeout',
-        body: `${session.slug}: ran past max duration; no PR`,
+        body: `${slug}: ran past max duration; no PR`,
         level: 'error',
       });
     }
-    this.restoreGaming(session.gamingPriorSnapshot);
-    this.session = null;
+    this.sessions.delete(slug);
+    this.maybeRestoreGaming();
   }
 
-  private restoreGaming(prior: GamingSnapshot): void {
+  private maybeRestoreGaming(): void {
+    if (this.sessions.size > 0) return;
+    const prior = this.firstSessionGamingPrior;
+    this.firstSessionGamingPrior = null;
+    if (!prior) return;
     if (!prior.active) {
       this.deps.gaming.cancel();
       return;

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -49,6 +49,9 @@ function makeContext(overrides: Overrides = {}): {
       permissionMatchers: ['Bash', 'Edit', 'Write'],
       rememberGranularity: 'tight',
       gamingAlwaysAsk: [],
+      sleepMaxDurationMs: 7_200_000,
+      sleepWorktreeDir: '/tmp/kuroboto-test-worktrees',
+      maxConcurrentSleeps: 3,
       failOpen: true,
       ...overrides.policy,
     },
@@ -65,6 +68,7 @@ function makeContext(overrides: Overrides = {}): {
     createWorktree: async () => {},
     removeWorktree: async () => {},
     onSuccess: async () => {},
+    maxConcurrent: 3,
   });
   const injectClients = new InjectClients();
   const ctx: DaemonContext = {
@@ -391,11 +395,11 @@ describe('sleep mode endpoints', () => {
     ({ ctx } = makeContext());
   });
 
-  it('GET /v1/sleeping returns idle when no session', async () => {
+  it('GET /v1/sleeping returns empty active list with capacity when no session', async () => {
     const res = await request(createServer(ctx))
       .get('/v1/sleeping')
       .set('X-Kuroboto-Token', TEST_TOKEN);
-    expect(res.body).toEqual({ active: false });
+    expect(res.body).toEqual({ active: [], capacity: 3 });
   });
 
   it('POST /v1/sleeping rejects empty body', async () => {
@@ -428,7 +432,52 @@ describe('sleep mode endpoints', () => {
     const res = await request(createServer(ctx))
       .delete('/v1/sleeping')
       .set('X-Kuroboto-Token', TEST_TOKEN);
-    expect(res.body).toEqual({ ok: true, cancelled: false, reason: 'idle' });
+    expect(res.body).toEqual({ ok: true, cancelled: false, slugs: [], reason: 'idle' });
+  });
+
+  it('POST /v1/sleeping returns 429 with capacity body when at cap', async () => {
+    // Fake the orchestrator to report at capacity
+    vi.spyOn(ctx.state.sleeping, 'start').mockImplementation(async () => {
+      const err = new Error('capacity reached (3/3)') as Error & { name: string; capacity: number; active: unknown[] };
+      err.name = 'CapacityReachedError';
+      err.capacity = 3;
+      err.active = [
+        { slug: 'a-xyz789', branch: 'sleep/a', worktreePath: '/x/a', startedAt: 1, expectedEndAt: 2 },
+      ];
+      throw err;
+    });
+    const res = await request(createServer(ctx))
+      .post('/v1/sleeping')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ repo: '/r', prompt: 'test' });
+    expect(res.status).toBe(429);
+    expect(res.body).toMatchObject({
+      error: 'capacity reached',
+      capacity: 3,
+    });
+    expect(res.body.active).toBeInstanceOf(Array);
+  });
+
+  it('POST /v1/sleeping/cancel with slug routes to orchestrator.cancel({slug})', async () => {
+    const cancelSpy = vi.spyOn(ctx.state.sleeping, 'cancel').mockResolvedValue({ cancelled: ['target-slug'] });
+    const res = await request(createServer(ctx))
+      .post('/v1/sleeping/cancel')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ slug: 'target-slug' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, cancelled: ['target-slug'] });
+    expect(cancelSpy).toHaveBeenCalledWith({ slug: 'target-slug' });
+  });
+
+  it('POST /v1/sleeping/cancel with all=true routes to orchestrator.cancel({all})', async () => {
+    const cancelSpy = vi.spyOn(ctx.state.sleeping, 'cancel').mockResolvedValue({ cancelled: ['a', 'b'] });
+    const res = await request(createServer(ctx))
+      .post('/v1/sleeping/cancel')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ all: true });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, cancelled: ['a', 'b'] });
+    expect(cancelSpy).toHaveBeenCalledWith({ all: true });
   });
 });
 
@@ -594,12 +643,16 @@ describe('prompt context header (session + intent)', () => {
     const { ctx, channel } = makeContext({ mode: 'away' });
     const worktreePath = path.join(tmpDir, 'work', 'fix-the-bot-ux-abc123');
     vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
-      active: true,
-      slug: 'fix-the-bot-ux-abc123',
-      branch: 'sleep/fix-the-bot-ux-abc123',
-      worktreePath,
-      startedAt: Date.now(),
-      expectedEndAt: Date.now() + 60_000,
+      active: [
+        {
+          slug: 'fix-the-bot-ux-abc123',
+          branch: 'sleep/fix-the-bot-ux-abc123',
+          worktreePath,
+          startedAt: Date.now(),
+          expectedEndAt: Date.now() + 60_000,
+        },
+      ],
+      capacity: 3,
     });
     const app = createServer(ctx);
     const pending = request(app)
@@ -803,12 +856,16 @@ describe('Q&A flow (tmux inject)', () => {
     });
     const worktreePath = path.join(tmpDir, 'sleep-work');
     vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
-      active: true,
-      slug: 'foo-abc123',
-      branch: 'sleep/foo-abc123',
-      worktreePath,
-      startedAt: Date.now(),
-      expectedEndAt: Date.now() + 60_000,
+      active: [
+        {
+          slug: 'foo-abc123',
+          branch: 'sleep/foo-abc123',
+          worktreePath,
+          startedAt: Date.now(),
+          expectedEndAt: Date.now() + 60_000,
+        },
+      ],
+      capacity: 3,
     });
     const app = createServer(ctx);
     await request(app)

--- a/test/unit/promptFormat.test.ts
+++ b/test/unit/promptFormat.test.ts
@@ -22,7 +22,7 @@ async function writeTranscript(name: string, lines: unknown[]): Promise<string> 
   return file;
 }
 
-const idleSleep: SleepingSnapshot = { active: false };
+const idleSleep: SleepingSnapshot = { active: [], capacity: 3 };
 
 function permissionPayload(over: Partial<PreToolUsePayload> = {}): PreToolUsePayload {
   return {
@@ -119,12 +119,16 @@ describe('formatPermissionPrompt — sleep mode', () => {
       { role: 'assistant', content: 'Will start with step 1' },
     ]);
     const sleeping: SleepingSnapshot = {
-      active: true,
-      slug: 'fix-the-bot-ux-abc123',
-      branch: 'sleep/fix-the-bot-ux-abc123',
-      worktreePath: '/work/fix-the-bot-ux-abc123',
-      startedAt: 1,
-      expectedEndAt: 2,
+      active: [
+        {
+          slug: 'fix-the-bot-ux-abc123',
+          branch: 'sleep/fix-the-bot-ux-abc123',
+          worktreePath: '/work/fix-the-bot-ux-abc123',
+          startedAt: 1,
+          expectedEndAt: 2,
+        },
+      ],
+      capacity: 3,
     };
     const out = await formatPermissionPrompt(
       permissionPayload({
@@ -143,12 +147,16 @@ describe('formatPermissionPrompt — sleep mode', () => {
 
   it('cwd does NOT match worktreePath while sleeping → treated as interactive', async () => {
     const sleeping: SleepingSnapshot = {
-      active: true,
-      slug: 'foo-abc123',
-      branch: 'sleep/foo-abc123',
-      worktreePath: '/work/foo-abc123',
-      startedAt: 1,
-      expectedEndAt: 2,
+      active: [
+        {
+          slug: 'foo-abc123',
+          branch: 'sleep/foo-abc123',
+          worktreePath: '/work/foo-abc123',
+          startedAt: 1,
+          expectedEndAt: 2,
+        },
+      ],
+      capacity: 3,
     };
     const out = await formatPermissionPrompt(
       permissionPayload({ cwd: '/x/elsewhere', tool_input: { command: 'ls' } }),

--- a/test/unit/sleeping.test.ts
+++ b/test/unit/sleeping.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { SleepingOrchestrator, type SleepingDeps, type SpawnFn } from '../../src/daemon/sleeping.js';
+import {
+  SleepingOrchestrator,
+  type SleepingDeps,
+  type SpawnFn,
+} from '../../src/daemon/sleeping.js';
 import { GamingState } from '../../src/daemon/gaming.js';
 
 class FakeChild extends EventEmitter {
@@ -14,31 +18,47 @@ class FakeChild extends EventEmitter {
 }
 
 interface DepsState {
+  /** Last spawned child (legacy single-session shorthand for tests that only start one). */
   child?: FakeChild;
+  /** All spawned children, in spawn order. Index by start order for multi-session tests. */
+  children: FakeChild[];
   notifications: string[];
   audits: unknown[];
-  worktreeCreated?: { repo: string; branch: string; dir: string };
+  worktreesCreated: { repo: string; branch: string; dir: string }[];
   worktreeRemoved: string[];
 }
 
-function makeDeps(): { deps: SleepingDeps; state: DepsState } {
-  const state: DepsState = { notifications: [], audits: [], worktreeRemoved: [] };
+function makeDeps(opts: { maxConcurrent?: number } = {}): { deps: SleepingDeps; state: DepsState } {
+  const state: DepsState = {
+    children: [],
+    notifications: [],
+    audits: [],
+    worktreesCreated: [],
+    worktreeRemoved: [],
+  };
   const spawnFn: SpawnFn = (_cmd, _args, _opts) => {
-    state.child = new FakeChild();
-    return state.child as unknown as ReturnType<SpawnFn>;
+    const child = new FakeChild();
+    state.children.push(child);
+    state.child = child;
+    return child as unknown as ReturnType<SpawnFn>;
   };
   const deps: SleepingDeps = {
     spawn: spawnFn,
     gaming: new GamingState(),
-    notify: async (msg) => { state.notifications.push(msg); },
-    audit: async (e) => { state.audits.push(e); },
+    notify: async (msg) => {
+      state.notifications.push(msg);
+    },
+    audit: async (e) => {
+      state.audits.push(e);
+    },
     createWorktree: async (repo, branch, dir) => {
-      state.worktreeCreated = { repo, branch, dir };
+      state.worktreesCreated.push({ repo, branch, dir });
     },
     removeWorktree: async (_repo, dir) => {
       state.worktreeRemoved.push(dir);
     },
     onSuccess: vi.fn(async (_session) => {}),
+    maxConcurrent: opts.maxConcurrent ?? 3,
   };
   return { deps, state };
 }
@@ -51,10 +71,10 @@ describe('SleepingOrchestrator', () => {
     vi.useRealTimers();
   });
 
-  it('initial: idle snapshot', () => {
-    const { deps } = makeDeps();
+  it('initial: idle snapshot with capacity', () => {
+    const { deps } = makeDeps({ maxConcurrent: 3 });
     const orch = new SleepingOrchestrator(deps);
-    expect(orch.snapshot()).toEqual({ active: false });
+    expect(orch.snapshot()).toEqual({ active: [], capacity: 3 });
   });
 
   it('start creates worktree, arms gaming, spawns child, returns session', async () => {
@@ -68,7 +88,8 @@ describe('SleepingOrchestrator', () => {
     });
     expect(session.slug).toMatch(/^implement-billing-flow-[a-z0-9]{6}$/);
     expect(session.branch).toMatch(/^sleep\/implement-billing-flow-[a-z0-9]{6}$/);
-    expect(state.worktreeCreated).toEqual({
+    expect(state.worktreesCreated).toHaveLength(1);
+    expect(state.worktreesCreated[0]).toEqual({
       repo: '/x/repo',
       branch: session.branch,
       dir: `/y/wt/${session.slug}`,
@@ -76,17 +97,43 @@ describe('SleepingOrchestrator', () => {
     expect(deps.gaming.snapshot().active).toBe(true);
     expect(state.child).toBeDefined();
     const snap = orch.snapshot();
-    expect(snap.active).toBe(true);
-    if (snap.active) expect(snap.slug).toMatch(/^implement-billing-flow-[a-z0-9]{6}$/);
+    expect(snap.active).toHaveLength(1);
+    expect(snap.active[0].slug).toMatch(/^implement-billing-flow-[a-z0-9]{6}$/);
   });
 
-  it('rejects start when one is already active', async () => {
-    const { deps } = makeDeps();
+  it('two concurrent starts both succeed when under capacity', async () => {
+    const { deps, state } = makeDeps({ maxConcurrent: 3 });
+    const orch = new SleepingOrchestrator(deps);
+    await orch.start({ repo: '/x', prompt: 'a', workRoot: '/y', maxDurationMs: 60_000 });
+    await orch.start({ repo: '/x', prompt: 'b', workRoot: '/y', maxDurationMs: 60_000 });
+    expect(orch.snapshot().active).toHaveLength(2);
+    expect(state.children).toHaveLength(2);
+    expect(state.worktreesCreated).toHaveLength(2);
+  });
+
+  it('rejects start when at capacity', async () => {
+    const { deps } = makeDeps({ maxConcurrent: 1 });
     const orch = new SleepingOrchestrator(deps);
     await orch.start({ repo: '/x', prompt: 'a', workRoot: '/y', maxDurationMs: 60_000 });
     await expect(
       orch.start({ repo: '/x', prompt: 'b', workRoot: '/y', maxDurationMs: 60_000 }),
-    ).rejects.toThrow(/already/);
+    ).rejects.toThrow(/capacity/i);
+  });
+
+  it('CapacityReachedError carries capacity + active list', async () => {
+    const { deps } = makeDeps({ maxConcurrent: 2 });
+    const orch = new SleepingOrchestrator(deps);
+    await orch.start({ repo: '/x', prompt: 'a', workRoot: '/y', maxDurationMs: 60_000 });
+    await orch.start({ repo: '/x', prompt: 'b', workRoot: '/y', maxDurationMs: 60_000 });
+    try {
+      await orch.start({ repo: '/x', prompt: 'c', workRoot: '/y', maxDurationMs: 60_000 });
+      throw new Error('expected throw');
+    } catch (e) {
+      const err = e as Error & { capacity?: number; active?: unknown[] };
+      expect(err.name).toBe('CapacityReachedError');
+      expect(err.capacity).toBe(2);
+      expect(err.active).toHaveLength(2);
+    }
   });
 
   it('child exit 0 → onSuccess called, gaming restored, state idle', async () => {
@@ -97,11 +144,10 @@ describe('SleepingOrchestrator', () => {
     await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
     expect(gaming.snapshot().active).toBe(true);
     state.child!.emit('exit', 0, null);
-    // onSuccess is awaited inside the IIFE — flush microtasks until orchestrator goes idle.
     for (let i = 0; i < 10; i++) await Promise.resolve();
     expect(deps.onSuccess).toHaveBeenCalledTimes(1);
     expect(gaming.snapshot().active).toBe(false);
-    expect(orch.snapshot().active).toBe(false);
+    expect(orch.snapshot().active).toEqual([]);
   });
 
   it('child exit non-zero → failure notification, gaming restored, state idle', async () => {
@@ -114,7 +160,7 @@ describe('SleepingOrchestrator', () => {
     expect(state.notifications.some((n) => n.includes('failed'))).toBe(true);
     expect(deps.onSuccess).not.toHaveBeenCalled();
     expect(deps.gaming.snapshot().active).toBe(false);
-    expect(orch.snapshot().active).toBe(false);
+    expect(orch.snapshot().active).toEqual([]);
   });
 
   it('max duration timer kills child, sends timeout notification', async () => {
@@ -127,7 +173,7 @@ describe('SleepingOrchestrator', () => {
     await Promise.resolve();
     expect(state.child!.killed).toBe(true);
     expect(state.notifications.some((n) => n.includes('timed out') || n.includes('timeout'))).toBe(true);
-    expect(orch.snapshot().active).toBe(false);
+    expect(orch.snapshot().active).toEqual([]);
   });
 
   it('handleChildExit non-zero → notifyDesktop fires with error level + slug', async () => {
@@ -166,7 +212,6 @@ describe('SleepingOrchestrator', () => {
 
   it('notifyDesktop omitted → child exit failure still notifies via Telegram', async () => {
     const { deps, state } = makeDeps();
-    // No notifyDesktop wired
     const orch = new SleepingOrchestrator(deps);
     await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
     state.child!.emit('exit', 1, null);
@@ -175,28 +220,87 @@ describe('SleepingOrchestrator', () => {
     expect(state.notifications.some((n) => n.includes('failed'))).toBe(true);
   });
 
-  it('cancel() kills child, sends cancelled notification, state idle', async () => {
+  it('cancel() with single active session kills child, returns slug', async () => {
     const { deps, state } = makeDeps();
     const orch = new SleepingOrchestrator(deps);
-    await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
+    const session = await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
     const cancelPromise = orch.cancel();
-    // FakeChild.kill() uses setImmediate() to emit exit; advance timers to trigger it
     vi.advanceTimersByTime(0);
-    await cancelPromise;
+    const r = await cancelPromise;
+    expect(r.cancelled).toEqual([session.slug]);
     expect(state.child!.killed).toBe(true);
     expect(state.notifications.some((n) => n.toLowerCase().includes('cancel'))).toBe(true);
-    expect(orch.snapshot().active).toBe(false);
+    expect(orch.snapshot().active).toEqual([]);
   });
 
-  it('cancel() is no-op when idle', async () => {
+  it('cancel() is no-op when idle (returns empty cancelled list)', async () => {
     const { deps } = makeDeps();
     const orch = new SleepingOrchestrator(deps);
     const r = await orch.cancel();
-    expect(r).toBe(false);
+    expect(r).toEqual({ cancelled: [] });
+  });
+
+  it('cancel() throws when multiple active and no slug given', async () => {
+    const { deps } = makeDeps({ maxConcurrent: 3 });
+    const orch = new SleepingOrchestrator(deps);
+    await orch.start({ repo: '/x', prompt: 'a', workRoot: '/y', maxDurationMs: 60_000 });
+    await orch.start({ repo: '/x', prompt: 'b', workRoot: '/y', maxDurationMs: 60_000 });
+    await expect(orch.cancel()).rejects.toThrow(/multiple/i);
+  });
+
+  it('cancel({ slug }) cancels only the matching session', async () => {
+    const { deps } = makeDeps({ maxConcurrent: 3 });
+    const orch = new SleepingOrchestrator(deps);
+    const a = await orch.start({ repo: '/x', prompt: 'a', workRoot: '/y', maxDurationMs: 60_000 });
+    const b = await orch.start({ repo: '/x', prompt: 'b', workRoot: '/y', maxDurationMs: 60_000 });
+    const cancelP = orch.cancel({ slug: a.slug });
+    vi.advanceTimersByTime(0);
+    const r = await cancelP;
+    expect(r.cancelled).toEqual([a.slug]);
+    const snap = orch.snapshot();
+    expect(snap.active).toHaveLength(1);
+    expect(snap.active[0].slug).toBe(b.slug);
+  });
+
+  it('cancel({ all: true }) cancels every active session', async () => {
+    const { deps } = makeDeps({ maxConcurrent: 3 });
+    const orch = new SleepingOrchestrator(deps);
+    const a = await orch.start({ repo: '/x', prompt: 'a', workRoot: '/y', maxDurationMs: 60_000 });
+    const b = await orch.start({ repo: '/x', prompt: 'b', workRoot: '/y', maxDurationMs: 60_000 });
+    const cancelP = orch.cancel({ all: true });
+    vi.advanceTimersByTime(0);
+    const r = await cancelP;
+    expect(r.cancelled.sort()).toEqual([a.slug, b.slug].sort());
+    expect(orch.snapshot().active).toEqual([]);
+  });
+
+  it('cancel({ slug }) on unknown slug returns empty', async () => {
+    const { deps } = makeDeps();
+    const orch = new SleepingOrchestrator(deps);
+    await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
+    const r = await orch.cancel({ slug: 'does-not-exist' });
+    expect(r.cancelled).toEqual([]);
+    // The active session is not affected
+    expect(orch.snapshot().active).toHaveLength(1);
+  });
+
+  it('one session finishing does not affect another concurrent session', async () => {
+    const { deps, state } = makeDeps({ maxConcurrent: 3 });
+    const orch = new SleepingOrchestrator(deps);
+    const a = await orch.start({ repo: '/x', prompt: 'a', workRoot: '/y', maxDurationMs: 60_000 });
+    await orch.start({ repo: '/x', prompt: 'b', workRoot: '/y', maxDurationMs: 60_000 });
+    // Exit child A; B should still be alive
+    state.children[0].emit('exit', 0, null);
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    const snap = orch.snapshot();
+    expect(snap.active).toHaveLength(1);
+    expect(snap.active[0].slug).not.toBe(a.slug);
+    // gaming is still on because session B is still active
+    expect(deps.gaming.snapshot().active).toBe(true);
   });
 
   it('plan content (instead of prompt) generates an execute-plan prompt', async () => {
-    const { deps, state } = makeDeps();
+    const { deps } = makeDeps();
     const orch = new SleepingOrchestrator(deps);
     const planSpy = vi.spyOn(deps, 'spawn');
     await orch.start({ repo: '/x', plan: '# Plan\n\nDo X', workRoot: '/y', maxDurationMs: 60_000 });
@@ -218,18 +322,15 @@ describe('SleepingOrchestrator', () => {
 
   it('gaming with prior timer restored to remaining duration after success', async () => {
     const { deps, state } = makeDeps();
-    // prior gaming on with 1000ms timer
     deps.gaming.arm(1000);
     const orch = new SleepingOrchestrator(deps);
     await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
-    // sleep took 200ms — fast-forward via fake timer
     vi.advanceTimersByTime(200);
     state.child!.emit('exit', 0, null);
     for (let i = 0; i < 10; i++) await Promise.resolve();
     const snap = deps.gaming.snapshot();
     expect(snap.active).toBe(true);
     expect(snap.until).not.toBeNull();
-    // Remaining should be roughly 800ms — allow generous tolerance.
     const remaining = (snap.until ?? 0) - Date.now();
     expect(remaining).toBeGreaterThan(700);
     expect(remaining).toBeLessThan(900);


### PR DESCRIPTION
## Summary

Implements [`docs/specs/parallel-sleeps.md`](docs/specs/parallel-sleeps.md). Daemon now supports running multiple sleep sessions concurrently, capped by `policy.maxConcurrentSleeps` (default 3). Refactors `SleepingOrchestrator` from a single-slot model to a `Map<slug, Session>`.

## Changes

**Orchestrator (`src/daemon/sleeping.ts`):**
- `snapshot()` returns `{ active: SessionSnap[], capacity }` (was `{ active: false } | { active: true, ... }`)
- `start()` throws `CapacityReachedError` when at cap (carries `capacity` + `active` for the daemon to surface as 429)
- `cancel({ slug?, all? })` replaces the boolean-returning `cancel()`; ambiguous no-arg with multiple active throws
- Gaming centralized: armed on 0→1 transition, snapshotted at first start, restored on N→0 transition (per-session restore would race when sessions overlap)

**HTTP (`src/daemon/routes.ts`):**
- New `POST /v1/sleeping/cancel` with body `{ slug?, all? }`
- `GET /v1/sleeping` returns `{ active: [...], capacity }`
- `POST /v1/sleeping` returns 429 with `{ error: "capacity reached", capacity, active }` when at cap
- `DELETE /v1/sleeping` kept as legacy single-cancel (delegates to `cancel()` no-args; 409 if multiple active)

**CLI (`src/cli/sleeping.ts`, `src/cli/index.ts`):**
- `kuroboto sleeping status` lists all active sessions ("(cap N)" annotation)
- `kuroboto sleeping cancel [slug] [--all] [--yes]` with confirmation prompts that always display the slug(s) being cancelled
- Capacity-reached output formatted clearly with active-list and cap

**Schema (`src/config/schema.ts`):**
- `policy.maxConcurrentSleeps: number` (min 1, default 3)
- Init wizard sets the default

## Test plan

- [x] `npx vitest run` — 254/254 passing (21 new in `sleeping.test.ts` for multi-session + capacity + cancel variants; 4 new in `daemon.test.ts` for new endpoints; existing tests updated for new snapshot shape)
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke (post-merge):
  - `kuroboto sleeping status` shows `sleep: idle (cap 3)`
  - dispatch two sleeps; `status` shows both
  - dispatch a third with cap=2 set in config → 429 with capacity-reached output
  - `kuroboto sleeping cancel <slug>` cancels the specific one; others continue
  - `kuroboto sleeping cancel --all` prompts and cancels every active

## Out of scope

- Per-repo lock/warning when same repo has multiple active
- Priority queue at cap
- Resource-aware cap heuristic
- Backlog: `docs/specs-backlog.md`