### PR TITLE
test(cli): CLI layer tests (Spec H)

### DIFF
--- a/docs/specs/cli-tests.md
+++ b/docs/specs/cli-tests.md
@@ -127,12 +127,14 @@ expect(exitSpy).toHaveBeenCalledWith(0);
 
 ### `audit.test.ts` (~6 tests)
 
-- `list` (no args) → GET /v1/audit, prints last 10 entries (default limit)
-- `list --since 5m` → query param `sinceMs=300000`
-- `list --cwd /path` → query param `cwd=/path`
-- `list --limit 50` → query param `limit=50`
-- `export` → GET, prints raw JSONL to stdout (machine-readable)
-- daemon offline → fetch fails → exits 1
+(Like `allowlist`, this command reads filesystem directly — `~/.kuroboto/audit.jsonl` — instead of going through the daemon. That keeps `kuroboto audit list` usable for diagnostics even when the daemon is offline. Tests stub `readAudit` rather than `fetch`.)
+
+- `list` (no args) → calls `readAudit({})`, prints last entries
+- `list --since 5m` → forwards `sinceMs=300000`
+- `list --cwd /path` → forwards `cwd=/path`
+- `list --limit 50` → forwards `limit=50`
+- `export` → prints raw JSONL to stdout (machine-readable)
+- empty log → prints `(sem entradas)` placeholder
 
 ### `allowlist.test.ts` (~5 tests)
 
@@ -146,10 +148,12 @@ expect(exitSpy).toHaveBeenCalledWith(0);
 
 ### `mode.test.ts` (~4 tests)
 
-- `kuroboto here` → PUT /v1/mode `{mode: 'here'}`, prints "mode: here"
-- `kuroboto away` → PUT /v1/mode `{mode: 'away'}`, prints "mode: away"
-- daemon offline (here) → exits 1
-- daemon returns 4xx → prints error from body
+(`mode` writes to `~/.kuroboto/state.json` first, then best-effort PUTs `/v1/mode` so the running daemon picks up the change immediately. Daemon-offline is a soft failure here — the local change persists and the next daemon start will read it.)
+
+- `kuroboto here` → saves locally, PUTs `/v1/mode {mode: 'here'}`, prints "mode set to here"
+- `kuroboto away` → saves locally, PUTs `/v1/mode {mode: 'away'}`, prints "mode set to away"
+- daemon offline (here) → still saves locally and reports `daemon offline` fallback (no exit 1)
+- daemon returns non-2xx → still saves locally, includes HTTP code in fallback message
 
 ## Behavior details / conventions
 

--- a/test/helpers/cliHarness.ts
+++ b/test/helpers/cliHarness.ts
@@ -1,0 +1,164 @@
+import { vi, type MockInstance } from 'vitest';
+import type { ConfigT } from '../../src/config/schema.js';
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+export interface FetchCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+export type FetchHandler = (
+  url: string,
+  init?: RequestInit,
+) => Response | Promise<Response>;
+
+export interface FetchStub {
+  calls: FetchCall[];
+  mock: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Replace global.fetch with a vi.fn that delegates to the supplied handler.
+ * Each call is recorded for assertions in `calls`.
+ */
+export function stubFetch(handler: FetchHandler): FetchStub {
+  const calls: FetchCall[] = [];
+  const mock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) headers[k] = h[k]!;
+    }
+    let body: unknown = undefined;
+    if (typeof init?.body === 'string') {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    calls.push({ url, method, headers, body });
+    return handler(url, init);
+  });
+  vi.stubGlobal('fetch', mock);
+  return { calls, mock };
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export interface CapturedIO {
+  stdout: string[];
+  stderr: string[];
+  out(): string;
+  err(): string;
+}
+
+/**
+ * Capture every write to process.stdout / process.stderr AND every console.log /
+ * console.error call. Vitest intercepts console.* directly (not via stdout.write),
+ * so we must spy on both layers to cover commands that mix the two (`auditExport`
+ * uses `process.stdout.write`, while everyone else uses `console.log`).
+ *
+ * Strip ANSI in the convenience `out()` / `err()` accessors.
+ */
+export function captureIO(): CapturedIO {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    stdout.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as never);
+  vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    stderr.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+    return true;
+  }) as never);
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    stdout.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
+  });
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    stderr.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
+  });
+  return {
+    stdout,
+    stderr,
+    out: () => stripAnsi(stdout.join('')),
+    err: () => stripAnsi(stderr.join('')),
+  };
+}
+
+export interface ExitCapture {
+  exitSpy: MockInstance;
+  /** Last code passed to process.exit, or null if never called. */
+  code(): number | null;
+}
+
+/** Replace process.exit with a stub that throws `__exit__:N` to short-circuit. */
+export function stubExit(): ExitCapture {
+  let lastCode: number | null = null;
+  const exitSpy = vi
+    .spyOn(process, 'exit')
+    .mockImplementation(((code?: number) => {
+      lastCode = code ?? 0;
+      throw new Error(`__exit__:${lastCode}`);
+    }) as never);
+  return { exitSpy, code: () => lastCode };
+}
+
+/**
+ * Run a CLI command, swallowing the `__exit__:N` sentinel so tests can
+ * inspect exit code and captured output without try/catch boilerplate.
+ *
+ * Re-throws unexpected errors so genuine failures still surface.
+ */
+export async function runWithExitCapture<T>(
+  fn: () => Promise<T>,
+): Promise<{ result?: T; exitCode: number | null; error?: unknown }> {
+  let lastCode: number | null = null;
+  const spy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    lastCode = code ?? 0;
+    throw new Error(`__exit__:${lastCode}`);
+  }) as never);
+  try {
+    const result = await fn();
+    return { result, exitCode: lastCode };
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('__exit__:')) {
+      return { exitCode: lastCode };
+    }
+    return { exitCode: lastCode, error: e };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+/** Default config used by the loadConfig mock. Override per-test if needed. */
+export const TEST_CONFIG: ConfigT = {
+  channel: { type: 'telegram', token: 'x', chatId: 1 },
+  daemon: { port: 47891, authToken: 't'.repeat(64) },
+  inject: { enabled: false, replyTimeoutMs: 7_200_000 },
+  policy: {
+    permissionTimeoutMs: 1_000,
+    notifyDelayMs: 60_000,
+    permissionMatchers: ['Bash', 'Edit', 'Write'],
+    rememberGranularity: 'tight',
+    gamingAlwaysAsk: [],
+    sleepMaxDurationMs: 7_200_000,
+    sleepWorktreeDir: '/tmp/kuroboto-test-worktrees',
+    maxConcurrentSleeps: 6,
+    failOpen: true,
+  },
+};

