### PR TITLE
fix(daemon): skip gaming FYI when sleep session is active

### DIFF
--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -318,9 +318,18 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
         source: 'gaming',
         remember: false,
       }).catch((e) => ctx.logger.warn('audit append failed', { err: (e as Error).message }));
-      formatPermissionPrompt(payload, fmtCtx())
-        .then((text) => ctx.channel.sendNotification(`🎮 ${text}`, topicCtx))
-        .catch((e) => ctx.logger.warn('gaming notify failed', { err: (e as Error).message }));
+      // Skip per-tool FYI when a sleep session is active. Autonomous claude
+      // hammers tool calls (playwright, Grep, Read, etc.); per-call FYIs flood
+      // Telegram badly enough to crash the client. Sleep mode already
+      // announces start/done/error; per-tool noise during sleep is pure spam.
+      // When gaming was armed manually (no active sleep), keep FYIs — that's
+      // the "playing a game, monitoring between rounds" use case.
+      const sleepActive = ctx.state.sleeping.snapshot().active.length > 0;
+      if (!sleepActive) {
+        formatPermissionPrompt(payload, fmtCtx())
+          .then((text) => ctx.channel.sendNotification(`🎮 ${text}`, topicCtx))
+          .catch((e) => ctx.logger.warn('gaming notify failed', { err: (e as Error).message }));
+      }
       res.json(decision);
       return;
     }


### PR DESCRIPTION
Stops Telegram-flooding-during-sleep flood. Witnessed live (client crashed).

When sleep mode is active, autonomous claude triggers dozens of tool calls per minute (playwright, Grep, Read). Each fired a `🎮`-prefixed FYI to Telegram. Result: chat flood + client crash.

This patch skips per-tool FYI when `sleeping.snapshot().active.length > 0`. Sleep mode already announces start/done/error; per-tool FYI was pure noise during autonomous work.

Manual gaming (`kuroboto gaming on`) still sends FYIs — that's the intended UX for 'play, monitor between rounds'.

## Test plan
- [x] tsc clean, all tests pass
- [ ] CI green
- [ ] Smoke: dispatch a sleep, observe Telegram — should only see start/done events, no per-tool 🎮