### PR TITLE
feat(channel): Telegram supergroup + topics (Spec F)

### DIFF
--- a/src/channels/Channel.ts
+++ b/src/channels/Channel.ts
@@ -12,13 +12,35 @@ export type ChannelEventHandlers = {
   freeText: (event: FreeTextEvent) => void;
 };
 
+/**
+ * Routing context for outbound messages. The channel implementation chooses
+ * where to deliver based on this — TelegramChannel uses it to pick a forum
+ * topic when forumMode is on; in DM mode it's ignored. Callers populate it
+ * from the source of the event (hook payload, sleep slug, system event).
+ */
+export interface ChannelContext {
+  /**
+   * Logical session key — Spec E client slug, sleep slug, or any other
+   * stable identity. Becomes the forum topic key directly.
+   */
+  slug?: string;
+  /** When true, `slug` refers to a sleep session and the topic name is prefixed with 💤. */
+  isSleep?: boolean;
+  /** Bare claude `session_id` used when no slug is available (direct `claude` invocation). */
+  sessionId?: string;
+  /** Used together with `sessionId` to derive a friendly topic name (`<basename>-<sid8>`). */
+  cwdBasename?: string;
+  /** Daemon lifecycle / channel-error notifications — routed to the kuroboto-system topic. */
+  system?: boolean;
+}
+
 export interface Channel {
   start(): Promise<void>;
   stop(): Promise<void>;
-  sendPrompt(req: PromptRequest): Promise<void>;
-  sendNotification(text: string): Promise<void>;
+  sendPrompt(req: PromptRequest, ctx?: ChannelContext): Promise<void>;
+  sendNotification(text: string, ctx?: ChannelContext): Promise<void>;
   /** Send a Q&A question that opens a Reply UI; returns the channel-specific
    *  message id used to correlate the user's reply back to this question. */
-  sendQuestion(req: QuestionRequest): Promise<{ sentMessageId: string }>;
+  sendQuestion(req: QuestionRequest, ctx?: ChannelContext): Promise<{ sentMessageId: string }>;
   on<K extends ChannelEventName>(event: K, handler: ChannelEventHandlers[K]): void;
 }

--- a/src/channels/telegram/TelegramChannel.ts
+++ b/src/channels/telegram/TelegramChannel.ts
@@ -6,19 +6,32 @@ import type {
   Decision,
 } from '../../core/types.js';
 import type { Logger } from '../../core/logger.js';
-import type { Channel, ChannelEventName, ChannelEventHandlers } from '../Channel.js';
-import { TelegramApi, type TelegramUpdate, type InlineKeyboardButton } from './api.js';
+import type {
+  Channel,
+  ChannelContext,
+  ChannelEventName,
+  ChannelEventHandlers,
+} from '../Channel.js';
+import {
+  TelegramApi,
+  isThreadNotFoundError,
+  type TelegramUpdate,
+  type InlineKeyboardButton,
+} from './api.js';
 import { Poller } from './poller.js';