--- a/test/helpers/cliHarness.ts
+++ b/test/helpers/cliHarness.ts
@@ -1,4 +1,4 @@
-import { vi, type MockInstance } from 'vitest';
+import { vi, expect } from 'vitest';
 import type { ConfigT } from '../../src/config/schema.js';
 
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
@@ -100,22 +100,15 @@ export function captureIO(): CapturedIO {
   };
 }
 
-export interface ExitCapture {
-  exitSpy: MockInstance;
-  /** Last code passed to process.exit, or null if never called. */
-  code(): number | null;
-}
-
-/** Replace process.exit with a stub that throws `__exit__:N` to short-circuit. */
-export function stubExit(): ExitCapture {
-  let lastCode: number | null = null;
-  const exitSpy = vi
-    .spyOn(process, 'exit')
-    .mockImplementation(((code?: number) => {
-      lastCode = code ?? 0;
-      throw new Error(`__exit__:${lastCode}`);
-    }) as never);
-  return { exitSpy, code: () => lastCode };
+/**
+ * Asserts every captured fetch carried the daemon auth header. Cheap insurance
+ * that future refactors don't drop the X-Kuroboto-Token requirement (which the
+ * daemon enforces on every authed call per AGENTS.md).
+ */
+export function expectAuthHeader(stub: FetchStub): void {
+  for (const call of stub.calls) {
+    expect(call.headers['X-Kuroboto-Token']).toBe(TEST_CONFIG.daemon.authToken);
+  }
 }
 
 /**

--- a/test/unit/cli/allowlist.test.ts
+++ b/test/unit/cli/allowlist.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { captureIO } from '../../helpers/cliHarness.js';
+import { allowlistList, allowlistExport } from '../../../src/cli/allowlist.js';
+
+describe('cli/allowlist', () => {
+  let io: ReturnType<typeof captureIO>;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    io = captureIO();
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-cli-allowlist-'));
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeSettings(content: string): Promise<void> {
+    await fsp.mkdir(path.join(tmpDir, '.claude'), { recursive: true });
+    await fsp.writeFile(path.join(tmpDir, '.claude', 'settings.local.json'), content);
+  }
+
+  describe('list', () => {
+    it('settings missing: prints placeholder, exits 0', async () => {
+      await allowlistList(tmpDir);
+      expect(io.out()).toContain('(nenhum .claude/settings.local.json em');
+      expect(io.out()).toContain(tmpDir);
+    });
+
+    it('allow array empty: prints "(allowlist vazia)"', async () => {
+      await writeSettings(JSON.stringify({ permissions: { allow: [] } }));
+      await allowlistList(tmpDir);
+      expect(io.out()).toContain('(allowlist vazia)');
+    });
+
+    it('with entries: prints header + one bullet per matcher', async () => {
+      await writeSettings(
+        JSON.stringify({
+          permissions: { allow: ['Bash(npm install:*)', 'Edit'] },
+        }),
+      );
+      await allowlistList(tmpDir);
+      const out = io.out();
+      expect(out).toContain('allowlist em');
+      expect(out).toContain('settings.local.json');
+      expect(out).toContain('Bash(npm install:*)');
+      expect(out).toContain('Edit');
+    });
+
+    it('malformed JSON: rejects (caller wraps to exit 1)', async () => {
+      await writeSettings('not-json');
+      await expect(allowlistList(tmpDir)).rejects.toThrow();
+    });
+  });
+
+  describe('export', () => {
+    it('settings missing: emits "{}" so machine readers see empty object', async () => {
+      await allowlistExport(tmpDir);
+      expect(io.stdout.join('').trim()).toBe('{}');
+    });
+
+    it('with settings: emits pretty-printed JSON of the parsed file', async () => {
+      const settings = {
+        permissions: { allow: ['Bash(ls:*)'], deny: ['Bash(rm:*)'] },
+        env: { FOO: 'bar' },
+      };
+      await writeSettings(JSON.stringify(settings));
+      await allowlistExport(tmpDir);
+      const printed = JSON.parse(io.stdout.join('').trim());
+      expect(printed).toEqual(settings);
+    });
+  });
+});

--- a/test/unit/cli/audit.test.ts
+++ b/test/unit/cli/audit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { captureIO } from '../../helpers/cliHarness.js';
+import * as auditModule from '../../../src/daemon/audit.js';
+import type { AuditEntry } from '../../../src/daemon/audit.js';
+
+import { auditList, auditExport } from '../../../src/cli/audit.js';
+
+function entry(o: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    ts: '2026-04-28T10:00:00.000Z',
+    requestId: 'r1',
+    tool: 'Bash',
+    cwd: '/x',
+    decision: 'allow',
+    reason: null,
+    source: 'telegram',
+    remember: false,
+    ...o,
+  };
+}
+
+describe('cli/audit', () => {
+  let io: ReturnType<typeof captureIO>;
+  let readSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    io = captureIO();
+    readSpy = vi.spyOn(auditModule, 'readAudit');
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('list', () => {
+    it('no opts: passes empty filter, prints one row per entry', async () => {
+      readSpy.mockResolvedValue([
+        entry({ requestId: 'r1', tool: 'Bash', cwd: '/x', decision: 'allow' }),
+        entry({ requestId: 'r2', tool: 'Edit', cwd: '/y', decision: 'deny', reason: 'no' }),
+      ]);
+      await auditList({});
+      expect(readSpy).toHaveBeenCalledWith({
+        sinceMs: undefined,
+        cwd: undefined,
+        limit: undefined,
+      });
+      const out = io.out();
+      expect(out).toContain('Bash');
+      expect(out).toContain('Edit');
+      expect(out).toContain('ALLOW');
+      expect(out).toContain('DENY');
+      expect(out).toContain('cwd=/x');
+      expect(out).toContain('cwd=/y');
+      expect(out).toContain('reason="no"');
+    });
+
+    it('empty: prints "(sem entradas)" placeholder', async () => {
+      readSpy.mockResolvedValue([]);
+      await auditList({});
+      expect(io.out()).toContain('(sem entradas)');
+    });
+
+    it('--since 5m: translates to sinceMs=300_000', async () => {
+      readSpy.mockResolvedValue([]);
+      await auditList({ since: '5m' });
+      expect(readSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sinceMs: 5 * 60_000 }),
+      );
+    });
+
+    it('--cwd /some/path: forwarded as cwd filter', async () => {
+      readSpy.mockResolvedValue([]);
+      await auditList({ cwd: '/some/path' });
+      expect(readSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: '/some/path' }),
+      );
+    });
+
+    it('--limit 50: forwarded as numeric limit', async () => {
+      readSpy.mockResolvedValue([]);
+      await auditList({ limit: '50' });
+      expect(readSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50 }),
+      );
+    });
+
+    it('renders ALLOW+R for remember=true entries', async () => {
+      readSpy.mockResolvedValue([entry({ decision: 'allow', remember: true })]);
+      await auditList({});
+      expect(io.out()).toContain('ALLOW+R');
+    });
+  });
+
+  describe('export', () => {
+    it('prints raw JSONL, one entry per line, machine-parseable', async () => {
+      const a = entry({ requestId: 'r1', tool: 'Bash' });
+      const b = entry({ requestId: 'r2', tool: 'Edit' });
+      readSpy.mockResolvedValue([a, b]);
+      await auditExport({});
+      const out = io.stdout.join('');
+      const lines = out.trim().split('\n').filter((l) => l.length > 0);
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]!)).toMatchObject({ requestId: 'r1', tool: 'Bash' });
+      expect(JSON.parse(lines[1]!)).toMatchObject({ requestId: 'r2', tool: 'Edit' });
+    });
+  });
+});

--- a/test/unit/cli/audit.test.ts
+++ b/test/unit/cli/audit.test.ts
@@ -5,6 +5,11 @@ import type { AuditEntry } from '../../../src/daemon/audit.js';
 
 import { auditList, auditExport } from '../../../src/cli/audit.js';
 
+// `audit list/export` reads `~/.kuroboto/audit.jsonl` directly (same pattern
+// as `allowlist`) — there's no `/v1/audit` HTTP route. That's intentional so
+// audit history stays inspectable when the daemon is offline. Tests therefore
+// stub `readAudit` rather than `fetch`.
+
 function entry(o: Partial<AuditEntry> = {}): AuditEntry {
   return {
     ts: '2026-04-28T10:00:00.000Z',

--- a/test/unit/cli/gaming.test.ts
+++ b/test/unit/cli/gaming.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  captureIO,
+  jsonResponse,
+  runWithExitCapture,
+  stubFetch,
+  TEST_CONFIG,
+  type FetchStub,
+} from '../../helpers/cliHarness.js';
+
+vi.mock('../../../src/config/load.js', () => ({
+  loadConfig: vi.fn(async () => TEST_CONFIG),
+}));
+
+import {
+  gamingOnCommand,
+  gamingOffCommand,
+  gamingStatusCommand,
+} from '../../../src/cli/gaming.js';
+
+describe('cli/gaming', () => {
+  let io: ReturnType<typeof captureIO>;
+  let fetchStub: FetchStub;
+
+  beforeEach(() => {
+    io = captureIO();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('on (no duration): PUT {on:true}, prints "gaming on (no timer ...)"', async () => {
+    fetchStub = stubFetch(() =>
+      jsonResponse({ ok: true, active: true, until: null }),
+    );
+    await gamingOnCommand();
+    expect(fetchStub.calls).toHaveLength(1);
+    const call = fetchStub.calls[0]!;
+    expect(call.method).toBe('PUT');
+    expect(call.url).toContain('/v1/gaming');
+    expect(call.body).toEqual({ on: true, durationMs: undefined });
+    expect(io.out()).toContain('gaming on');
+    expect(io.out()).toContain('no timer');
+  });
+
+  it('on 15m: durationMs=900_000, prints remaining', async () => {
+    const future = Date.now() + 15 * 60_000;
+    fetchStub = stubFetch(() =>
+      jsonResponse({ ok: true, active: true, until: future }),
+    );
+    await gamingOnCommand('15m');
+    expect(fetchStub.calls[0]!.body).toMatchObject({
+      on: true,
+      durationMs: 15 * 60_000,
+    });
+    expect(io.out()).toMatch(/15m remaining/);
+  });
+
+  it('on 2h: durationMs=7_200_000', async () => {
+    const future = Date.now() + 2 * 3_600_000;
+    fetchStub = stubFetch(() =>
+      jsonResponse({ ok: true, active: true, until: future }),
+    );
+    await gamingOnCommand('2h');
+    expect(fetchStub.calls[0]!.body).toMatchObject({
+      on: true,
+      durationMs: 2 * 3_600_000,
+    });
+    expect(io.out()).toMatch(/2h remaining/);
+  });
+
+  it('on bad: parseDuration error → exits 1', async () => {
+    fetchStub = stubFetch(() =>
+      jsonResponse({ ok: true, active: true, until: null }),
+    );
+    const r = await runWithExitCapture(() => gamingOnCommand('not-a-duration'));
+    expect(r.exitCode).toBe(1);
+    expect(fetchStub.calls).toHaveLength(0);
+    expect(io.err().toLowerCase()).toMatch(/duration|invalid/);
+  });
+
+  it('off: PUT {on:false}, prints "gaming off"', async () => {
+    fetchStub = stubFetch(() =>
+      jsonResponse({ ok: true, active: false, until: null }),
+    );
+    await gamingOffCommand();
+    expect(fetchStub.calls[0]!.body).toEqual({ on: false, durationMs: undefined });
+    expect(io.out()).toContain('gaming off');
+  });
+
+  it('status (off): GET, prints "gaming: off"', async () => {
+    fetchStub = stubFetch(() => jsonResponse({ active: false, until: null }));
+    await gamingStatusCommand();
+    expect(fetchStub.calls[0]!.method).toBe('GET');
+    expect(io.out()).toContain('gaming: off');
+  });
+
+  it('status (on, no timer): prints "gaming: on (no timer)"', async () => {
+    fetchStub = stubFetch(() => jsonResponse({ active: true, until: null }));
+    await gamingStatusCommand();
+    expect(io.out()).toContain('gaming: on');
+    expect(io.out()).toContain('no timer');
+  });
+
+  it('status (on, with timer): prints remaining', async () => {
+    const future = Date.now() + 10 * 60_000;
+    fetchStub = stubFetch(() => jsonResponse({ active: true, until: future }));
+    await gamingStatusCommand();
+    const out = io.out();
+    expect(out).toContain('gaming: on');
+    expect(out).toMatch(/\d+m/);
+  });
+
+  it('daemon offline (on): fetch rejects → throws daemon-down message', async () => {
+    stubFetch(() => {
+      throw new Error('ECONNREFUSED');
+    });
+    await expect(gamingOnCommand()).rejects.toThrow(/daemon offline|unreachable/i);
+  });
+});

--- a/test/unit/cli/gaming.test.ts
+++ b/test/unit/cli/gaming.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   captureIO,
+  expectAuthHeader,
   jsonResponse,
   runWithExitCapture,
   stubFetch,
@@ -30,7 +31,7 @@ describe('cli/gaming', () => {
     vi.restoreAllMocks();
   });
 
-  it('on (no duration): PUT {on:true}, prints "gaming on (no timer ...)"', async () => {
+  it('on (no duration): PUT {on:true}, prints "gaming on (no timer ...)" and sends auth header', async () => {
     fetchStub = stubFetch(() =>
       jsonResponse({ ok: true, active: true, until: null }),
     );
@@ -42,6 +43,7 @@ describe('cli/gaming', () => {
     expect(call.body).toEqual({ on: true, durationMs: undefined });
     expect(io.out()).toContain('gaming on');
     expect(io.out()).toContain('no timer');
+    expectAuthHeader(fetchStub);
   });
 
   it('on 15m: durationMs=900_000, prints remaining', async () => {
@@ -112,10 +114,13 @@ describe('cli/gaming', () => {
     expect(out).toMatch(/\d+m/);
   });
 
-  it('daemon offline (on): fetch rejects → throws daemon-down message', async () => {
+  it('daemon offline (on): kuroFetch prints daemon-down message and exits 1', async () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
     stubFetch(() => {
-      throw new Error('ECONNREFUSED');
+      throw err;
     });
-    await expect(gamingOnCommand()).rejects.toThrow(/daemon offline|unreachable/i);
+    const r = await runWithExitCapture(() => gamingOnCommand());
+    expect(r.exitCode).toBe(1);
+    expect(io.err()).toMatch(/daemon offline/i);
   });
 });

--- a/test/unit/cli/mode.test.ts
+++ b/test/unit/cli/mode.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   captureIO,
+  expectAuthHeader,
   jsonResponse,
   stubFetch,
   TEST_CONFIG,
@@ -28,7 +29,7 @@ describe('cli/mode', () => {
     vi.restoreAllMocks();
   });
 
-  it('here: persists mode locally, PUTs /v1/mode, prints "mode set to here"', async () => {
+  it('here: persists mode locally, PUTs /v1/mode, prints "mode set to here" with auth header', async () => {
     fetchStub = stubFetch(() => jsonResponse({ ok: true }));
     await hereCommand();
     expect(saveModeSpy).toHaveBeenCalledWith('here');
@@ -37,6 +38,7 @@ describe('cli/mode', () => {
     expect(call.url).toContain('/v1/mode');
     expect(call.body).toEqual({ mode: 'here' });
     expect(io.out()).toContain('mode set to here');
+    expectAuthHeader(fetchStub);
   });
 
   it('away: persists mode locally, PUTs /v1/mode, prints "mode set to away"', async () => {

--- a/test/unit/cli/mode.test.ts
+++ b/test/unit/cli/mode.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  captureIO,
+  jsonResponse,
+  stubFetch,
+  TEST_CONFIG,
+  type FetchStub,
+} from '../../helpers/cliHarness.js';
+import * as stateModule from '../../../src/daemon/state.js';
+
+vi.mock('../../../src/config/load.js', () => ({
+  loadConfig: vi.fn(async () => TEST_CONFIG),
+}));
+
+import { hereCommand, awayCommand } from '../../../src/cli/mode.js';
+
+describe('cli/mode', () => {
+  let io: ReturnType<typeof captureIO>;
+  let saveModeSpy: ReturnType<typeof vi.spyOn>;
+  let fetchStub: FetchStub;
+
+  beforeEach(() => {
+    io = captureIO();
+    saveModeSpy = vi.spyOn(stateModule, 'saveMode').mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('here: persists mode locally, PUTs /v1/mode, prints "mode set to here"', async () => {
+    fetchStub = stubFetch(() => jsonResponse({ ok: true }));
+    await hereCommand();
+    expect(saveModeSpy).toHaveBeenCalledWith('here');
+    const call = fetchStub.calls[0]!;
+    expect(call.method).toBe('PUT');
+    expect(call.url).toContain('/v1/mode');
+    expect(call.body).toEqual({ mode: 'here' });
+    expect(io.out()).toContain('mode set to here');
+  });
+
+  it('away: persists mode locally, PUTs /v1/mode, prints "mode set to away"', async () => {
+    fetchStub = stubFetch(() => jsonResponse({ ok: true }));
+    await awayCommand();
+    expect(saveModeSpy).toHaveBeenCalledWith('away');
+    expect(fetchStub.calls[0]!.body).toEqual({ mode: 'away' });
+    expect(io.out()).toContain('mode set to away');
+  });
+
+  it('daemon offline: still saves locally and reports fallback', async () => {
+    stubFetch(() => {
+      throw new Error('ECONNREFUSED');
+    });
+    await hereCommand();
+    expect(saveModeSpy).toHaveBeenCalledWith('here');
+    const out = io.out();
+    expect(out).toContain('mode set to here');
+    expect(out).toContain('daemon offline');
+  });
+
+  it('daemon returns non-2xx: reports HTTP code in fallback message', async () => {
+    fetchStub = stubFetch(() => jsonResponse({ error: 'bad' }, 500));
+    await awayCommand();
+    expect(saveModeSpy).toHaveBeenCalledWith('away');
+    const out = io.out();
+    expect(out).toContain('mode set to away');
+    expect(out).toContain('500');
+  });
+});

--- a/test/unit/cli/sleeping.test.ts
+++ b/test/unit/cli/sleeping.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import prompts from 'prompts';
+import {
+  captureIO,
+  jsonResponse,
+  runWithExitCapture,
+  stubFetch,
+  TEST_CONFIG,
+  type FetchStub,
+} from '../../helpers/cliHarness.js';
+
+vi.mock('prompts', () => ({ default: vi.fn() }));
+vi.mock('../../../src/config/load.js', () => ({
+  loadConfig: vi.fn(async () => TEST_CONFIG),
+}));
+
+const mockedPrompts = vi.mocked(prompts);
+
+import {
+  sleepingStartCommand,
+  sleepingStatusCommand,
+  sleepingCancelCommand,
+} from '../../../src/cli/sleeping.js';
+
+interface SnapSession {
+  slug: string;
+  branch: string;
+  worktreePath: string;
+  startedAt: number;
+  expectedEndAt: number;
+}
+
+function snap(session: Partial<SnapSession> = {}): SnapSession {
+  const now = Date.now();
+  return {
+    slug: 'demo-aaa111',
+    branch: 'sleep/demo-aaa111',
+    worktreePath: '/tmp/wt/demo-aaa111',
+    startedAt: now,
+    expectedEndAt: now + 60 * 60 * 1000,
+    ...session,
+  };
+}
+
+describe('cli/sleeping', () => {
+  let io: ReturnType<typeof captureIO>;
+  let fetchStub: FetchStub;
+
+  beforeEach(() => {
+    io = captureIO();
+    mockedPrompts.mockReset();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('status', () => {
+    it('idle: prints "sleep: idle (cap 6)"', async () => {
+      fetchStub = stubFetch(() => jsonResponse({ active: [], capacity: 6 }));
+      await sleepingStatusCommand();
+      expect(io.out()).toContain('sleep: idle (cap 6)');
+      expect(fetchStub.calls).toHaveLength(1);
+      expect(fetchStub.calls[0]!.url).toContain('/v1/sleeping');
+      expect(fetchStub.calls[0]!.method).toBe('GET');
+    });
+
+    it('one active: prints count line + slug bullet', async () => {
+      fetchStub = stubFetch(() =>
+        jsonResponse({ active: [snap({ slug: 'one-x' })], capacity: 6 }),
+      );
+      await sleepingStatusCommand();
+      const out = io.out();
+      expect(out).toContain('sleep: 1 active (cap 6)');
+      expect(out).toContain('• one-x');
+      expect(out).toMatch(/remaining/);
+    });
+
+    it('multiple active: count line + bullet per session', async () => {
+      fetchStub = stubFetch(() =>
+        jsonResponse({
+          active: [snap({ slug: 'first-1' }), snap({ slug: 'second-2' })],
+          capacity: 6,
+        }),
+      );
+      await sleepingStatusCommand();
+      const out = io.out();
+      expect(out).toContain('sleep: 2 active (cap 6)');
+      expect(out).toContain('• first-1');
+      expect(out).toContain('• second-2');
+    });
+  });
+
+  describe('start', () => {
+    it('rejects when both --prompt and --plan are given', async () => {
+      const r = await runWithExitCapture(() =>
+        sleepingStartCommand({ prompt: 'x', plan: 'y' }),
+      );
+      expect(r.exitCode).toBe(1);
+      expect(io.err()).toContain('mutually exclusive');
+    });
+
+    it('rejects when neither --prompt nor --plan is given', async () => {
+      const r = await runWithExitCapture(() => sleepingStartCommand({}));
+      expect(r.exitCode).toBe(1);
+      expect(io.err()).toContain('--prompt or --plan required');
+    });
+
+    it('--prompt: POSTs to /v1/sleeping and prints session details', async () => {
+      const session = snap({ slug: 'echo-hi-zz9999' });
+      fetchStub = stubFetch(() => jsonResponse(session));
+      await sleepingStartCommand({ prompt: 'echo hi', repo: '/repo/x' });
+      expect(fetchStub.calls).toHaveLength(1);
+      const call = fetchStub.calls[0]!;
+      expect(call.method).toBe('POST');
+      expect(call.url).toContain('/v1/sleeping');
+      expect(call.body).toMatchObject({ repo: path.resolve('/repo/x'), prompt: 'echo hi' });
+      const out = io.out();
+      expect(out).toContain('💤 sleep started');
+      expect(out).toContain(`slug:     ${session.slug}`);
+      expect(out).toContain(`branch:   ${session.branch}`);
+      expect(out).toContain(`worktree: ${session.worktreePath}`);
+    });
+
+    it('--plan: reads file and posts plan content', async () => {
+      const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-cli-'));
+      const planFile = path.join(tmp, 'plan.md');
+      await fsp.writeFile(planFile, '# Plan\n\nDo X');
+      try {
+        const session = snap();
+        fetchStub = stubFetch(() => jsonResponse(session));
+        await sleepingStartCommand({ plan: planFile, repo: '/repo/x' });
+        const body = fetchStub.calls[0]!.body as { plan?: string; prompt?: string };
+        expect(body.plan).toContain('# Plan');
+        expect(body.prompt).toBeUndefined();
+      } finally {
+        await fsp.rm(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('capacity reached (429): renders error block and rejects', async () => {
+      fetchStub = stubFetch(() =>
+        jsonResponse(
+          {
+            error: 'capacity',
+            capacity: 2,
+            active: [snap({ slug: 'busy-1' }), snap({ slug: 'busy-2' })],
+          },
+          429,
+        ),
+      );
+      await expect(sleepingStartCommand({ prompt: 'p' })).rejects.toThrow(
+        /capacity/i,
+      );
+      const err = io.err();
+      expect(err).toContain('capacity reached');
+      expect(err).toContain('2/2 active');
+      expect(err).toContain('busy-1');
+      expect(err).toContain('busy-2');
+    });
+  });
+
+  describe('cancel', () => {
+    it('no active sleeps: prints "(no active sleeps)" and returns', async () => {
+      fetchStub = stubFetch(() => jsonResponse({ active: [], capacity: 6 }));
+      await sleepingCancelCommand(undefined, {});
+      expect(io.out()).toContain('(no active sleeps)');
+      // status GET only — no cancel POST
+      expect(fetchStub.calls).toHaveLength(1);
+    });
+
+    it('explicit slug: POSTs cancel without prompting', async () => {
+      const s = snap({ slug: 'target-1' });
+      fetchStub = stubFetch((url) => {
+        if (url.includes('/cancel')) return jsonResponse({ cancelled: ['target-1'] });
+        return jsonResponse({ active: [s], capacity: 6 });
+      });
+      await sleepingCancelCommand('target-1', {});
+      expect(mockedPrompts).not.toHaveBeenCalled();
+      expect(io.out()).toContain('sleep cancelled: target-1');
+      const cancelCall = fetchStub.calls.find((c) => c.url.includes('/cancel'))!;
+      expect(cancelCall.body).toEqual({ slug: 'target-1' });
+    });
+
+    it('explicit slug not found: prints error and exits 1', async () => {
+      fetchStub = stubFetch(() =>
+        jsonResponse({ active: [snap({ slug: 'other' })], capacity: 6 }),
+      );
+      const r = await runWithExitCapture(() =>
+        sleepingCancelCommand('missing', {}),
+      );
+      expect(r.exitCode).toBe(1);
+      expect(io.err()).toContain("no active sleep with slug 'missing'");
+    });
+
+    it('one active, no slug: confirmation y → cancels', async () => {
+      const s = snap({ slug: 'lonely-1' });
+      mockedPrompts.mockResolvedValueOnce({ val: true });
+      fetchStub = stubFetch((url) => {
+        if (url.includes('/cancel')) return jsonResponse({ cancelled: ['lonely-1'] });
+        return jsonResponse({ active: [s], capacity: 6 });
+      });
+      await sleepingCancelCommand(undefined, {});
+      expect(mockedPrompts).toHaveBeenCalledTimes(1);
+      const arg = mockedPrompts.mock.calls[0]![0] as { message: string };
+      expect(arg.message).toContain('lonely-1');
+      expect(io.out()).toContain('sleep cancelled: lonely-1');
+    });
+
+    it('one active, no slug: confirmation n → aborts', async () => {
+      mockedPrompts.mockResolvedValueOnce({ val: false });
+      fetchStub = stubFetch(() =>
+        jsonResponse({ active: [snap({ slug: 'spared' })], capacity: 6 }),
+      );
+      await sleepingCancelCommand(undefined, {});
+      expect(io.out()).toContain('aborted');
+      // No /cancel POST should have happened
+      expect(fetchStub.calls.some((c) => c.url.includes('/cancel'))).toBe(false);
+    });
+
+    it('--all confirmed: cancels every active session', async () => {
+      mockedPrompts.mockResolvedValueOnce({ val: true });
+      const a = snap({ slug: 'a-aaaaaa' });
+      const b = snap({ slug: 'b-bbbbbb' });
+      fetchStub = stubFetch((url) => {
+        if (url.includes('/cancel')) {
+          return jsonResponse({ cancelled: ['a-aaaaaa', 'b-bbbbbb'] });
+        }
+        return jsonResponse({ active: [a, b], capacity: 6 });
+      });
+      await sleepingCancelCommand(undefined, { all: true });
+      expect(mockedPrompts).toHaveBeenCalledTimes(1);
+      const cancelCall = fetchStub.calls.find((c) => c.url.includes('/cancel'))!;
+      expect(cancelCall.body).toEqual({ all: true });
+      expect(io.out()).toContain('cancelled 2 sleeps');
+      expect(io.out()).toContain('a-aaaaaa, b-bbbbbb');
+    });
+
+    it('--all --yes: skips prompt', async () => {
+      const a = snap({ slug: 'a-1' });
+      const b = snap({ slug: 'b-2' });
+      fetchStub = stubFetch((url) => {
+        if (url.includes('/cancel')) return jsonResponse({ cancelled: ['a-1', 'b-2'] });
+        return jsonResponse({ active: [a, b], capacity: 6 });
+      });
+      await sleepingCancelCommand(undefined, { all: true, yes: true });
+      expect(mockedPrompts).not.toHaveBeenCalled();
+      expect(io.out()).toContain('cancelled 2 sleeps');
+    });
+
+    it('--yes single active: skips prompt', async () => {
+      const s = snap({ slug: 'solo-1' });
+      fetchStub = stubFetch((url) => {
+        if (url.includes('/cancel')) return jsonResponse({ cancelled: ['solo-1'] });
+        return jsonResponse({ active: [s], capacity: 6 });
+      });
+      await sleepingCancelCommand(undefined, { yes: true });
+      expect(mockedPrompts).not.toHaveBeenCalled();
+      expect(io.out()).toContain('sleep cancelled: solo-1');
+    });
+
+    it('--yes multi active, no slug: cancels most-recent silently', async () => {
+      const older = snap({ slug: 'older-x', startedAt: 1_000 });
+      const newer = snap({ slug: 'newer-y', startedAt: 9_000 });
+      fetchStub = stubFetch((url) => {
+        if (url.includes('/cancel')) return jsonResponse({ cancelled: ['newer-y'] });
+        return jsonResponse({ active: [older, newer], capacity: 6 });
+      });
+      await sleepingCancelCommand(undefined, { yes: true });
+      expect(mockedPrompts).not.toHaveBeenCalled();
+      const cancelCall = fetchStub.calls.find((c) => c.url.includes('/cancel'))!;
+      expect(cancelCall.body).toEqual({ slug: 'newer-y' });
+      expect(io.out()).toContain('sleep cancelled: newer-y');
+    });
+  });
+});

--- a/test/unit/cli/sleeping.test.ts
+++ b/test/unit/cli/sleeping.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import prompts from 'prompts';
 import {
   captureIO,
+  expectAuthHeader,
   jsonResponse,
   runWithExitCapture,
   stubFetch,
@@ -59,13 +60,14 @@ describe('cli/sleeping', () => {
   });
 
   describe('status', () => {
-    it('idle: prints "sleep: idle (cap 6)"', async () => {
+    it('idle: prints "sleep: idle (cap 6)" and sends auth header', async () => {
       fetchStub = stubFetch(() => jsonResponse({ active: [], capacity: 6 }));
       await sleepingStatusCommand();
       expect(io.out()).toContain('sleep: idle (cap 6)');
       expect(fetchStub.calls).toHaveLength(1);
       expect(fetchStub.calls[0]!.url).toContain('/v1/sleeping');
       expect(fetchStub.calls[0]!.method).toBe('GET');
+      expectAuthHeader(fetchStub);
     });
 
     it('one active: prints count line + slug bullet', async () => {


### PR DESCRIPTION
## Summary

Automated implementation via `kuroboto sleeping` (sleep mode).

## Original prompt

```
Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.

# CLI layer tests

> Status: planned. Spec H. Closes the test-coverage gap between the daemon's HTTP layer (already covered by integration tests) and what the user actually types — output formatting, argument parsing, interactive prompts, exit codes.

## Problem

Today every layer below the CLI has automated tests:
- Unit tests cover the orchestrator (`SleepingOrchestrator`), TopicManager, transcript parser, etc.
- Integration tests cover the daemon's HTTP routes (`POST /v1/sleeping`, `POST /v1/permission`, …)
- 308/308 passing.

But the CLI commands (`kuroboto sleeping start --prompt …`, `kuroboto gaming on 15m`, `kuroboto audit list`, etc.) are **not** automatically tested. Their behaviors — argument parsing, output formatting, interactive prompts, exit codes — are validated only by manual smoke checklists in each spec.

This was acceptable while the CLI surface was small. After Spec D (parallel sleeps with new `cancel` UX, capacity-reached rendering, multi-line status output) and the CI/CD setup, the gap is the most likely source of regressions.

## Solution

Add a `test/unit/cli/` directory with one spec file per subcommand group. Each test:

- Stubs `global.fetch` via `vi.stubGlobal('fetch', vi.fn(...))` — simulates daemon responses without running one
- Mocks `prompts` lib via `vi.mock('prompts')` — controls user input on confirmation prompts
- Captures stdout / stderr via `vi.spyOn(process.stdout, 'write')` — asserts on output
- Captures exit code via `vi.spyOn(process, 'exit')` — asserts on success/failure paths

Tests run offline, fast (~5s for the whole suite), zero external dependencies (no daemon, no Telegram, no tmux). They live alongside the existing `test/unit/` tree.

## Files

**Create:**
- `test/unit/cli/sleeping.test.ts` — `kuroboto sleeping start | status | cancel` (the feature with the most surface area, post-Spec D)
- `test/unit/cli/gaming.test.ts` — `kuroboto gaming on | off | status`
- `test/unit/cli/audit.test.ts` — `kuroboto audit list | export`
- `test/unit/cli/allowlist.test.ts` — `kuroboto allowlist list | export`
- `test/unit/cli/mode.test.ts` — `kuroboto here | away`
- `test/helpers/cliHarness.ts` — shared helpers: `stubFetch(handler)`, `mockPrompts(answers)`, `captureStdout()`, `runWithExitCapture(fn)`

**Modify:**
- `vitest.config.ts` — no change expected; existing config picks up `test/unit/cli/**` automatically via the test glob
- (None of the CLI source files change.)

## Test approach — concrete patterns

**Stub fetch with handler:**

```ts
import { vi } from 'vitest';

function stubFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
  vi.stubGlobal('fetch', vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
    const u = typeof url === 'string' ? url : url.toString();
    return handler(u, init);
  }));
}

// Usage:
stubFetch((url) => {
  if (url.endsWith('/v1/sleeping')) {
    return new Response(JSON.stringify({ active: [], capacity: 6 }), { status: 200 });
  }
  return new Response('not found', { status: 404 });
});
```

**Mock prompts:**

```ts
import { vi } from 'vitest';

vi.mock('prompts', () => ({
  default: vi.fn(async (question: { name: string; type: string }) => {
    // return prepared answers
    return { val: true };  // override per test
  }),
}));
```

**Capture stdout + exit:**

```ts
const writes: string[] = [];
const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
  writes.push(typeof chunk === 'string' ? chunk : chunk.toString());
  return true;
});
const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?) => {
  throw new Error(`__exit__:${code ?? 0}`);  // throw to short-circuit, catch in test
}) as unknown as typeof process.exit;

await expect(sleepingStartCommand({ prompt: 'x' })).rejects.toThrow(/__exit__/);

expect(writes.join('')).toContain('💤 sleep started');
expect(exitSpy).toHaveBeenCalledWith(0);
```

(Helper `runWithExitCapture` wraps this pattern.)

## Coverage breakdown per file

### `sleeping.test.ts` (~12 tests)

- `status` with empty `active: []` → prints `sleep: idle (cap 6)`
- `status` with one active → prints 1 line with slug + remaining
- `status` with multiple → prints `sleep: N active (cap 6)` + N lines
- `start --prompt X` happy path → POSTs to /v1/sleeping, prints "💤 sleep started" + slug + branch + worktree
- `start --plan ./plan.md` → reads file, posts plan content, plus PLAN_INTRO behavior
- `start` rejects when both `--prompt` and `--plan` given
- `start` rejects when neither given
- `start` at capacity (429) → renders capacity-reached output (cap, active list), exits 1
- `cancel` with no active → prints "(no active sleeps)", exits 0
- `cancel` with one active → confirmation prompt with slug → on `y` cancels → prints success
- `cancel <slug>` → cancels without prompt, prints success
- `cancel <slug>` (slug not found) → exits 1 with clear error
- `cancel --all` (multiple active) → prompt lists all → on `y` cancels all → prints summary
- `cancel --yes` (single active) → no prompt, cancels
- `cancel --yes` (multi active, no slug) → silently picks most-recent (validates documented behavior)

### `gaming.test.ts` (~8 tests)

- `on` → PUT /v1/gaming `{on: true}`, prints "gaming armed"
- `on 15m` → POST with `durationMs: 900_000`, prints "armed for 15m"
- `on 2h` → POST with `durationMs: 7_200_000`
- `on bad` → fails parsing → exits 1
- `off` → PUT `{on: false}`
- `status` (active) → prints "gaming: active" + remaining if has timer
- `status` (idle) → prints "gaming: off"
- daemon offline → fetch fails → exits 1 with daemon-down message

### `audit.test.ts` (~6 tests)

- `list` (no args) → GET /v1/audit, prints last 10 entries (default limit)
- `list --since 5m` → query param `sinceMs=300000`
- `list --cwd /path` → query param `cwd=/path`
- `list --limit 50` → query param `limit=50`
- `export` → GET, prints raw JSONL to stdout (machine-readable)
- daemon offline → fetch fails → exits 1

### `allowlist.test.ts` (~5 tests)

(Different from above — these read filesystem directly, not daemon. Mock `fs`.)

- `list` (default cwd) → reads `<cwd>/.claude/settings.local.json`, prints allow + deny entries
- `list /path` → reads that path's settings
- `list` with missing settings file → prints "(empty)" / exits 0
- `list` with malformed JSON → prints error, exits 1
- `export` → JSON dump of the parsed entries

### `mode.test.ts` (~4 tests)

- `kuroboto here` → PUT /v1/mode `{mode: 'here'}`, prints "mode: here"
- `kuroboto away` → PUT /v1/mode `{mode: 'away'}`, prints "mode: away"
- daemon offline (here) → exits 1
- daemon returns 4xx → prints error from body

## Behavior details / conventions

- **No real daemon ever spawned.** All HTTP via `fetch` stub. Speed: ~5ms per test.
- **No real prompts** — `prompts` lib is mocked, answers are scripted.
- **Process exit is throwable.** Tests catch via `__exit__:N` sentinel pattern, then assert exit code.
- **Stdout/stderr captured separately.** Don't accidentally assert on color codes — strip ANSI in helper.
- **Existing tests untouched.** New `test/unit/cli/` tree is purely additive.

## Out of scope (follow-ups)

- **`kuroboto init`** — the interactive wizard has 10+ prompts and side-effects (writes config file, merges hooks into `~/.claude/settings.json`, calls Telegram for chat_id discovery). Worth a dedicated spec (`init-tests.md`) — too big to fit here without losing focus.
- **`kuroboto start | stop | status`** — process lifecycle (spawns/kills daemon). Real process management is manual-smoke territory; mocking `child_process.spawn` is brittle.
- **`kuroboto claude` / `ohayo`** — these spawn child processes (claude, tmux). Same reasoning.
- **`kuroboto hook <type>`** — internal API. Already covered indirectly via daemon integration tests.
- **End-to-end shell integration** — running the actual `kuroboto` binary via `child_process.spawnSync`. Would need a built dist + npm-link. Manual smoke covers it.

## Test plan

For each new test file: ~5–15 tests, all passing. Total ~35 tests added, ~308 → ~343.

Manual smoke (post-merge, run the original Spec D smoke from its test plan once to confirm CLI works against a live daemon — quick sanity check that the mock-based tests didn't drift from reality):

```bash
kuroboto sleeping status                     # → idle (cap 6)
kuroboto sleeping start --prompt "echo hi"
kuroboto sleeping start --prompt "echo hi 2"
kuroboto sleeping status                     # → 2 active
kuroboto sleeping cancel --all --yes         # → cancels both
```

If CLI output matches what the unit tests assert on, the mock layer is faithful.

## Tasks

1. **M1**: Create `test/helpers/cliHarness.ts` with `stubFetch`, `mockPrompts`, `captureStdout`, `runWithExitCapture`. Add `test/unit/cli/sleeping.test.ts` (15 tests). Verify all pass via `npx vitest run test/unit/cli/sleeping.test.ts`.
2. **M2**: Add `test/unit/cli/gaming.test.ts` + `test/unit/cli/mode.test.ts` (state-toggle commands).
3. **M3**: Add `test/unit/cli/audit.test.ts` + `test/unit/cli/allowlist.test.ts` (data-read commands; allowlist mocks fs instead of fetch). Run full suite — all 343 tests passing. PR.

```

## Test plan

- [ ] Review the diff against the original prompt
- [ ] Run the test suite locally
- [ ] Smoke-test the new behavior end-to-end

_Generated by kuroboto sleep mode._