+import { TopicManager, pickTopicKey } from './topics.js';
 
 export interface TelegramChannelOptions {
   token: string;
   chatId: number;
   logger: Logger;
+  topicManager?: TopicManager;
 }
 
 export class TelegramChannel implements Channel {
   private readonly api: TelegramApi;
   private readonly poller: Poller;
+  private readonly topicManager?: TopicManager;
   private readonly handlers = {
     decision: [] as Array<(event: DecisionEvent) => void>,
     freeText: [] as Array<(event: FreeTextEvent) => void>,
@@ -28,6 +41,7 @@ export class TelegramChannel implements Channel {
 
   constructor(private readonly opts: TelegramChannelOptions) {
     this.api = new TelegramApi(opts.token);
+    this.topicManager = opts.topicManager;
     this.poller = new Poller({
       api: this.api,
       chatId: opts.chatId,
@@ -46,25 +60,57 @@ export class TelegramChannel implements Channel {
     this.opts.logger.info('telegram channel stopped');
   }
 
-  async sendNotification(text: string): Promise<void> {
-    await this.api.sendMessage(this.opts.chatId, text);
+  async sendNotification(text: string, ctx?: ChannelContext): Promise<void> {
+    await this.sendInTopic(ctx, (threadId) =>
+      this.api.sendMessage(this.opts.chatId, text, { messageThreadId: threadId }),
+    );
   }
 
-  async sendPrompt(req: PromptRequest): Promise<void> {
+  async sendPrompt(req: PromptRequest, ctx?: ChannelContext): Promise<void> {
     const keyboard = buildKeyboard(req);
-    const messageId = await this.api.sendMessage(this.opts.chatId, req.text, { keyboard });
+    const messageId = await this.sendInTopic(ctx, (threadId) =>
+      this.api.sendMessage(this.opts.chatId, req.text, { keyboard, messageThreadId: threadId }),
+    );
     this.promptMessageIds.set(req.requestId, { messageId, chatId: this.opts.chatId });
   }
 
-  async sendQuestion(req: QuestionRequest): Promise<{ sentMessageId: string }> {
-    const messageId = await this.api.sendMessage(this.opts.chatId, req.text, {
-      forceReply: req.forceReply ?? true,
-    });
+  async sendQuestion(req: QuestionRequest, ctx?: ChannelContext): Promise<{ sentMessageId: string }> {
+    const messageId = await this.sendInTopic(ctx, (threadId) =>
+      this.api.sendMessage(this.opts.chatId, req.text, {
+        forceReply: req.forceReply ?? true,
+        messageThreadId: threadId,
+      }),
+    );
     return { sentMessageId: String(messageId) };
   }
 
   on<K extends ChannelEventName>(event: K, handler: ChannelEventHandlers[K]): void {
     this.handlers[event].push(handler as never);
+  }
+
+  /**
+   * Resolve the routing context to a thread id, run `send`, and on a
+   * "message thread not found" 400 — meaning the topic was deleted in
+   * the client — purge the cached entry and retry once with a fresh
+   * topic. When forumMode is off (no topicManager), `send` is invoked
+   * directly with `undefined` so the message lands in the main chat.
+   */
+  private async sendInTopic(
+    ctx: ChannelContext | undefined,
+    send: (threadId: number | undefined) => Promise<number>,
+  ): Promise<number> {
+    if (!this.topicManager) return send(undefined);
+    const { key, name } = pickTopicKey(ctx);
+    const threadId = await this.topicManager.resolve(key, name);
+    try {
+      return await send(threadId);
+    } catch (e) {
+      if (!isThreadNotFoundError(e)) throw e;
+      this.opts.logger.warn('topic missing, purging and recreating', { key });
+      await this.topicManager.purge(key);
+      const newId = await this.topicManager.resolve(key, name);
+      return send(newId);
+    }
   }
 
   private handleUpdate(update: TelegramUpdate): void {

--- a/src/channels/telegram/api.ts
+++ b/src/channels/telegram/api.ts
@@ -23,6 +23,11 @@ export interface InlineKeyboardButton {
   callback_data: string;
 }
 
+export interface ChatMember {
+  status: string;
+  can_manage_topics?: boolean;
+}
+
 export class TelegramApi {
   constructor(private readonly token: string) {}
 
@@ -50,13 +55,21 @@ export class TelegramApi {
   async sendMessage(
     chatId: number,
     text: string,
-    opts?: { keyboard?: InlineKeyboardButton[][]; forceReply?: boolean; timeoutMs?: number },
+    opts?: {
+      keyboard?: InlineKeyboardButton[][];
+      forceReply?: boolean;
+      timeoutMs?: number;
+      messageThreadId?: number;
+    },
   ): Promise<number> {
     const timeoutMs = opts?.timeoutMs ?? 10_000;
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     try {
       const body: Record<string, unknown> = { chat_id: chatId, text };
+      if (opts?.messageThreadId !== undefined) {
+        body.message_thread_id = opts.messageThreadId;
+      }
       if (opts?.keyboard) {
         body.reply_markup = { inline_keyboard: opts.keyboard };
       } else if (opts?.forceReply) {
@@ -71,16 +84,12 @@ export class TelegramApi {
         body: JSON.stringify(body),
         signal: ctrl.signal,
       });
-      if (!res.ok) {
-        throw new ChannelError(`sendMessage HTTP ${res.status}`);
-      }
-      const json = (await res.json()) as {
-        ok: boolean;
-        result?: { message_id: number };
-        description?: string;
-      };
-      if (!json.ok || !json.result) {
-        throw new ChannelError(`telegram: ${json.description ?? 'unknown error'}`);
+      const json = (await res.json().catch(() => null)) as
+        | { ok: boolean; result?: { message_id: number }; description?: string }
+        | null;
+      if (!res.ok || !json?.ok || !json.result) {
+        const desc = json?.description ?? `HTTP ${res.status}`;
+        throw new ChannelError(`telegram: ${desc}`);
       }
       return json.result.message_id;
     } finally {
@@ -136,4 +145,77 @@ export class TelegramApi {
       clearTimeout(timer);
     }
   }
+
+  async createForumTopic(chatId: number, name: string, timeoutMs = 10_000): Promise<number> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(this.url('createForumTopic'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, name }),
+        signal: ctrl.signal,
+      });
+      const json = (await res.json().catch(() => null)) as
+        | { ok: boolean; result?: { message_thread_id: number }; description?: string }
+        | null;
+      if (!res.ok || !json?.ok || !json.result) {
+        const desc = json?.description ?? `HTTP ${res.status}`;
+        throw new ChannelError(`telegram: ${desc}`);
+      }
+      return json.result.message_thread_id;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async getMe(timeoutMs = 5_000): Promise<{ id: number }> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(this.url('getMe'), { signal: ctrl.signal });
+      const json = (await res.json().catch(() => null)) as
+        | { ok: boolean; result?: { id: number }; description?: string }
+        | null;
+      if (!res.ok || !json?.ok || !json.result) {
+        const desc = json?.description ?? `HTTP ${res.status}`;
+        throw new ChannelError(`telegram: ${desc}`);
+      }
+      return { id: json.result.id };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async getChatMember(chatId: number, userId: number, timeoutMs = 5_000): Promise<ChatMember> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(this.url('getChatMember'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, user_id: userId }),
+        signal: ctrl.signal,
+      });
+      const json = (await res.json().catch(() => null)) as
+        | { ok: boolean; result?: ChatMember; description?: string }
+        | null;
+      if (!res.ok || !json?.ok || !json.result) {
+        const desc = json?.description ?? `HTTP ${res.status}`;
+        throw new ChannelError(`telegram: ${desc}`);
+      }
+      return json.result;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Returns true when an error matches Telegram's "message thread not found"
+ * 400 — the signal that a previously-cached topic was deleted client-side.
+ */
+export function isThreadNotFoundError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  return /message thread not found/i.test(e.message);
 }

--- a/src/channels/telegram/forumValidation.ts
+++ b/src/channels/telegram/forumValidation.ts
@@ -34,14 +34,18 @@ export async function validateBotPermissions(
       `forumMode validation failed — getChatMember error: ${(e as Error).message}`,
     );
   }
-  if (member.status !== 'administrator') {
+  // 'creator' = group owner, also has full topic-management capability per
+  // Telegram API docs. Only reject when the bot is a plain member / left / etc.
+  if (member.status !== 'administrator' && member.status !== 'creator') {
     throw new ChannelError(
       `forumMode requires the bot to be an administrator of chat ${chatId} ` +
         `(current status: ${member.status}). Open the supergroup settings ` +
         `→ Administrators, add the bot, and enable "Manage Topics".`,
     );
   }
-  if (member.can_manage_topics !== true) {
+  // Group creators implicitly have all permissions; only check the explicit
+  // can_manage_topics flag for non-creator administrators.
+  if (member.status === 'administrator' && member.can_manage_topics !== true) {
     throw new ChannelError(
       `forumMode requires the bot's "Manage Topics" admin permission to be ` +
         `granted in chat ${chatId}. Open the supergroup settings → ` +

--- a/src/channels/telegram/forumValidation.ts
+++ b/src/channels/telegram/forumValidation.ts
@@ -1,0 +1,51 @@
+import { ChannelError } from '../../core/errors.js';
+
+export interface ForumValidationApi {
+  getMe(): Promise<{ id: number }>;
+  getChatMember(
+    chatId: number,
+    userId: number,
+  ): Promise<{ status: string; can_manage_topics?: boolean }>;
+}
+
+/**
+ * Verifies the bot can manage topics in the configured supergroup. Called on
+ * daemon startup when `channel.forumMode === true` so we fail fast instead
+ * of waiting for the first sendMessage to 400.
+ */
+export async function validateBotPermissions(
+  api: ForumValidationApi,
+  chatId: number,
+): Promise<void> {
+  let botId: number;
+  try {
+    const me = await api.getMe();
+    botId = me.id;
+  } catch (e) {
+    throw new ChannelError(
+      `forumMode validation failed — getMe error: ${(e as Error).message}`,
+    );
+  }
+  let member: { status: string; can_manage_topics?: boolean };
+  try {
+    member = await api.getChatMember(chatId, botId);
+  } catch (e) {
+    throw new ChannelError(
+      `forumMode validation failed — getChatMember error: ${(e as Error).message}`,
+    );
+  }
+  if (member.status !== 'administrator') {
+    throw new ChannelError(
+      `forumMode requires the bot to be an administrator of chat ${chatId} ` +
+        `(current status: ${member.status}). Open the supergroup settings ` +
+        `→ Administrators, add the bot, and enable "Manage Topics".`,
+    );
+  }
+  if (member.can_manage_topics !== true) {
+    throw new ChannelError(
+      `forumMode requires the bot's "Manage Topics" admin permission to be ` +
+        `granted in chat ${chatId}. Open the supergroup settings → ` +
+        `Administrators → the bot, and toggle "Manage Topics" on.`,
+    );
+  }
+}

--- a/src/channels/telegram/topics.ts
+++ b/src/channels/telegram/topics.ts
@@ -1,0 +1,141 @@
+import fsp from 'node:fs/promises';
+import type { Logger } from '../../core/logger.js';
+
+export type TopicAuditSource =
+  | 'topic-created'
+  | 'topic-create-failed'
+  | 'topic-purged';
+
+export interface TopicAuditEvent {
+  source: TopicAuditSource;
+  key: string;
+  name?: string;
+  threadId?: number;
+  error?: string;
+}
+
+export interface TopicManagerApi {
+  createForumTopic(chatId: number, name: string): Promise<number>;
+}
+
+export interface TopicManagerOptions {
+  api: TopicManagerApi;
+  chatId: number;
+  forumMode: boolean;
+  storagePath: string;
+  logger: Logger;
+  audit?: (event: TopicAuditEvent) => void;
+}
+
+/**
+ * Maps logical session keys (CLI slug, sleep slug, "kuroboto-system", etc.)
+ * to Telegram forum `message_thread_id` values, with on-disk persistence so
+ * daemon restarts don't recreate topics. Lazy: a topic isn't created until the
+ * first outbound message for its key fires through `resolve()`.
+ *
+ * When `forumMode: false`, `resolve()` is a no-op returning `undefined` —
+ * messages flow into the main chat as in the original DM behavior.
+ */
+export class TopicManager {
+  private readonly cache = new Map<string, number>();
+  private loaded = false;
+  /**
+   * Serializes createForumTopic calls per-key so two concurrent resolves for
+   * the same key wait on a single API request and reuse its thread id.
+   */
+  private readonly inflight = new Map<string, Promise<number | undefined>>();
+
+  constructor(private readonly opts: TopicManagerOptions) {}
+
+  async loadFromDisk(): Promise<void> {
+    if (this.loaded) return;
+    this.loaded = true;
+    let raw: string;
+    try {
+      raw = await fsp.readFile(this.opts.storagePath, 'utf-8');
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return;
+      this.opts.logger.warn('topics.json read failed', {
+        err: (e as Error).message,
+      });
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      this.opts.logger.warn('topics.json malformed, starting empty', {
+        err: (e as Error).message,
+      });
+      return;
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      this.opts.logger.warn('topics.json malformed, starting empty');
+      return;
+    }
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        this.cache.set(key, value);
+      }
+    }
+  }
+
+  /**
+   * Resolve a key to its forum thread id. Returns `undefined` when forumMode
+   * is off, when topic creation fails (so callers post to the main chat), or
+   * when no cached entry exists and `name` is omitted.
+   */
+  async resolve(key: string, name: string): Promise<number | undefined> {
+    if (!this.opts.forumMode) return undefined;
+    if (!this.loaded) await this.loadFromDisk();
+    const cached = this.cache.get(key);
+    if (cached !== undefined) return cached;
+    const existing = this.inflight.get(key);
+    if (existing) return existing;
+    const promise = this.createAndPersist(key, name).finally(() => {
+      this.inflight.delete(key);
+    });
+    this.inflight.set(key, promise);
+    return promise;
+  }
+
+  private async createAndPersist(key: string, name: string): Promise<number | undefined> {
+    let threadId: number;
+    try {
+      threadId = await this.opts.api.createForumTopic(this.opts.chatId, name);
+    } catch (e) {
+      const msg = (e as Error).message;
+      this.opts.logger.warn('createForumTopic failed', { key, err: msg });
+      this.opts.audit?.({ source: 'topic-create-failed', key, name, error: msg });
+      return undefined;
+    }
+    this.cache.set(key, threadId);
+    await this.flushToDisk();
+    this.opts.audit?.({ source: 'topic-created', key, name, threadId });
+    return threadId;
+  }
+
+  /**
+   * Drop a key from cache + disk. Used when the daemon learns a topic was
+   * deleted client-side (Telegram returns `message thread not found`).
+   */
+  async purge(key: string): Promise<void> {
+    if (!this.cache.delete(key)) return;
+    await this.flushToDisk();
+    this.opts.audit?.({ source: 'topic-purged', key });
+  }
+
+  private async flushToDisk(): Promise<void> {
+    const obj: Record<string, number> = {};
+    for (const [k, v] of this.cache) obj[k] = v;
+    try {
+      await fsp.writeFile(this.opts.storagePath, JSON.stringify(obj, null, 2), {
+        mode: 0o600,
+      });
+    } catch (e) {
+      this.opts.logger.warn('topics.json write failed', {
+        err: (e as Error).message,
+      });
+    }
+  }
+}

--- a/src/channels/telegram/topics.ts
+++ b/src/channels/telegram/topics.ts
@@ -1,5 +1,38 @@
 import fsp from 'node:fs/promises';
 import type { Logger } from '../../core/logger.js';
+import type { ChannelContext } from '../Channel.js';
+
+export const SYSTEM_TOPIC_KEY = 'kuroboto-system';
+const SLEEP_SLUG_SUFFIX_RE = /-[a-z0-9]{6}$/;
+
+/**
+ * Resolves a `ChannelContext` to the `(key, name)` pair the TopicManager
+ * uses for forum topics. Centralized so both routing and tests share the
+ * exact mapping rules from spec F.
+ *
+ *   slug + isSleep  → key=slug,    name=`💤 <slug-without-suffix>`
+ *   slug            → key=slug,    name=slug
+ *   sessionId       → key=sessionId, name=`<basename>-<sid8>`
+ *   system / empty  → key="kuroboto-system", name="kuroboto-system"
+ */
+export function pickTopicKey(ctx: ChannelContext | undefined): { key: string; name: string } {
+  if (!ctx || ctx.system) {
+    return { key: SYSTEM_TOPIC_KEY, name: SYSTEM_TOPIC_KEY };
+  }
+  if (ctx.slug) {
+    if (ctx.isSleep) {
+      const stripped = ctx.slug.replace(SLEEP_SLUG_SUFFIX_RE, '');
+      return { key: ctx.slug, name: `💤 ${stripped}` };
+    }
+    return { key: ctx.slug, name: ctx.slug };
+  }
+  if (ctx.sessionId) {
+    const sid8 = ctx.sessionId.slice(0, 8);
+    const basename = ctx.cwdBasename ?? 'session';
+    return { key: ctx.sessionId, name: `${basename}-${sid8}` };
+  }
+  return { key: SYSTEM_TOPIC_KEY, name: SYSTEM_TOPIC_KEY };
+}
 
 export type TopicAuditSource =
   | 'topic-created'

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -94,7 +94,7 @@ export async function initCommand(): Promise<void> {
 
   const authToken = randomBytes(32).toString('hex');
   const config: ConfigT = {
-    channel: { type: 'telegram', token, chatId },
+    channel: { type: 'telegram', token, chatId, forumMode: false },
     daemon: { port, authToken },
     inject,
     policy: {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,6 +7,8 @@ import chalk from 'chalk';
 import { saveConfig } from '../config/save.js';
 import { CONFIG_FILE } from '../config/paths.js';
 import type { ConfigT } from '../config/schema.js';
+import { TelegramApi } from '../channels/telegram/api.js';
+import { validateBotPermissions } from '../channels/telegram/forumValidation.js';
 
 interface TelegramGetUpdatesResp {
   ok: boolean;
@@ -44,22 +46,77 @@ export async function initCommand(): Promise<void> {
   const token = ((tokenAns.val as string) ?? '').trim();
   if (!token) { console.log('Cancelado.'); return; }
 
-  console.log(chalk.cyan('\nAbra seu bot no Telegram (busca pelo username dele) e envie /start.'));
-  await prompts({ type: 'confirm', name: 'val', message: 'Mandou /start? Eu busco o chat_id.', initial: true });
+  const modeAns = await prompts({
+    type: 'select',
+    name: 'val',
+    message: 'Onde o bot vai postar?',
+    choices: [
+      { title: 'DM 1:1 (padrão)', value: 'dm', description: 'um único chat com você' },
+      {
+        title: 'Supergroup com topics',
+        value: 'forum',
+        description: 'um topic por sessão Claude — recomendado pra multi-sessão',
+      },
+    ],
+    initial: 0,
+  });
+  const forumMode = modeAns.val === 'forum';
+
+  if (forumMode) {
+    console.log(chalk.cyan('\nSupergroup com topics:'));
+    console.log('  1. No Telegram, crie um New Group (só você) e converta pra Supergroup');
+    console.log('  2. Settings do grupo → "Topics" → ative');
+    console.log('  3. Add o bot como Administrator com a permissão "Manage Topics"');
+    console.log('  4. Mande qualquer mensagem dentro do supergroup (qualquer topic, ex: General)');
+    console.log('     — eu uso essa mensagem pra capturar o chat_id (negativo, começa com -100)');
+    await prompts({
+      type: 'confirm',
+      name: 'val',
+      message: 'Pronto, mandou a mensagem? Eu busco o chat_id.',
+      initial: true,
+    });
+  } else {
+    console.log(chalk.cyan('\nAbra seu bot no Telegram (busca pelo username dele) e envie /start.'));
+    await prompts({
+      type: 'confirm',
+      name: 'val',
+      message: 'Mandou /start? Eu busco o chat_id.',
+      initial: true,
+    });
+  }
 
   let chatId: number | null = null;
   for (let i = 0; i < 3 && chatId === null; i++) {
-    chatId = await fetchChatId(token);
+    chatId = await fetchChatId(token, forumMode);
     if (chatId === null && i < 2) {
-      const retry = await prompts({ type: 'confirm', name: 'val', message: 'Nada encontrado. Manda /start de novo e tenta de novo?', initial: true });
+      const retry = await prompts({
+        type: 'confirm',
+        name: 'val',
+        message: forumMode
+          ? 'Nada encontrado. Manda outra mensagem no supergroup e tenta de novo?'
+          : 'Nada encontrado. Manda /start de novo e tenta de novo?',
+        initial: true,
+      });
       if (retry.val !== true) break;
     }
   }
   if (chatId === null) {
-    console.log(chalk.red('\nNão consegui pegar o chat_id. Rode `kuroboto init` de novo após mandar /start.'));
+    console.log(chalk.red('\nNão consegui pegar o chat_id. Rode `kuroboto init` de novo.'));
     return;
   }
   console.log(chalk.green(`✓ chat_id capturado: ${chatId}`));
+
+  if (forumMode) {
+    // Hard gate: refuse to save a forum config that won't work at runtime.
+    try {
+      await validateBotPermissions(new TelegramApi(token), chatId);
+      console.log(chalk.green('✓ permissões do bot OK (admin + can_manage_topics)'));
+    } catch (e) {
+      console.log(chalk.red(`\n${(e as Error).message}`));
+      console.log(chalk.yellow('Ajusta as permissões e roda `kuroboto init` de novo.'));
+      return;
+    }
+  }
 
   const portAns = await prompts({
     type: 'number',
@@ -94,7 +151,7 @@ export async function initCommand(): Promise<void> {
 
   const authToken = randomBytes(32).toString('hex');
   const config: ConfigT = {
-    channel: { type: 'telegram', token, chatId, forumMode: false },
+    channel: { type: 'telegram', token, chatId, forumMode },
     daemon: { port, authToken },
     inject,
     policy: {
@@ -130,7 +187,7 @@ export async function initCommand(): Promise<void> {
   console.log('  • ou direto `kuroboto claude` em qualquer pasta\n');
 }
 
-async function fetchChatId(token: string): Promise<number | null> {
+async function fetchChatId(token: string, forumMode: boolean): Promise<number | null> {
   try {
     const res = await fetch(`https://api.telegram.org/bot${token}/getUpdates`);
     if (!res.ok) return null;
@@ -138,7 +195,13 @@ async function fetchChatId(token: string): Promise<number | null> {
     if (!json.ok) return null;
     for (const update of [...json.result].reverse()) {
       const id = update.message?.chat?.id;
-      if (typeof id === 'number') return id;
+      if (typeof id !== 'number') continue;
+      // In forum mode the chatId is a negative supergroup id (-100…). DM mode
+      // is positive. Filter so we don't accidentally pick up an unrelated DM
+      // when the user has both kinds of chat with the bot in flight.
+      if (forumMode && id >= 0) continue;
+      if (!forumMode && id < 0) continue;
+      return id;
     }
     return null;
   } catch {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -7,3 +7,4 @@ export const PID_FILE = path.join(CONFIG_DIR, 'daemon.pid');
 export const DAEMON_SENTINEL_FILE = path.join(CONFIG_DIR, 'daemon.pid.json');
 export const LOG_DIR = path.join(CONFIG_DIR, 'logs');
 export const AUDIT_FILE = path.join(CONFIG_DIR, 'audit.jsonl');
+export const TOPICS_FILE = path.join(CONFIG_DIR, 'topics.json');

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5,6 +5,10 @@ export const ChannelConfig = z.discriminatedUnion('type', [
     type: z.literal('telegram'),
     token: z.string().min(1),
     chatId: z.number(),
+    // When true, the chat is a supergroup with forum (topics) enabled and the
+    // daemon routes every outbound message into a per-session topic. Default
+    // false preserves the original 1:1 DM behavior.
+    forumMode: z.boolean().default(false),
   }),
 ]);
 

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -5,8 +5,11 @@ import { spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
 import type { Channel } from '../channels/Channel.js';
 import type { ConfigT } from '../config/schema.js';
 import { TelegramChannel } from '../channels/telegram/TelegramChannel.js';
+import { TelegramApi } from '../channels/telegram/api.js';
+import { TopicManager, type TopicAuditEvent } from '../channels/telegram/topics.js';
+import { validateBotPermissions } from '../channels/telegram/forumValidation.js';
 import { createLogger, type Logger } from '../core/logger.js';
-import { CONFIG_DIR, LOG_DIR, PID_FILE, DAEMON_SENTINEL_FILE } from '../config/paths.js';
+import { CONFIG_DIR, LOG_DIR, PID_FILE, DAEMON_SENTINEL_FILE, TOPICS_FILE } from '../config/paths.js';
 import { DaemonError } from '../core/errors.js';
 import { PendingMap } from './pending.js';
 import { PendingNotifications } from './pendingNotifications.js';
@@ -21,6 +24,8 @@ import { createServer, type DaemonContext } from './server.js';
 import { createInjectStrategy } from '../inject/index.js';
 import { validateTmuxAvailable } from '../inject/validate.js';
 import { InjectClients } from './injectClients.js';
+import { appendAudit } from './audit.js';
+import { topicContextSystem } from './topicContext.js';
 
 export interface RunningDaemon {
   stop(): Promise<void>;
@@ -42,7 +47,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   const logger = createLogger(LOG_DIR);
   logger.info('daemon starting', { port: config.daemon.port });
 
-  const channel = makeChannel(config, logger);
+  const channel = await makeChannel(config, logger);
   const pending = new PendingMap();
   pending.startCleanupLoop();
   const pendingNotifications = new PendingNotifications();
@@ -66,7 +71,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   const sleeping = new SleepingOrchestrator({
     spawn: claudeSpawn,
     gaming,
-    notify: (msg) => channel.sendNotification(msg),
+    notify: (msg, ctx) => channel.sendNotification(msg, ctx),
     audit: async () => {}, // skip audit at daemon level; sleep events go to Telegram
     createWorktree,
     removeWorktree,
@@ -84,7 +89,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
             child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
           });
         },
-        notify: (msg) => channel.sendNotification(msg),
+        notify: (msg, ctx) => channel.sendNotification(msg, ctx),
         notifyDesktop: desktopNotifyDep,
       }),
   });
@@ -151,7 +156,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     pendingReplies.cancelAll();
     await new Promise<void>((resolve) => server.close(() => resolve()));
     try {
-      await channel.sendNotification('🔻 kuroboto offline');
+      await channel.sendNotification('🔻 kuroboto offline', topicContextSystem());
     } catch {
       // best-effort
     }
@@ -182,7 +187,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
   process.on('SIGINT', onSignal);
 
   try {
-    await channel.sendNotification('✅ kuroboto online');
+    await channel.sendNotification('✅ kuroboto online', topicContextSystem());
   } catch {
     // best-effort
   }
@@ -218,8 +223,29 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function makeChannel(config: ConfigT, logger: Logger): Channel {
+async function makeChannel(config: ConfigT, logger: Logger): Promise<Channel> {
   if (config.channel.type === 'telegram') {
+    if (config.channel.forumMode) {
+      const api = new TelegramApi(config.channel.token);
+      // Fail fast if the bot can't manage topics — saves chasing a 400 on
+      // the first sendMessage and gives the user actionable instructions.
+      await validateBotPermissions(api, config.channel.chatId);
+      const topicManager = new TopicManager({
+        api,
+        chatId: config.channel.chatId,
+        forumMode: true,
+        storagePath: TOPICS_FILE,
+        logger,
+        audit: forwardTopicAudit(logger),
+      });
+      await topicManager.loadFromDisk();
+      return new TelegramChannel({
+        token: config.channel.token,
+        chatId: config.channel.chatId,
+        logger,
+        topicManager,
+      });
+    }
     return new TelegramChannel({
       token: config.channel.token,
       chatId: config.channel.chatId,
@@ -227,5 +253,22 @@ function makeChannel(config: ConfigT, logger: Logger): Channel {
     });
   }
   throw new DaemonError(`unsupported channel type: ${(config.channel as { type: string }).type}`);
+}
+
+function forwardTopicAudit(logger: Logger): (e: TopicAuditEvent) => void {
+  return (e) => {
+    const decision: 'allow' | 'deny' | 'ask' =
+      e.source === 'topic-create-failed' ? 'deny' : e.source === 'topic-purged' ? 'ask' : 'allow';
+    appendAudit({
+      ts: new Date().toISOString(),
+      requestId: e.threadId !== undefined ? `topic:${e.threadId}` : `topic:${e.key}`,
+      tool: 'topic',
+      cwd: null,
+      decision,
+      reason: e.error ?? null,
+      source: e.source,
+      remember: false,
+    }).catch((err) => logger.warn('topic audit append failed', { err: (err as Error).message }));
+  };
 }
 

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -257,8 +257,11 @@ async function makeChannel(config: ConfigT, logger: Logger): Promise<Channel> {
 
 function forwardTopicAudit(logger: Logger): (e: TopicAuditEvent) => void {
   return (e) => {
-    const decision: 'allow' | 'deny' | 'ask' =
-      e.source === 'topic-create-failed' ? 'deny' : e.source === 'topic-purged' ? 'ask' : 'allow';
+    // Topic lifecycle is not a permission decision; we audit the event but
+    // map decisions semantically: success (created/purged) = allow, failure
+    // = deny. 'ask' would imply pending/timeout and doesn't fit any topic
+    // event shape.
+    const decision: 'allow' | 'deny' = e.source === 'topic-create-failed' ? 'deny' : 'allow';
     appendAudit({
       ts: new Date().toISOString(),
       requestId: e.threadId !== undefined ? `topic:${e.threadId}` : `topic:${e.key}`,

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -18,12 +18,19 @@ import {
 import { isQAPrompt } from './notificationDetect.js';
 import { injectViaPty } from '../inject/pty.js';
 import type { SessionSnap } from './sleeping.js';
+import { topicContextFromHook } from './topicContext.js';
+import type { ChannelContext } from '../channels/Channel.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
   const fmtCtx = (): PromptFormatContext => ({
     hostname: ctx.hostname,
     sleeping: ctx.state.sleeping.snapshot(),
   });
+  const hookTopicCtx = (p: { cwd?: string; session_id: string }): ChannelContext =>
+    topicContextFromHook(p, {
+      injectClients: ctx.injectClients,
+      sleepingSnap: ctx.state.sleeping.snapshot(),
+    });
 
   app.get('/v1/health', (_req, res) => {
     res.json({
@@ -254,10 +261,11 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
     if (payload.session_id && payload.cwd) {
       ctx.injectClients.bindSessionByCwd(payload.session_id, payload.cwd);
     }
+    const topicCtx = hookTopicCtx(payload);
     if (shouldHandleAsQA(payload, ctx)) {
       // Fire-and-forget: the Q&A flow runs end-to-end (send question, await
       // reply, inject, audit) in the background. The hook just gets ack.
-      handleQAPrompt(payload, ctx, fmtCtx()).catch((e) =>
+      handleQAPrompt(payload, ctx, fmtCtx(), topicCtx).catch((e) =>
         ctx.logger.warn('Q&A flow failed', { err: (e as Error).message }),
       );
       ctx.logger.info('notify received (Q&A)', { cwd: payload.cwd });
@@ -273,14 +281,17 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
     });
     if (delayMs <= 0) {
       formatNotification(payload, fmtCtx())
-        .then((text) => ctx.channel.sendNotification(text))
+        .then((text) => ctx.channel.sendNotification(text, topicCtx))
         .then(() => ctx.logger.info('notify sent (immediate)'))
         .catch((e) => ctx.logger.warn('sendNotification failed', { err: (e as Error).message }));
     } else {
       ctx.pendingNotifications.arm(payload, delayMs, (p) => {
         ctx.logger.info('notify timer fired, sending');
+        // Re-derive context at fire time since sleep / inject-client state
+        // may have changed during the delay.
+        const lateCtx = hookTopicCtx(p);
         formatNotification(p, fmtCtx())
-          .then((text) => ctx.channel.sendNotification(text))
+          .then((text) => ctx.channel.sendNotification(text, lateCtx))
           .then(() => ctx.logger.info('notify sent (delayed)'))
           .catch((e) => ctx.logger.warn('sendNotification (delayed) failed', { err: (e as Error).message }));
       });
@@ -294,6 +305,7 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
       ctx.injectClients.bindSessionByCwd(payload.session_id, payload.cwd);
     }
     const gamingSnap = ctx.state.gaming.snapshot();
+    const topicCtx = hookTopicCtx(payload);
     if (gamingSnap.active && !ctx.config.policy.gamingAlwaysAsk.includes(payload.tool_name)) {
       const decision: Decision = { decision: 'allow', reason: 'gaming' };
       appendAudit({
@@ -307,7 +319,7 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
         remember: false,
       }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
       formatPermissionPrompt(payload, fmtCtx())
-        .then((text) => ctx.channel.sendNotification(`🎮 ${text}`))
+        .then((text) => ctx.channel.sendNotification(`🎮 ${text}`, topicCtx))
         .catch((e) => ctx.logger.warn('gaming notify failed', { err: (e as Error).message }));
       res.json(decision);
       return;
@@ -361,16 +373,19 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
     const { requestId, promise } = ctx.pending.create(ctx.config.policy.permissionTimeoutMs);
     try {
       const text = await formatPermissionPrompt(payload, fmtCtx());
-      await ctx.channel.sendPrompt({
-        requestId,
-        text,
-        buttons: [
-          { label: '✅ Allow', action: 'allow' },
-          { label: '🔓 Allow & remember', action: 'allow_remember' },
-          { label: '❌ Deny', action: 'deny' },
-          { label: '💬 Deny with note', action: 'deny_note' },
-        ],
-      });
+      await ctx.channel.sendPrompt(
+        {
+          requestId,
+          text,
+          buttons: [
+            { label: '✅ Allow', action: 'allow' },
+            { label: '🔓 Allow & remember', action: 'allow_remember' },
+            { label: '❌ Deny', action: 'deny' },
+            { label: '💬 Deny with note', action: 'deny_note' },
+          ],
+        },
+        topicCtx,
+      );
     } catch (e) {
       ctx.logger.error('sendPrompt failed', { err: (e as Error).message });
       ctx.pending.resolve(requestId, { decision: 'ask', reason: 'channel unavailable' });
@@ -443,11 +458,12 @@ async function handleQAPrompt(
   payload: NotificationPayload,
   ctx: DaemonContext,
   fmtCtx: PromptFormatContext,
+  topicCtx: ChannelContext,
 ): Promise<void> {
   const text = await formatQAPrompt(payload, fmtCtx);
   let sentMessageId: string;
   try {
-    ({ sentMessageId } = await ctx.channel.sendQuestion({ text, forceReply: true }));
+    ({ sentMessageId } = await ctx.channel.sendQuestion({ text, forceReply: true }, topicCtx));
   } catch (e) {
     ctx.logger.warn('Q&A sendQuestion failed', { err: (e as Error).message });
     return;
@@ -481,7 +497,7 @@ async function handleQAPrompt(
         remember: false,
       }).catch((e2) => ctx.logger.warn('audit append failed', { err: (e2 as Error).message }));
       await ctx.channel
-        .sendNotification('⏱ Q&A expirou (Claude pode ainda estar esperando)')
+        .sendNotification('⏱ Q&A expirou (Claude pode ainda estar esperando)', topicCtx)
         .catch((e2) => ctx.logger.warn('sendNotification (qa-timeout) failed', { err: (e2 as Error).message }));
       return;
     }
@@ -502,7 +518,7 @@ async function handleQAPrompt(
       remember: false,
     }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
     await ctx.channel
-      .sendNotification('✅ Reply injetada')
+      .sendNotification('✅ Reply injetada', topicCtx)
       .catch((e) => ctx.logger.warn('sendNotification (qa-injected) failed', { err: (e as Error).message }));
     return;
   }
@@ -517,7 +533,7 @@ async function handleQAPrompt(
     remember: false,
   }).catch((e2) => ctx.logger.warn('audit append failed', { err: (e2 as Error).message }));
   await ctx.channel
-    .sendNotification(`❌ Inject falhou: ${result.reason}\n\nSua reply foi:\n${reply}`)
+    .sendNotification(`❌ Inject falhou: ${result.reason}\n\nSua reply foi:\n${reply}`, topicCtx)
     .catch((e2) => ctx.logger.warn('sendNotification (qa-inject-failed) failed', { err: (e2 as Error).message }));
 }
 

--- a/src/daemon/sleepFinish.ts
+++ b/src/daemon/sleepFinish.ts
@@ -1,5 +1,6 @@
 import type { SleepingSession } from './sleeping.js';
 import type { DesktopNotifyOpts } from '../notify/desktop.js';
+import type { ChannelContext } from '../channels/Channel.js';
 
 export interface ExecResult {
   code: number;
@@ -15,7 +16,7 @@ export type ExecFn = (
 
 export interface FinishDeps {
   exec: ExecFn;
-  notify: (msg: string) => Promise<void>;
+  notify: (msg: string, ctx?: ChannelContext) => Promise<void>;
   notifyDesktop?: (opts: DesktopNotifyOpts) => Promise<void>;
 }
 
@@ -46,6 +47,7 @@ function buildBody(session: SleepingSession): string {
 }
 
 export async function finishSleep(session: SleepingSession, deps: FinishDeps): Promise<void> {
+  const topicCtx: ChannelContext = { slug: session.slug, isSleep: true };
   // 1. Push branch from the worktree
   const push = await deps.exec('git', ['push', '-u', 'origin', session.branch], {
     cwd: session.worktreePath,
@@ -54,6 +56,7 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
     await deps.notify(
       `❌ sleep finalize failed — push failed: ${push.stderr.trim() || 'unknown'}. ` +
         `worktree: ${session.worktreePath}`,
+      topicCtx,
     );
     if (deps.notifyDesktop) {
       await deps.notifyDesktop({
@@ -87,6 +90,7 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
     await deps.notify(
       `❌ sleep finalize failed — pr create failed: ${create.stderr.trim() || 'unknown'}. ` +
         `worktree: ${session.worktreePath}`,
+      topicCtx,
     );
     if (deps.notifyDesktop) {
       await deps.notifyDesktop({
@@ -101,6 +105,7 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
   const url = create.stdout.trim().split('\n').pop() ?? '';
   await deps.notify(
     `✅ sleep done — PR: ${url}\n\nTest plan in the PR body. Worktree: ${session.worktreePath}`,
+    topicCtx,
   );
   if (deps.notifyDesktop) {
     await deps.notifyDesktop({

--- a/src/daemon/sleeping.ts
+++ b/src/daemon/sleeping.ts
@@ -2,13 +2,14 @@ import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { GamingState, type GamingSnapshot } from './gaming.js';
 import { slugify } from './worktree.js';
 import type { DesktopNotifyOpts } from '../notify/desktop.js';
+import type { ChannelContext } from '../channels/Channel.js';
 
 export type SpawnFn = (cmd: string, args: string[], opts: SpawnOptions) => ChildProcess;
 
 export interface SleepingDeps {
   spawn: SpawnFn;
   gaming: GamingState;
-  notify: (msg: string) => Promise<void>;
+  notify: (msg: string, ctx?: ChannelContext) => Promise<void>;
   audit: (entry: Record<string, unknown>) => Promise<void>;
   createWorktree: (repo: string, branch: string, dir: string) => Promise<void>;
   removeWorktree: (repo: string, dir: string) => Promise<void>;
@@ -158,6 +159,7 @@ export class SleepingOrchestrator {
 
     void this.deps.notify(
       `\u{1F4A4} sleep started — ${slug}, max ${formatDuration(req.maxDurationMs)}`,
+      { slug, isSleep: true },
     );
     void this.deps.audit({
       ts: new Date(startedAt).toISOString(),
@@ -226,6 +228,7 @@ export class SleepingOrchestrator {
     });
     void this.deps.notify(
       `\u{1F6D1} sleep cancelled — ${slug}. log: ${session.worktreePath}/.kuroboto-sleep.log`,
+      { slug, isSleep: true },
     );
     this.sessions.delete(slug);
     this.maybeRestoreGaming();
@@ -256,6 +259,7 @@ export class SleepingOrchestrator {
         } catch (e) {
           void this.deps.notify(
             `⚠️ sleep onSuccess hook failed for ${slug}: ${(e as Error).message}`,
+            { slug, isSleep: true },
           );
         } finally {
           this.sessions.delete(slug);
@@ -266,6 +270,7 @@ export class SleepingOrchestrator {
       const reason = signal ? `signal ${signal}` : `exit ${code}`;
       void this.deps.notify(
         `❌ sleep failed — ${slug} — ${reason}. log: ${session.worktreePath}/.kuroboto-sleep.log`,
+        { slug, isSleep: true },
       );
       if (this.deps.notifyDesktop) {
         void this.deps.notifyDesktop({
@@ -286,6 +291,7 @@ export class SleepingOrchestrator {
     session.child.kill('SIGTERM');
     void this.deps.notify(
       `⏰ sleep timed out — ${slug}. log: ${session.worktreePath}/.kuroboto-sleep.log. PR not created.`,
+      { slug, isSleep: true },
     );
     if (this.deps.notifyDesktop) {
       void this.deps.notifyDesktop({

--- a/src/daemon/topicContext.ts
+++ b/src/daemon/topicContext.ts
@@ -12,7 +12,10 @@ export interface TopicContextDeps {
  * Derive the routing context for an inbound hook payload. Priority:
  *   1. cwd matches an active sleep worktree → that sleep slug (with 💤)
  *   2. session is bound to a registered CLI client → that slug
- *   3. cwd matches a registered CLI client → that slug (late-bind path)
+ *   3. cwd matches a registered CLI client → that slug (defense-in-depth
+ *      safety net for the rare case where `bindSessionByCwd` hasn't fired
+ *      yet — in normal flow routes.ts calls it before us, so step 2 hits
+ *      first)
  *   4. otherwise → bare session_id (direct `claude`, no kuroboto wrapper)
  * Falls through to the kuroboto-system topic if nothing identifies the
  * source (handled inside the channel via `pickTopicKey`).

--- a/src/daemon/topicContext.ts
+++ b/src/daemon/topicContext.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+import type { ChannelContext } from '../channels/Channel.js';
+import type { InjectClients } from './injectClients.js';
+import type { SleepingSnapshot } from './sleeping.js';
+
+export interface TopicContextDeps {
+  injectClients: InjectClients;
+  sleepingSnap: SleepingSnapshot;
+}
+
+/**
+ * Derive the routing context for an inbound hook payload. Priority:
+ *   1. cwd matches an active sleep worktree → that sleep slug (with 💤)
+ *   2. session is bound to a registered CLI client → that slug
+ *   3. cwd matches a registered CLI client → that slug (late-bind path)
+ *   4. otherwise → bare session_id (direct `claude`, no kuroboto wrapper)
+ * Falls through to the kuroboto-system topic if nothing identifies the
+ * source (handled inside the channel via `pickTopicKey`).
+ */
+export function topicContextFromHook(
+  payload: { cwd?: string; session_id: string },
+  deps: TopicContextDeps,
+): ChannelContext {
+  if (payload.cwd) {
+    const sleep = deps.sleepingSnap.active.find((s) => samePath(payload.cwd!, s.worktreePath));
+    if (sleep) return { slug: sleep.slug, isSleep: true };
+  }
+  const bound = deps.injectClients.lookupBySession(payload.session_id);
+  if (bound) return { slug: bound.slug };
+  if (payload.cwd) {
+    for (const client of deps.injectClients.list()) {
+      if (samePath(client.cwd, payload.cwd)) return { slug: client.slug };
+    }
+  }
+  return {
+    sessionId: payload.session_id,
+    cwdBasename: cwdBasename(payload.cwd),
+  };
+}
+
+export function topicContextForSleep(slug: string): ChannelContext {
+  return { slug, isSleep: true };
+}
+
+export function topicContextSystem(): ChannelContext {
+  return { system: true };
+}
+
+function samePath(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
+
+function cwdBasename(cwd: string | undefined): string | undefined {
+  if (!cwd) return undefined;
+  const parts = cwd.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1];
+}

--- a/test/helpers/mockChannel.ts
+++ b/test/helpers/mockChannel.ts
@@ -1,14 +1,30 @@
 import type {
   Channel,
+  ChannelContext,
   ChannelEventHandlers,
   ChannelEventName,
 } from '../../src/channels/Channel.js';
 import type { PromptRequest, QuestionRequest, Decision } from '../../src/core/types.js';
 
+interface SentNotification {
+  text: string;
+  ctx?: ChannelContext;
+}
+
+interface SentPrompt {
+  req: PromptRequest;
+  ctx?: ChannelContext;
+}
+
+interface SentQuestion {
+  req: QuestionRequest;
+  ctx?: ChannelContext;
+}
+
 export class MockChannel implements Channel {
-  public sentNotifications: string[] = [];
-  public sentPrompts: PromptRequest[] = [];
-  public sentQuestions: QuestionRequest[] = [];
+  public sentNotificationsDetailed: SentNotification[] = [];
+  public sentPromptsDetailed: SentPrompt[] = [];
+  public sentQuestionsDetailed: SentQuestion[] = [];
   public throwOnSendPrompt = false;
   public throwOnSendQuestion = false;
   private nextSentMessageId = 1000;
@@ -17,21 +33,39 @@ export class MockChannel implements Channel {
     freeText: [],
   };
 
+  /** Back-compat shorthand used by older tests — text array. */
+  get sentNotifications(): string[] {
+    return this.sentNotificationsDetailed.map((n) => n.text);
+  }
+
+  /** Back-compat shorthand used by older tests — prompt requests. */
+  get sentPrompts(): PromptRequest[] {
+    return this.sentPromptsDetailed.map((p) => p.req);
+  }
+
+  /** Back-compat shorthand used by older tests — question requests. */
+  get sentQuestions(): QuestionRequest[] {
+    return this.sentQuestionsDetailed.map((q) => q.req);
+  }
+
   async start(): Promise<void> {}
   async stop(): Promise<void> {}
 
-  async sendNotification(text: string): Promise<void> {
-    this.sentNotifications.push(text);
+  async sendNotification(text: string, ctx?: ChannelContext): Promise<void> {
+    this.sentNotificationsDetailed.push({ text, ctx });
   }
 
-  async sendPrompt(req: PromptRequest): Promise<void> {
+  async sendPrompt(req: PromptRequest, ctx?: ChannelContext): Promise<void> {
     if (this.throwOnSendPrompt) throw new Error('mock channel error');
-    this.sentPrompts.push(req);
+    this.sentPromptsDetailed.push({ req, ctx });
   }
 
-  async sendQuestion(req: QuestionRequest): Promise<{ sentMessageId: string }> {
+  async sendQuestion(
+    req: QuestionRequest,
+    ctx?: ChannelContext,
+  ): Promise<{ sentMessageId: string }> {
     if (this.throwOnSendQuestion) throw new Error('mock channel error');
-    this.sentQuestions.push(req);
+    this.sentQuestionsDetailed.push({ req, ctx });
     return { sentMessageId: String(this.nextSentMessageId++) };
   }
 

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -953,6 +953,176 @@ describe('inject-clients endpoints', () => {
   });
 });
 
+describe('forumMode topic context routing', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-topics-int-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeTranscript(name: string, lines: unknown[]): Promise<string> {
+    const file = path.join(tmpDir, name);
+    await fsp.writeFile(file, lines.map((l) => JSON.stringify(l)).join('\n'));
+    return file;
+  }
+
+  it('PreToolUse with cwd matching a registered CLI → sendPrompt ctx.slug = client slug', async () => {
+    const { ctx, channel, injectClients } = makeContext({ mode: 'away' });
+    injectClients.register({
+      slug: 'proj-a',
+      pid: 1,
+      cwd: '/x/proj-a',
+      localPort: 60000,
+      registeredAt: Date.now(),
+    });
+    const app = createServer(ctx);
+    const pending = request(app)
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-A',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        cwd: '/x/proj-a',
+      })
+      .then((r) => r);
+    await waitFor(() => channel.sentPromptsDetailed.length === 1);
+    expect(channel.sentPromptsDetailed[0].ctx).toEqual({ slug: 'proj-a' });
+    channel.emitDecision(channel.sentPromptsDetailed[0].req.requestId, { decision: 'allow' });
+    await pending;
+  });
+
+  it('PreToolUse inside an active sleep worktree → sendPrompt ctx isSleep + sleep slug', async () => {
+    const worktreePath = path.join(tmpDir, 'work', 'fix-bot-ux-abc123');
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
+      active: [
+        {
+          slug: 'fix-bot-ux-abc123',
+          branch: 'sleep/fix-bot-ux-abc123',
+          worktreePath,
+          startedAt: Date.now(),
+          expectedEndAt: Date.now() + 60_000,
+        },
+      ],
+      capacity: 3,
+    });
+    const app = createServer(ctx);
+    const pending = request(app)
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-S',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        cwd: worktreePath,
+      })
+      .then((r) => r);
+    await waitFor(() => channel.sentPromptsDetailed.length === 1);
+    expect(channel.sentPromptsDetailed[0].ctx).toEqual({
+      slug: 'fix-bot-ux-abc123',
+      isSleep: true,
+    });
+    channel.emitDecision(channel.sentPromptsDetailed[0].req.requestId, { decision: 'allow' });
+    await pending;
+  });
+
+  it('PreToolUse with no matching CLI / sleep → sendPrompt ctx falls back to sessionId', async () => {
+    const { ctx, channel } = makeContext({ mode: 'away' });
+    const app = createServer(ctx);
+    const pending = request(app)
+      .post('/v1/permission')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'PreToolUse',
+        session_id: 'a3f9b2c1-rest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        cwd: '/x/some-project',
+      })
+      .then((r) => r);
+    await waitFor(() => channel.sentPromptsDetailed.length === 1);
+    expect(channel.sentPromptsDetailed[0].ctx).toEqual({
+      sessionId: 'a3f9b2c1-rest',
+      cwdBasename: 'some-project',
+    });
+    channel.emitDecision(channel.sentPromptsDetailed[0].req.requestId, { decision: 'allow' });
+    await pending;
+  });
+
+  it('Notification (immediate, away mode) → sendNotification ctx matches the inject client slug', async () => {
+    const { ctx, channel, injectClients } = makeContext({ mode: 'away' });
+    injectClients.register({
+      slug: 'proj-b',
+      pid: 1,
+      cwd: '/x/proj-b',
+      localPort: 60001,
+      registeredAt: Date.now(),
+    });
+    const app = createServer(ctx);
+    await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        session_id: 'sess-N',
+        message: 'plain notice',
+        cwd: '/x/proj-b',
+      });
+    await waitFor(() => channel.sentNotificationsDetailed.length === 1);
+    expect(channel.sentNotificationsDetailed[0].ctx).toEqual({ slug: 'proj-b' });
+  });
+
+  it('Q&A reply pipeline tags every channel call with the same routing context', async () => {
+    const transcript = await writeTranscript('q.jsonl', [
+      { role: 'user', content: 'help' },
+      { role: 'assistant', content: 'pick A or B' },
+    ]);
+    const { ctx, channel, injectClients, pendingReplies } = makeContext({
+      mode: 'away',
+      inject: { enabled: true, strategy: 'pty', replyTimeoutMs: 60_000 },
+    });
+    injectClients.register({
+      slug: 'proj-q',
+      pid: 1,
+      cwd: '/x/proj-q',
+      // localPort 1 is unreachable — we expect the inject to fail, but the
+      // resulting "❌ Inject falhou" notification still gets the topic ctx.
+      localPort: 1,
+      registeredAt: Date.now(),
+    });
+    const app = createServer(ctx);
+    await request(app)
+      .post('/v1/notify')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({
+        hook_event_name: 'Notification',
+        session_id: 'sess-Q',
+        message: 'Claude is waiting for your input',
+        cwd: '/x/proj-q',
+        transcript_path: transcript,
+      });
+    await waitFor(() => channel.sentQuestionsDetailed.length === 1);
+    expect(channel.sentQuestionsDetailed[0].ctx).toEqual({ slug: 'proj-q' });
+    await waitFor(() => pendingReplies.size() === 1);
+    channel.emitFreeText('A', '1000');
+    await waitFor(
+      () => channel.sentNotificationsDetailed.some((n) => n.text.startsWith('❌ Inject falhou')),
+      5000,
+    );
+    const failNotif = channel.sentNotificationsDetailed.find((n) =>
+      n.text.startsWith('❌ Inject falhou'),
+    )!;
+    expect(failNotif.ctx).toEqual({ slug: 'proj-q' });
+  });
+
+});
+
 describe('Q&A flow (PTY inject)', () => {
   let tmpDir: string;
 

--- a/test/unit/forumValidation.test.ts
+++ b/test/unit/forumValidation.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { validateBotPermissions } from '../../src/channels/telegram/forumValidation.js';
+
+interface MemberShape {
+  status: string;
+  can_manage_topics?: boolean;
+}
+
+function fakeApi(opts: {
+  me?: { id: number };
+  meErr?: Error;
+  member?: MemberShape;
+  memberErr?: Error;
+}) {
+  return {
+    async getMe(): Promise<{ id: number }> {
+      if (opts.meErr) throw opts.meErr;
+      return opts.me ?? { id: 42 };
+    },
+    async getChatMember(): Promise<MemberShape> {
+      if (opts.memberErr) throw opts.memberErr;
+      return opts.member ?? { status: 'administrator', can_manage_topics: true };
+    },
+  };
+}
+
+describe('validateBotPermissions', () => {
+  it('resolves when bot is admin with can_manage_topics', async () => {
+    const api = fakeApi({});
+    await expect(validateBotPermissions(api, -100123)).resolves.toBeUndefined();
+  });
+
+  it('throws when status is not administrator', async () => {
+    const api = fakeApi({ member: { status: 'member' } });
+    await expect(validateBotPermissions(api, -100123)).rejects.toThrow(
+      /not.*administrator|administrator.*chat/i,
+    );
+  });
+
+  it('throws when admin but missing can_manage_topics', async () => {
+    const api = fakeApi({ member: { status: 'administrator', can_manage_topics: false } });
+    await expect(validateBotPermissions(api, -100123)).rejects.toThrow(
+      /can_manage_topics|Manage Topics/i,
+    );
+  });
+
+  it('throws when admin but can_manage_topics field is missing entirely', async () => {
+    const api = fakeApi({ member: { status: 'administrator' } });
+    await expect(validateBotPermissions(api, -100123)).rejects.toThrow(/Manage Topics/i);
+  });
+
+  it('wraps getMe errors with context', async () => {
+    const api = fakeApi({ meErr: new Error('connect ECONNREFUSED') });
+    await expect(validateBotPermissions(api, -100123)).rejects.toThrow(
+      /getMe error.*ECONNREFUSED/,
+    );
+  });
+
+  it('wraps getChatMember errors with context', async () => {
+    const api = fakeApi({ memberErr: new Error('chat not found') });
+    await expect(validateBotPermissions(api, -100123)).rejects.toThrow(
+      /getChatMember error.*chat not found/,
+    );
+  });
+});

--- a/test/unit/forumValidation.test.ts
+++ b/test/unit/forumValidation.test.ts
@@ -49,6 +49,19 @@ describe('validateBotPermissions', () => {
     await expect(validateBotPermissions(api, -100123)).rejects.toThrow(/Manage Topics/i);
   });
 
+  it('resolves when bot is the group creator (creator implies all permissions)', async () => {
+    // creator = group owner. Per Telegram API, the owner has implicit
+    // can_manage_topics regardless of the field's presence.
+    const api = fakeApi({ member: { status: 'creator' } });
+    await expect(validateBotPermissions(api, -100123)).resolves.toBeUndefined();
+  });
+
+  it('resolves when bot is creator even with can_manage_topics: false', async () => {
+    // Creator's can_manage_topics flag is irrelevant; ownership grants the capability.
+    const api = fakeApi({ member: { status: 'creator', can_manage_topics: false } });
+    await expect(validateBotPermissions(api, -100123)).resolves.toBeUndefined();
+  });
+
   it('wraps getMe errors with context', async () => {
     const api = fakeApi({ meErr: new Error('connect ECONNREFUSED') });
     await expect(validateBotPermissions(api, -100123)).rejects.toThrow(

--- a/test/unit/sleepFinish.test.ts
+++ b/test/unit/sleepFinish.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { finishSleep, type FinishDeps } from '../../src/daemon/sleepFinish.js';
 import type { SleepingSession } from '../../src/daemon/sleeping.js';
+import type { ChannelContext } from '../../src/channels/Channel.js';
 
 const SESSION: SleepingSession = {
   slug: 'add-feature-x',
@@ -12,8 +13,19 @@ const SESSION: SleepingSession = {
   repo: '/tmp/repo',
 };
 
-function makeDeps(prUrl = 'https://github.com/x/y/pull/42'): { deps: FinishDeps; calls: { exec: Array<{ cmd: string; args: string[]; cwd?: string }>; notify: string[] } } {
-  const calls = { exec: [] as Array<{ cmd: string; args: string[]; cwd?: string }>, notify: [] as string[] };
+function makeDeps(prUrl = 'https://github.com/x/y/pull/42'): {
+  deps: FinishDeps;
+  calls: {
+    exec: Array<{ cmd: string; args: string[]; cwd?: string }>;
+    notify: string[];
+    notifyCtxs: (ChannelContext | undefined)[];
+  };
+} {
+  const calls = {
+    exec: [] as Array<{ cmd: string; args: string[]; cwd?: string }>,
+    notify: [] as string[],
+    notifyCtxs: [] as (ChannelContext | undefined)[],
+  };
   const deps: FinishDeps = {
     exec: vi.fn(async (cmd, args, opts) => {
       calls.exec.push({ cmd, args, cwd: opts?.cwd });
@@ -25,7 +37,10 @@ function makeDeps(prUrl = 'https://github.com/x/y/pull/42'): { deps: FinishDeps;
       }
       return { code: 0, stdout: '', stderr: '' };
     }),
-    notify: vi.fn(async (msg) => { calls.notify.push(msg); }),
+    notify: vi.fn(async (msg, ctx) => {
+      calls.notify.push(msg);
+      calls.notifyCtxs.push(ctx);
+    }),
   };
   return { deps, calls };
 }
@@ -138,6 +153,20 @@ describe('finishSleep', () => {
     await finishSleep(SESSION, deps);
     expect(calls.notify).toHaveLength(1);
     expect(calls.notify[0]).toContain('https://github.com/x/y/pull/42');
+  });
+
+  it('routes notify with the sleep slug + isSleep ctx on success and on failure', async () => {
+    const { deps, calls } = makeDeps();
+    await finishSleep(SESSION, deps);
+    expect(calls.notifyCtxs).toEqual([{ slug: SESSION.slug, isSleep: true }]);
+
+    const failed = makeDeps();
+    failed.deps.exec = vi.fn(async (cmd) => {
+      if (cmd === 'git') return { code: 1, stdout: '', stderr: 'no upstream' };
+      return { code: 0, stdout: '', stderr: '' };
+    });
+    await finishSleep(SESSION, failed.deps);
+    expect(failed.calls.notifyCtxs).toEqual([{ slug: SESSION.slug, isSleep: true }]);
   });
 
   it('uses the default branch from gh repo view', async () => {

--- a/test/unit/sleeping.test.ts
+++ b/test/unit/sleeping.test.ts
@@ -6,6 +6,7 @@ import {
   type SpawnFn,
 } from '../../src/daemon/sleeping.js';
 import { GamingState } from '../../src/daemon/gaming.js';
+import type { ChannelContext } from '../../src/channels/Channel.js';
 
 class FakeChild extends EventEmitter {
   killed = false;
@@ -23,6 +24,7 @@ interface DepsState {
   /** All spawned children, in spawn order. Index by start order for multi-session tests. */
   children: FakeChild[];
   notifications: string[];
+  notificationCtxs: (ChannelContext | undefined)[];
   audits: unknown[];
   worktreesCreated: { repo: string; branch: string; dir: string }[];
   worktreeRemoved: string[];
@@ -32,6 +34,7 @@ function makeDeps(opts: { maxConcurrent?: number } = {}): { deps: SleepingDeps; 
   const state: DepsState = {
     children: [],
     notifications: [],
+    notificationCtxs: [],
     audits: [],
     worktreesCreated: [],
     worktreeRemoved: [],
@@ -45,8 +48,9 @@ function makeDeps(opts: { maxConcurrent?: number } = {}): { deps: SleepingDeps; 
   const deps: SleepingDeps = {
     spawn: spawnFn,
     gaming: new GamingState(),
-    notify: async (msg) => {
+    notify: async (msg, ctx) => {
       state.notifications.push(msg);
+      state.notificationCtxs.push(ctx);
     },
     audit: async (e) => {
       state.audits.push(e);
@@ -334,5 +338,55 @@ describe('SleepingOrchestrator', () => {
     const remaining = (snap.until ?? 0) - Date.now();
     expect(remaining).toBeGreaterThan(700);
     expect(remaining).toBeLessThan(900);
+  });
+
+  it('forwards isSleep ctx to notify on start, cancel, timeout, and failure', async () => {
+    const { deps, state } = makeDeps();
+    const orch = new SleepingOrchestrator(deps);
+    const session = await orch.start({
+      repo: '/x',
+      prompt: 'p',
+      workRoot: '/y',
+      maxDurationMs: 60_000,
+    });
+    expect(state.notifications[0]).toContain('sleep started');
+    expect(state.notificationCtxs[0]).toEqual({ slug: session.slug, isSleep: true });
+
+    // Cancel
+    const cancelP = orch.cancel({ slug: session.slug });
+    await vi.advanceTimersByTimeAsync(0);
+    await cancelP;
+    expect(state.notifications.some((n) => n.includes('cancelled'))).toBe(true);
+    const cancelIdx = state.notifications.findIndex((n) => n.includes('cancelled'));
+    expect(state.notificationCtxs[cancelIdx]).toEqual({ slug: session.slug, isSleep: true });
+
+    // Failure (non-zero exit)
+    const session2 = await orch.start({
+      repo: '/x',
+      prompt: 'p2',
+      workRoot: '/y',
+      maxDurationMs: 60_000,
+    });
+    state.child!.emit('exit', 1, null);
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    const failIdx = state.notifications.findIndex((n) => n.includes('failed'));
+    expect(failIdx).toBeGreaterThanOrEqual(0);
+    expect(state.notificationCtxs[failIdx]).toEqual({ slug: session2.slug, isSleep: true });
+  });
+
+  it('forwards isSleep ctx to notify on max-duration timeout', async () => {
+    const { deps, state } = makeDeps();
+    const orch = new SleepingOrchestrator(deps);
+    const session = await orch.start({
+      repo: '/x',
+      prompt: 'p',
+      workRoot: '/y',
+      maxDurationMs: 100,
+    });
+    vi.advanceTimersByTime(150);
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    const tmIdx = state.notifications.findIndex((n) => n.includes('timed out'));
+    expect(tmIdx).toBeGreaterThanOrEqual(0);
+    expect(state.notificationCtxs[tmIdx]).toEqual({ slug: session.slug, isSleep: true });
   });
 });

--- a/test/unit/telegramApi.test.ts
+++ b/test/unit/telegramApi.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TelegramApi, isThreadNotFoundError } from '../../src/channels/telegram/api.js';
+
+interface CapturedRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+function captureFetch(responder: (req: CapturedRequest) => Response | Promise<Response>): {
+  calls: CapturedRequest[];
+  restore: () => void;
+} {
+  const calls: CapturedRequest[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const req = { url: typeof input === 'string' ? input : input.toString(), init };
+    calls.push(req);
+    return responder(req);
+  }) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('TelegramApi.sendMessage', () => {
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it('includes message_thread_id when messageThreadId is provided', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true, result: { message_id: 7 } }));
+    restore = cap.restore;
+    const api = new TelegramApi('TKN');
+    const id = await api.sendMessage(123, 'hi', { messageThreadId: 42 });
+    expect(id).toBe(7);
+    expect(cap.calls).toHaveLength(1);
+    const body = JSON.parse(String(cap.calls[0].init?.body));
+    expect(body.message_thread_id).toBe(42);
+    expect(body.chat_id).toBe(123);
+    expect(body.text).toBe('hi');
+  });
+
+  it('omits message_thread_id when messageThreadId is undefined', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true, result: { message_id: 7 } }));
+    restore = cap.restore;
+    const api = new TelegramApi('TKN');
+    await api.sendMessage(123, 'hi');
+    const body = JSON.parse(String(cap.calls[0].init?.body));
+    expect('message_thread_id' in body).toBe(false);
+  });
+
+  it('throws ChannelError including telegram description on 4xx', async () => {
+    const cap = captureFetch(() =>
+      jsonResponse({ ok: false, description: 'Bad Request: message thread not found' }, 400),
+    );
+    restore = cap.restore;
+    const api = new TelegramApi('TKN');
+    await expect(api.sendMessage(123, 'hi', { messageThreadId: 99 })).rejects.toThrow(
+      /message thread not found/,
+    );
+  });
+});
+
+describe('TelegramApi.createForumTopic', () => {
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it('returns message_thread_id from result', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true, result: { message_thread_id: 99 } }));
+    restore = cap.restore;
+    const api = new TelegramApi('TKN');
+    const id = await api.createForumTopic(-100123, 'fix-bot-ux');
+    expect(id).toBe(99);
+    const body = JSON.parse(String(cap.calls[0].init?.body));
+    expect(body).toEqual({ chat_id: -100123, name: 'fix-bot-ux' });
+  });
+
+  it('throws on telegram error', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: false, description: 'CHAT_NOT_FOUND' }, 400));
+    restore = cap.restore;
+    const api = new TelegramApi('TKN');
+    await expect(api.createForumTopic(-1, 'x')).rejects.toThrow(/CHAT_NOT_FOUND/);
+  });
+});
+
+describe('TelegramApi.getMe', () => {
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it('returns the bot id', async () => {
+    const cap = captureFetch(() =>
+      jsonResponse({ ok: true, result: { id: 12345, is_bot: true, username: 'bot' } }),
+    );
+    restore = cap.restore;
+    const api = new TelegramApi('TKN');
+    const me = await api.getMe();
+    expect(me).toEqual({ id: 12345 });
+  });
+});
+
+describe('TelegramApi.getChatMember', () => {
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it('returns status and can_manage_topics', async () => {
+    const cap = captureFetch(() =>
+      jsonResponse({
+        ok: true,
+        result: { status: 'administrator', can_manage_topics: true },
+      }),
+    );
+    restore = cap.restore;
+    const api = new TelegramApi('TKN');
+    const member = await api.getChatMember(-100, 42);
+    expect(member.status).toBe('administrator');
+    expect(member.can_manage_topics).toBe(true);
+    const body = JSON.parse(String(cap.calls[0].init?.body));
+    expect(body).toEqual({ chat_id: -100, user_id: 42 });
+  });
+});
+
+describe('isThreadNotFoundError', () => {
+  it('matches the telegram description case-insensitively', () => {
+    expect(isThreadNotFoundError(new Error('telegram: Bad Request: MESSAGE THREAD NOT FOUND'))).toBe(true);
+    expect(isThreadNotFoundError(new Error('telegram: message thread not found'))).toBe(true);
+  });
+
+  it('returns false for other errors', () => {
+    expect(isThreadNotFoundError(new Error('something else'))).toBe(false);
+    expect(isThreadNotFoundError('not an error')).toBe(false);
+    expect(isThreadNotFoundError(undefined)).toBe(false);
+  });
+});

--- a/test/unit/telegramChannel.test.ts
+++ b/test/unit/telegramChannel.test.ts
@@ -1,15 +1,36 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
 import { TelegramChannel } from '../../src/channels/telegram/TelegramChannel.js';
+import { TopicManager } from '../../src/channels/telegram/topics.js';
 import type { Decision } from '../../src/core/types.js';
 import { noopLogger } from '../helpers/mockChannel.js';
 
 class FakeApi {
-  public messages: Array<{ chatId: number; text: string; keyboard?: unknown }> = [];
+  public messages: Array<{
+    chatId: number;
+    text: string;
+    opts?: { messageThreadId?: number; keyboard?: unknown; forceReply?: boolean };
+  }> = [];
   public callbacksAnswered: string[] = [];
   public editKeyboardCalls: Array<{ messageId: number; keyboard: unknown }> = [];
+  public createTopicCalls: Array<{ chatId: number; name: string }> = [];
   private nextMessageId = 100;
-  async sendMessage(chatId: number, text: string, keyboard?: unknown): Promise<number> {
-    this.messages.push({ chatId, text, keyboard });
+  private nextThreadId = 200;
+  /** Per-call programmable error: pop the next error before each sendMessage. */
+  public sendErrors: Error[] = [];
+
+  async sendMessage(
+    chatId: number,
+    text: string,
+    opts?: { messageThreadId?: number; keyboard?: unknown; forceReply?: boolean },
+  ): Promise<number> {
+    if (this.sendErrors.length > 0) {
+      const e = this.sendErrors.shift()!;
+      throw e;
+    }
+    this.messages.push({ chatId, text, opts });
     return this.nextMessageId++;
   }
   async answerCallbackQuery(id: string): Promise<void> {
@@ -17,6 +38,10 @@ class FakeApi {
   }
   async editMessageReplyMarkup(_chat: number, messageId: number, keyboard: unknown): Promise<void> {
     this.editKeyboardCalls.push({ messageId, keyboard });
+  }
+  async createForumTopic(chatId: number, name: string): Promise<number> {
+    this.createTopicCalls.push({ chatId, name });
+    return this.nextThreadId++;
   }
   async getUpdates(): Promise<never[]> { return []; }
 }
@@ -98,5 +123,93 @@ describe('TelegramChannel callbacks', () => {
     text('hello');
     expect(decisions).toEqual([]);
     expect(free).toEqual(['hello']);
+  });
+});
+
+describe('TelegramChannel topic routing', () => {
+  let api: FakeApi;
+  let dir: string;
+  let storagePath: string;
+
+  beforeEach(async () => {
+    api = new FakeApi();
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-tg-channel-'));
+    storagePath = path.join(dir, 'topics.json');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+
+  function makeChannelWithTm(forumMode: boolean): TelegramChannel {
+    const tm = new TopicManager({
+      api,
+      chatId: -100123,
+      forumMode,
+      storagePath,
+      logger: noopLogger,
+    });
+    const ch = new TelegramChannel({
+      token: 't',
+      chatId: -100123,
+      logger: noopLogger,
+      topicManager: tm,
+    });
+    (ch as unknown as { api: unknown }).api = api;
+    return ch;
+  }
+
+  it('forumMode off: sendNotification omits message_thread_id', async () => {
+    const ch = makeChannelWithTm(false);
+    await ch.sendNotification('hi', { slug: 'fix-bot-ux' });
+    expect(api.messages).toHaveLength(1);
+    expect(api.messages[0].opts?.messageThreadId).toBeUndefined();
+    expect(api.createTopicCalls).toHaveLength(0);
+  });
+
+  it('forumMode on: first send creates topic, second send same key reuses it', async () => {
+    const ch = makeChannelWithTm(true);
+    await ch.sendNotification('first', { slug: 'fix-bot-ux' });
+    await ch.sendNotification('second', { slug: 'fix-bot-ux' });
+    expect(api.createTopicCalls).toEqual([{ chatId: -100123, name: 'fix-bot-ux' }]);
+    expect(api.messages).toHaveLength(2);
+    expect(api.messages[0].opts?.messageThreadId).toBe(200);
+    expect(api.messages[1].opts?.messageThreadId).toBe(200);
+  });
+
+  it('forumMode on: sleep slug → topic name uses 💤 prefix and stripped suffix', async () => {
+    const ch = makeChannelWithTm(true);
+    await ch.sendNotification('💤', { slug: 'fix-bot-ux-abc123', isSleep: true });
+    expect(api.createTopicCalls).toEqual([{ chatId: -100123, name: '💤 fix-bot-ux' }]);
+  });
+
+  it('forumMode on: missing context → kuroboto-system topic', async () => {
+    const ch = makeChannelWithTm(true);
+    await ch.sendNotification('hi');
+    expect(api.createTopicCalls).toEqual([{ chatId: -100123, name: 'kuroboto-system' }]);
+  });
+
+  it('forumMode on: thread-not-found → purge and recreate', async () => {
+    const ch = makeChannelWithTm(true);
+    // First send creates topic 200
+    await ch.sendNotification('warmup', { slug: 'fix-bot-ux' });
+    // Next send: api fails with thread-not-found, channel should purge and retry
+    api.sendErrors.push(new Error('telegram: Bad Request: message thread not found'));
+    await ch.sendNotification('after-delete', { slug: 'fix-bot-ux' });
+    expect(api.createTopicCalls).toHaveLength(2);
+    expect(api.createTopicCalls[0].name).toBe('fix-bot-ux');
+    expect(api.createTopicCalls[1].name).toBe('fix-bot-ux');
+    // Final message used the new thread id
+    expect(api.messages[api.messages.length - 1].opts?.messageThreadId).toBe(201);
+  });
+
+  it('forumMode on: createForumTopic failure → message goes to main chat (no thread id)', async () => {
+    api.createForumTopic = async () => {
+      throw new Error('rate limited');
+    };
+    const ch = makeChannelWithTm(true);
+    await ch.sendNotification('hi', { slug: 'fix-bot-ux' });
+    expect(api.messages).toHaveLength(1);
+    expect(api.messages[0].opts?.messageThreadId).toBeUndefined();
   });
 });

--- a/test/unit/topicContext.test.ts
+++ b/test/unit/topicContext.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  topicContextFromHook,
+  topicContextForSleep,
+  topicContextSystem,
+} from '../../src/daemon/topicContext.js';
+import { InjectClients } from '../../src/daemon/injectClients.js';
+import { pickTopicKey } from '../../src/channels/telegram/topics.js';
+
+function emptySleep() {
+  return { active: [], capacity: 3 };
+}
+
+describe('topicContextFromHook', () => {
+  it('matches an active sleep worktree → isSleep + sleep slug', () => {
+    const ctx = topicContextFromHook(
+      { cwd: '/tmp/work/fix-bot-ux-abc123', session_id: 's' },
+      {
+        injectClients: new InjectClients(),
+        sleepingSnap: {
+          active: [
+            {
+              slug: 'fix-bot-ux-abc123',
+              branch: 'sleep/fix-bot-ux-abc123',
+              worktreePath: '/tmp/work/fix-bot-ux-abc123',
+              startedAt: 0,
+              expectedEndAt: 0,
+            },
+          ],
+          capacity: 3,
+        },
+      },
+    );
+    expect(ctx).toEqual({ slug: 'fix-bot-ux-abc123', isSleep: true });
+    expect(pickTopicKey(ctx).name).toBe('💤 fix-bot-ux');
+  });
+
+  it('uses bound CLI client slug when session is bound', () => {
+    const clients = new InjectClients();
+    clients.register({ slug: 'proj-a', pid: 1, cwd: '/x/proj-a', localPort: 5000, registeredAt: 0 });
+    clients.bindSessionToSlug('sess-1', 'proj-a');
+    const ctx = topicContextFromHook(
+      { cwd: '/elsewhere', session_id: 'sess-1' },
+      { injectClients: clients, sleepingSnap: emptySleep() },
+    );
+    expect(ctx).toEqual({ slug: 'proj-a' });
+  });
+
+  it('late-binds via cwd match when session is not yet bound', () => {
+    const clients = new InjectClients();
+    clients.register({ slug: 'proj-b', pid: 1, cwd: '/x/proj-b', localPort: 5001, registeredAt: 0 });
+    const ctx = topicContextFromHook(
+      { cwd: '/x/proj-b', session_id: 'sess-fresh' },
+      { injectClients: clients, sleepingSnap: emptySleep() },
+    );
+    expect(ctx).toEqual({ slug: 'proj-b' });
+  });
+
+  it('falls back to bare session_id with cwd basename when no slug found', () => {
+    const ctx = topicContextFromHook(
+      { cwd: '/some/path/kuroboto', session_id: 'a3f9b2c1-rest' },
+      { injectClients: new InjectClients(), sleepingSnap: emptySleep() },
+    );
+    expect(ctx).toEqual({ sessionId: 'a3f9b2c1-rest', cwdBasename: 'kuroboto' });
+    expect(pickTopicKey(ctx).name).toBe('kuroboto-a3f9b2c1');
+  });
+
+  it('drops basename when cwd is missing', () => {
+    const ctx = topicContextFromHook(
+      { session_id: 'a3f9b2c1-rest' },
+      { injectClients: new InjectClients(), sleepingSnap: emptySleep() },
+    );
+    expect(ctx).toEqual({ sessionId: 'a3f9b2c1-rest', cwdBasename: undefined });
+  });
+});
+
+describe('topicContextForSleep / topicContextSystem', () => {
+  it('sleep returns slug + isSleep', () => {
+    expect(topicContextForSleep('s-abc123')).toEqual({ slug: 's-abc123', isSleep: true });
+  });
+
+  it('system returns { system: true }', () => {
+    expect(topicContextSystem()).toEqual({ system: true });
+  });
+});
+
+describe('pickTopicKey', () => {
+  it('strips suffix from sleep topic name', () => {
+    expect(pickTopicKey({ slug: 'foo-bar-abc123', isSleep: true })).toEqual({
+      key: 'foo-bar-abc123',
+      name: '💤 foo-bar',
+    });
+  });
+
+  it('uses slug as both key and name for client slugs', () => {
+    expect(pickTopicKey({ slug: 'fix-bot-ux' })).toEqual({
+      key: 'fix-bot-ux',
+      name: 'fix-bot-ux',
+    });
+  });
+
+  it('falls back to system topic when nothing identifies the source', () => {
+    expect(pickTopicKey(undefined)).toEqual({
+      key: 'kuroboto-system',
+      name: 'kuroboto-system',
+    });
+    expect(pickTopicKey({})).toEqual({
+      key: 'kuroboto-system',
+      name: 'kuroboto-system',
+    });
+  });
+
+  it('explicit system flag wins regardless of other fields', () => {
+    expect(pickTopicKey({ system: true, slug: 'x' })).toEqual({
+      key: 'kuroboto-system',
+      name: 'kuroboto-system',
+    });
+  });
+});

--- a/test/unit/topics.test.ts
+++ b/test/unit/topics.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { TopicManager, type TopicAuditEvent } from '../../src/channels/telegram/topics.js';
+import { noopLogger } from '../helpers/mockChannel.js';
+
+class FakeApi {
+  public calls: Array<{ chatId: number; name: string }> = [];
+  public nextId = 100;
+  public failNext: Error | null = null;
+
+  async createForumTopic(chatId: number, name: string): Promise<number> {
+    this.calls.push({ chatId, name });
+    if (this.failNext) {
+      const e = this.failNext;
+      this.failNext = null;
+      throw e;
+    }
+    return this.nextId++;
+  }
+}
+
+describe('TopicManager', () => {
+  let dir: string;
+  let storagePath: string;
+  let api: FakeApi;
+  let auditEvents: TopicAuditEvent[];
+
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-topics-'));
+    storagePath = path.join(dir, 'topics.json');
+    api = new FakeApi();
+    auditEvents = [];
+  });
+
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+
+  function make(forumMode = true): TopicManager {
+    return new TopicManager({
+      api,
+      chatId: -100123,
+      forumMode,
+      storagePath,
+      logger: noopLogger,
+      audit: (e) => auditEvents.push(e),
+    });
+  }
+
+  it('first resolve creates topic, persists to disk, returns thread id', async () => {
+    const tm = make();
+    const id = await tm.resolve('fix-bot-ux', 'fix-bot-ux');
+    expect(id).toBe(100);
+    expect(api.calls).toEqual([{ chatId: -100123, name: 'fix-bot-ux' }]);
+    const persisted = JSON.parse(await fsp.readFile(storagePath, 'utf-8'));
+    expect(persisted).toEqual({ 'fix-bot-ux': 100 });
+    expect(auditEvents).toEqual([
+      { source: 'topic-created', key: 'fix-bot-ux', name: 'fix-bot-ux', threadId: 100 },
+    ]);
+  });
+
+  it('second resolve same key is a cache hit (no api call)', async () => {
+    const tm = make();
+    await tm.resolve('fix-bot-ux', 'fix-bot-ux');
+    const id = await tm.resolve('fix-bot-ux', 'fix-bot-ux');
+    expect(id).toBe(100);
+    expect(api.calls).toHaveLength(1);
+  });
+
+  it('concurrent resolves for the same key share one createForumTopic call', async () => {
+    const tm = make();
+    const [a, b, c] = await Promise.all([
+      tm.resolve('k', 'k'),
+      tm.resolve('k', 'k'),
+      tm.resolve('k', 'k'),
+    ]);
+    expect(a).toBe(100);
+    expect(b).toBe(100);
+    expect(c).toBe(100);
+    expect(api.calls).toHaveLength(1);
+  });
+
+  it('returns undefined and skips api call when forumMode is false', async () => {
+    const tm = make(false);
+    const id = await tm.resolve('x', 'x');
+    expect(id).toBeUndefined();
+    expect(api.calls).toHaveLength(0);
+    expect(auditEvents).toEqual([]);
+  });
+
+  it('createForumTopic failure → undefined, no cache, no disk write, audit failed', async () => {
+    api.failNext = new Error('rate limited');
+    const tm = make();
+    const id = await tm.resolve('k', 'k');
+    expect(id).toBeUndefined();
+    await expect(fsp.access(storagePath)).rejects.toThrow();
+    expect(auditEvents).toEqual([
+      { source: 'topic-create-failed', key: 'k', name: 'k', error: 'rate limited' },
+    ]);
+    // Next resolve retries (failure didn't poison cache)
+    const id2 = await tm.resolve('k', 'k');
+    expect(id2).toBe(100);
+  });
+
+  it('purge removes from cache and disk, fires audit', async () => {
+    const tm = make();
+    await tm.resolve('a', 'a');
+    await tm.resolve('b', 'b');
+    auditEvents.length = 0;
+    await tm.purge('a');
+    expect(auditEvents).toEqual([{ source: 'topic-purged', key: 'a' }]);
+    const persisted = JSON.parse(await fsp.readFile(storagePath, 'utf-8'));
+    expect(persisted).toEqual({ b: 101 });
+  });
+
+  it('purge of unknown key is a no-op (no audit, no rewrite)', async () => {
+    const tm = make();
+    await tm.resolve('a', 'a');
+    auditEvents.length = 0;
+    const beforeWrite = (await fsp.stat(storagePath)).mtimeMs;
+    await new Promise((r) => setTimeout(r, 5));
+    await tm.purge('does-not-exist');
+    expect(auditEvents).toEqual([]);
+    expect((await fsp.stat(storagePath)).mtimeMs).toBe(beforeWrite);
+  });
+
+  it('loadFromDisk with malformed json starts empty (no throw)', async () => {
+    await fsp.writeFile(storagePath, '{not valid');
+    const tm = make();
+    const id = await tm.resolve('k', 'k');
+    // Cache started empty, so resolve creates a new topic
+    expect(id).toBe(100);
+    expect(api.calls).toHaveLength(1);
+  });
+
+  it('loadFromDisk with non-object json starts empty', async () => {
+    await fsp.writeFile(storagePath, '"unexpected"');
+    const tm = make();
+    const id = await tm.resolve('k', 'k');
+    expect(id).toBe(100);
+  });
+
+  it('loadFromDisk filters out non-numeric values', async () => {
+    await fsp.writeFile(storagePath, JSON.stringify({ ok: 42, bad: 'string' }));
+    const tm = make();
+    const ok = await tm.resolve('ok', 'ok');
+    expect(ok).toBe(42);
+    expect(api.calls).toHaveLength(0);
+    const bad = await tm.resolve('bad', 'bad');
+    expect(bad).toBe(100);
+    expect(api.calls).toHaveLength(1);
+  });
+
+  it('loadFromDisk picks up entries written by a previous run', async () => {
+    await fsp.writeFile(storagePath, JSON.stringify({ 'pre-existing': 7 }));
+    const tm = make();
+    const id = await tm.resolve('pre-existing', 'pre-existing');
+    expect(id).toBe(7);
+    expect(api.calls).toHaveLength(0);
+  });
+
+  it('flushToDisk failure is logged but cache survives in memory', async () => {
+    const writeSpy = vi.spyOn(fsp, 'writeFile').mockRejectedValueOnce(new Error('disk full'));
+    const tm = make();
+    const id = await tm.resolve('k', 'k');
+    expect(id).toBe(100);
+    expect(writeSpy).toHaveBeenCalled();
+    // Subsequent resolve still hits cache despite the persist failure
+    const id2 = await tm.resolve('k', 'k');
+    expect(id2).toBe(100);
+    expect(api.calls).toHaveLength(1);
+    writeSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation via `kuroboto sleeping` (sleep mode).

## Original prompt

```
Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.

# Telegram supergroup + topics (one topic per session)

> Status: planned. Spec F. Pinned in backlog since the original UX overhaul series; promoted to formal spec because parallel Spec E sessions and multi-machine workflow make a flat DM chat increasingly noisy.

## Problem

Today the bot lives in a 1:1 DM with the user. Every kuroboto event (permission prompt, Q&A reply, gaming FYI, sleep start/done, desktop fallback, daemon errors) lands in the same flat scroll. With multiple Claude sessions running in parallel — different repos, different machines, sleep + interactive concurrently — messages from unrelated sessions interleave and the user has to mentally re-thread by reading headers.

The pinned fix has been: move from DM to a **private supergroup** (only the user in it) with **forum mode** enabled, and create one topic per session. Each session gets its own thread, scroll, name, and notification setting. Cross-session interleaving disappears at the chat-level instead of the user's head.

This unlocks naturally:
- **Multi-claude visual organization** — no more `[host / folder / "..."]` decoding to know who's asking
- **Per-session notification control** — mute the topic of a long-running sleep that spams commits
- **Closed/archived sessions** stay browsable as separate threads instead of disappearing into the scroll
- **Better foundation for multi-machine** — when the user runs kuroboto on both mac and Windows, both can post to the same supergroup with topics keyed by hostname-prefixed slug

This spec is independent of (but informed by) Spec E (PTY injection): both center on the **slug** identity that lets us route messages cleanly per session.

## Solution

Extend the existing `telegram` channel type with `forumMode: true`. When enabled, the daemon:

- Creates one topic per logical session, keyed by slug (Spec E client slug, sleep slug, or fallback chain)
- Routes every outbound message through `resolveTopic(payload)` to find/create the right topic and stamp `message_thread_id` on the API call
- Sends system events (daemon lifecycle, errors) to a dedicated `kuroboto-system` topic
- Validates bot permissions (`can_manage_topics`) on startup; refuses to start if missing
- Persists `slug → message_thread_id` mapping in `~/.config/kuroboto/topics.json` so daemon restarts don't recreate topics

DM mode (current default) is preserved — `forumMode` is opt-in. Existing users see no behavior change unless they migrate.

## Topic key resolution

For each outbound message, the daemon picks a topic key in this order:

| Source | Topic key | Topic name when created |
|---|---|---|
| Spec E client slug (interactive `kuroboto claude`) | the slug | `<slug>` (e.g., `fix-bot-ux`) |
| Spec E client slug + tmux mode | the slug | `<slug>` |
| Sleep mode slug | sleep slug | `💤 <slug-no-suffix>` (e.g., `💤 desktop-notifications`) |
| Direct `claude` (no kuroboto wrapper) | `session_id` | `<cwd-basename>-<sid8>` (e.g., `kuroboto-a3f9b2c1`) |
| System events (no session) | hardcoded `kuroboto-system` | `kuroboto-system` |

Lookup happens in `~/.config/kuroboto/topics.json` first; on miss, daemon calls `createForumTopic` and persists the result.

## Architecture

```
+-------------+    +--------------------+    +-------------------+
|  hook /     |    | resolveTopic(p):   |    | TelegramChannel   |
|  CLI route  +--->| - pick key         +--->| sendMessage(...   |
|             |    | - lookup map       |    |   message_thread_ |
|             |    | - createTopic if   |    |   id: id          |
|             |    |   miss + persist   |    |                   |
+-------------+    +--------------------+    +-------------------+
                          |
                          v
                  ~/.config/kuroboto/topics.json
                  { "fix-bot-ux": 42, "💤 ...": 127, "kuroboto-system": 1 }
```

## Files

**Create:**
- `src/channels/telegram/topics.ts` — `class TopicManager`. Methods: `resolve(key, name): Promise<message_thread_id>`, `purge(key)`, `loadFromDisk()`, `flushToDisk()`. In-memory cache + on-disk persistence to `topics.json`.
- `src/channels/telegram/forumValidation.ts` — `validateBotPermissions(api, chatId): Promise<void>`. Calls `getChatMember` for the bot's own ID; throws clear error if not admin or missing `can_manage_topics`.
- `test/unit/topics.test.ts` — TopicManager: cache hit, cache miss → create + persist, persist failure handling, purge.
- `test/unit/forumValidation.test.ts` — mock api responses for "not admin", "missing manage_topics", "ok".

**Modify:**
- `src/config/schema.ts` — extend telegram channel with optional `forumMode: z.boolean().default(false)`.
- `src/channels/telegram/api.ts` — `sendMessage`, `sendPrompt`, `sendQuestion` accept optional `messageThreadId: number` and pass it as `message_thread_id` body field on Telegram requests. New wrappers: `createForumTopic(chatId, name)` and `getChatMember(chatId, userId)`.
- `src/channels/telegram/TelegramChannel.ts` — every outbound call routes through `topicManager.resolve(key, name)` to get the thread id, then calls api with it. Adds a `bindContext({ slug?, sessionId?, cwd? })` context that callers populate so the channel can pick the right key. On `forumMode: false`, all this is a no-op (passes `undefined` for threadId, behavior is current DM mode).
- `src/daemon/lifecycle.ts` — instantiates `TopicManager` (loads topics.json), runs `validateBotPermissions` if `channel.forumMode === true`. Refuses to start on validation fail.
- `src/daemon/routes.ts` — every `channel.send*` call site is updated to pass the routing context (slug if known, session_id otherwise). Helper `topicContext(payload)` derives the right context from a hook payload + the daemon's `injectClients` map.
- `src/daemon/sleeping.ts` / `src/daemon/sleepFinish.ts` — same: pass slug context to channel calls.
- `src/cli/init.ts` — wizard branches: "DM (default) or supergroup with topics?". If supergroup chosen: instructions for creating supergroup, enabling forum mode, adding bot as admin, capturing chatId; runs validation before saving config.
- `src/config/paths.ts` — add `TOPICS_FILE = path.join(CONFIG_DIR, 'topics.json')`.

## Behavior details

- **Lazy topic creation.** Topics aren't pre-created on CLI register or sleep start. They're created when the first outbound message for that key fires. Saves API round-trips for sessions that don't generate Telegram traffic.
- **Reuse by slug.** If user runs `kuroboto claude --name fix-bot-ux` today, gets a topic `fix-bot-ux`. Tomorrow, runs the same — same topic, history preserved. (Sleep mode slugs include random suffix, so each dispatch gets a fresh topic — that's intended; sleep history is per-PR.)
- **Topic deleted in client.** Next outbound message attempt fails with `Bad Request: message thread not found` from Telegram. `TopicManager` catches this, purges the entry, and retries with `createForumTopic`. User sees a fresh topic; the old chat history is gone (matches what they did in the client).
- **System events** (daemon online/offline, channel errors, audit append failures, gaming arm/cancel, etc.) all route to `kuroboto-system`. Created lazily on first system event.
- **Persistence.** `topics.json` is written on every successful `createForumTopic` (small, ~hundred bytes per entry). File is plain JSON; user can hand-edit if they need to remap.
- **Permissions validation.** On startup with `forumMode: true`, daemon calls `getMe` to learn its own bot ID, then `getChatMember(chatId, botId)`. If `status !== 'administrator'` or `can_manage_topics !== true`, throws with a clear message including the Telegram link to fix it.
- **Migration is manual.** User edits config, restarts daemon. The doc walks them through the Telegram steps (create supergroup, enable forum, add bot, copy chatId).
- **Backwards compat.** `forumMode` defaults to `false`. Existing configs load and behave identically. `TopicManager.resolve(...)` returns `undefined` for thread id when `forumMode === false`, which propagates as `message_thread_id: undefined` (omitted from API call), and Telegram delivers to the main chat as today.

## Failure modes

| Failure | Behavior |
|---|---|
| `forumMode: true` but bot not admin | daemon refuses startup with link to bot settings |
| `forumMode: true` but bot missing `can_manage_topics` | same — refuse + clear instruction |
| `createForumTopic` fails (API error, rate limit) | log warn, skip topic for this message, fall back to main chat (no `message_thread_id`); retry on next message |
| `topics.json` write fails (disk full) | log warn; in-memory cache still works for this run; survives within the daemon process; lost on restart |
| Topic deleted in client mid-session | next message → 400 → purge + recreate (transparent to user) |
| Bot kicked from supergroup | daemon's polling errors out (existing channel-error path); user has to re-add bot |

## Audit

New `source` values:
- `topic-created` — fired when `createForumTopic` succeeds
- `topic-create-failed` — fired on `createForumTopic` 4xx/5xx
- `topic-purged` — fired when daemon detects a deleted topic and clears the entry

Existing audit values unchanged.

## Out of scope (follow-ups, see `docs/specs-backlog.md`)

- **Per-host slug prefix** (multi-machine: prepend `mac-juan/` or `win-juan/` to slug) — natural extension once multi-machine setup proves the need
- **Custom topic icons** (premium emoji or per-type colors) — cosmetic; v1 uses Telegram defaults
- **Auto-archive on session end** (Stop hook) — future ergonomic
- **`kuroboto topics list/prune`** CLI helpers — manual cleanup if `topics.json` drifts
- **Migration tool** — automated DM→supergroup, including reposting recent history
- **Inbound routing per topic** — for v1, force_reply already disambiguates Q&A replies via `reply_to_message`; the topic is just visual

## Test plan

**Unit (`topics.test.ts`):** (mock fs + mock api)
- `resolve('fix-bot-ux', 'fix-bot-ux')` first call → calls `createForumTopic`, persists `topics.json`, returns thread id
- Second call same key → cache hit, no api call
- `resolve` with `forumMode: false` → returns `undefined` (no api call)
- `purge('fix-bot-ux')` → removes from cache and from disk
- `loadFromDisk` with malformed json → starts empty (no throw)
- `flushToDisk` failure → logged, in-memory cache unaffected

**Unit (`forumValidation.test.ts`):**
- Mock api `getChatMember` returning `{ status: 'administrator', can_manage_topics: true }` → resolves
- Mock returning `{ status: 'member' }` → throws "bot is not an admin"
- Mock returning `{ status: 'administrator', can_manage_topics: false }` → throws "missing can_manage_topics"
- Mock api throws → throws with original error wrapped

**Unit (`api.test.ts` extension):**
- `sendMessage` with `messageThreadId: 42` → request body includes `message_thread_id: 42`
- `sendMessage` with `messageThreadId: undefined` → no `message_thread_id` field

**Integration (`daemon.test.ts` extension):**
- `forumMode: true` + interactive PreToolUse hook with cwd matching a registered CLI → mock channel receives sendPrompt with thread-id matching the slug's topic; topic is created lazily on first message
- `forumMode: true` + sleep mode start → sleep notif's sendNotification is called with the sleep-slug topic
- `forumMode: true` + system event (daemon online) → sendNotification with `kuroboto-system` topic
- `forumMode: false` → all messages have `messageThreadId: undefined` (current DM behavior)
- `forumMode: true` + bot lacks permissions → daemon throws on startup with clear error
- Topic deleted (api returns 400 message-thread-not-found) → next message recreates the topic, audit `topic-purged` + `topic-created`

**Smoke (post-merge, manual):**
1. Create a private supergroup; enable forum mode (Settings → Topics); add bot as admin with manage-topics permission
2. Copy supergroup `chatId` (negative number, starts with `-100...`)
3. Edit `~/.config/kuroboto/config.json`: set `chatId` to the new id, add `"forumMode": true`
4. `kuroboto stop && kuroboto start` — daemon validates and starts cleanly
5. Run `kuroboto claude --name proj-a` in one window, `kuroboto claude --name proj-b` in another
6. Trigger a Bash prompt in each — verify each lands in its own topic
7. Run `kuroboto sleeping start --plan something.md` — sleep notifs land in their own topic with `💤 ` prefix
8. Cause a daemon error (e.g., kill Telegram connectivity) — verify error msg lands in `kuroboto-system` topic
9. Delete the `proj-a` topic in the Telegram client; trigger another Bash in proj-a — verify a new topic is created (audit shows `topic-purged` + `topic-created`)

## Tasks

1. **M1**: Create `topics.ts` (TopicManager) and `forumValidation.ts`. Schema migration (`forumMode` field). Path constant for `topics.json`. Unit tests.
2. **M2**: Extend `api.ts` (`messageThreadId` parameter, new wrappers). Modify `TelegramChannel` to thread context through every outbound. Wire `routes.ts`/`sleeping.ts`/`sleepFinish.ts` to populate context. Lifecycle bot-permissions validation.
3. **M3**: Init wizard branch for supergroup setup. Integration tests. Manual smoke. PR.

```

## Test plan

- [ ] Review the diff against the original prompt
- [ ] Run the test suite locally
- [ ] Smoke-test the new behavior end-to-end

_Generated by kuroboto sleep mode._