### PR TITLE
feat(cli): improvements bundle (Spec I)

### DIFF
--- a/src/channels/Channel.ts
+++ b/src/channels/Channel.ts
@@ -34,6 +34,22 @@ export interface ChannelContext {
   system?: boolean;
 }
 
+export interface ClearTopicsResult {
+  /** Topic keys that were successfully cleared. */
+  cleared: string[];
+  /** Topic keys that errored out (Telegram refused, network, etc.). */
+  failed: Array<{ key: string; error: string }>;
+}
+
+export interface ClearMessagesResult {
+  /** Messages the daemon attempted to delete. */
+  attempted: number;
+  /** Successfully deleted messages. */
+  deleted: number;
+  /** Messages outside the 48h bot delete window — Telegram refuses these. */
+  outOfWindow: number;
+}
+
 export interface Channel {
   start(): Promise<void>;
   stop(): Promise<void>;
@@ -43,4 +59,11 @@ export interface Channel {
    *  message id used to correlate the user's reply back to this question. */
   sendQuestion(req: QuestionRequest, ctx?: ChannelContext): Promise<{ sentMessageId: string }>;
   on<K extends ChannelEventName>(event: K, handler: ChannelEventHandlers[K]): void;
+  /**
+   * Clear forum topics by key (or all of them, except optional preserved keys).
+   * Implementations without a forum surface (DM mode) reject the request.
+   */
+  clearTopics?(opts: { keys?: string[]; all?: boolean; except?: string[]; dryRun?: boolean }): Promise<ClearTopicsResult>;
+  /** Delete the last N outbound messages tracked by the channel. */
+  clearLastMessages?(n: number, opts?: { dryRun?: boolean }): Promise<ClearMessagesResult>;
 }

--- a/src/channels/telegram/TelegramChannel.ts
+++ b/src/channels/telegram/TelegramChannel.ts
@@ -135,11 +135,6 @@ export class TelegramChannel implements Channel {
     }
   }
 
-  /** Test helper — exposes the tracked outbound message IDs. */
-  getSentMessages(): ReadonlyArray<{ messageId: number; sentAt: number }> {
-    return this.sentMessages;
-  }
-
   async clearTopics(opts: {
     keys?: string[];
     all?: boolean;

--- a/src/channels/telegram/TelegramChannel.ts
+++ b/src/channels/telegram/TelegramChannel.ts
@@ -11,6 +11,8 @@ import type {
   ChannelContext,
   ChannelEventName,
   ChannelEventHandlers,
+  ClearTopicsResult,
+  ClearMessagesResult,
 } from '../Channel.js';
 import {
   TelegramApi,
@@ -20,6 +22,11 @@ import {
 } from './api.js';
 import { Poller } from './poller.js';
 import { TopicManager, pickTopicKey } from './topics.js';
+
+/** Telegram refuses bot deleteMessage on messages older than 48 hours. */
+const BOT_DELETE_WINDOW_MS = 48 * 60 * 60 * 1000;
+/** Cap how many outbound message IDs we keep for chat clear. */
+const SENT_MESSAGE_RING_SIZE = 1000;
 
 export interface TelegramChannelOptions {
   token: string;
@@ -38,6 +45,8 @@ export class TelegramChannel implements Channel {
   };
   private readonly promptMessageIds = new Map<string, { messageId: number; chatId: number }>();
   private awaitingNoteFor: string | null = null;
+  /** Ring buffer of outbound message ids — used by chat clear. Newest last. */
+  private readonly sentMessages: Array<{ messageId: number; sentAt: number }> = [];
 
   constructor(private readonly opts: TelegramChannelOptions) {
     this.api = new TelegramApi(opts.token);
@@ -99,18 +108,123 @@ export class TelegramChannel implements Channel {
     ctx: ChannelContext | undefined,
     send: (threadId: number | undefined) => Promise<number>,
   ): Promise<number> {
-    if (!this.topicManager) return send(undefined);
-    const { key, name } = pickTopicKey(ctx);
-    const threadId = await this.topicManager.resolve(key, name);
-    try {
-      return await send(threadId);
-    } catch (e) {
-      if (!isThreadNotFoundError(e)) throw e;
-      this.opts.logger.warn('topic missing, purging and recreating', { key });
-      await this.topicManager.purge(key);
-      const newId = await this.topicManager.resolve(key, name);
-      return send(newId);
+    let messageId: number;
+    if (!this.topicManager) {
+      messageId = await send(undefined);
+    } else {
+      const { key, name } = pickTopicKey(ctx);
+      const threadId = await this.topicManager.resolve(key, name);
+      try {
+        messageId = await send(threadId);
+      } catch (e) {
+        if (!isThreadNotFoundError(e)) throw e;
+        this.opts.logger.warn('topic missing, purging and recreating', { key });
+        await this.topicManager.purge(key);
+        const newId = await this.topicManager.resolve(key, name);
+        messageId = await send(newId);
+      }
     }
+    this.recordSent(messageId);
+    return messageId;
+  }
+
+  private recordSent(messageId: number): void {
+    this.sentMessages.push({ messageId, sentAt: Date.now() });
+    if (this.sentMessages.length > SENT_MESSAGE_RING_SIZE) {
+      this.sentMessages.splice(0, this.sentMessages.length - SENT_MESSAGE_RING_SIZE);
+    }
+  }
+
+  /** Test helper — exposes the tracked outbound message IDs. */
+  getSentMessages(): ReadonlyArray<{ messageId: number; sentAt: number }> {
+    return this.sentMessages;
+  }
+
+  async clearTopics(opts: {
+    keys?: string[];
+    all?: boolean;
+    except?: string[];
+    dryRun?: boolean;
+  }): Promise<ClearTopicsResult> {
+    if (!this.topicManager) {
+      throw new Error('forumMode is off — use `kuroboto chat clear` instead');
+    }
+    const except = new Set(opts.except ?? []);
+    let targets: Array<{ key: string; threadId: number }>;
+    if (opts.all) {
+      targets = this.topicManager.entries().filter((e) => !except.has(e.key));
+    } else {
+      targets = (opts.keys ?? [])
+        .map((k) => {
+          const threadId = this.topicManager!.get(k);
+          return threadId === undefined ? null : { key: k, threadId };
+        })
+        .filter((x): x is { key: string; threadId: number } => x !== null);
+    }
+    const cleared: string[] = [];
+    const failed: Array<{ key: string; error: string }> = [];
+    if (opts.dryRun) {
+      return { cleared: targets.map((t) => t.key), failed: [] };
+    }
+    for (const t of targets) {
+      try {
+        await this.api.deleteForumTopic(this.opts.chatId, t.threadId);
+        await this.topicManager.purge(t.key);
+        cleared.push(t.key);
+      } catch (e) {
+        const err = (e as Error).message;
+        // Telegram already lost the topic? Purge our cache so it doesn't keep
+        // pointing at a dead thread.
+        if (isThreadNotFoundError(e)) {
+          await this.topicManager.purge(t.key).catch(() => {});
+          cleared.push(t.key);
+        } else {
+          failed.push({ key: t.key, error: err });
+        }
+      }
+    }
+    return { cleared, failed };
+  }
+
+  async clearLastMessages(n: number, opts: { dryRun?: boolean } = {}): Promise<ClearMessagesResult> {
+    if (n <= 0) return { attempted: 0, deleted: 0, outOfWindow: 0 };
+    const slice = this.sentMessages.slice(-n);
+    if (opts.dryRun) {
+      const cutoff = Date.now() - BOT_DELETE_WINDOW_MS;
+      const outOfWindow = slice.filter((m) => m.sentAt < cutoff).length;
+      return { attempted: slice.length, deleted: 0, outOfWindow };
+    }
+    const cutoff = Date.now() - BOT_DELETE_WINDOW_MS;
+    let deleted = 0;
+    let outOfWindow = 0;
+    const survivors: number[] = [];
+    for (const m of slice) {
+      if (m.sentAt < cutoff) {
+        outOfWindow += 1;
+        continue;
+      }
+      try {
+        await this.api.deleteMessage(this.opts.chatId, m.messageId);
+        deleted += 1;
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (/can't be deleted|message to delete not found/i.test(msg)) {
+          outOfWindow += 1;
+        } else {
+          survivors.push(m.messageId);
+          this.opts.logger.warn('deleteMessage failed', { messageId: m.messageId, err: msg });
+        }
+      }
+    }
+    // Drop deleted ids from the tracker so a second `chat clear --last N` does
+    // not re-attempt them.
+    for (const m of slice) {
+      const stillTracked = survivors.includes(m.messageId);
+      if (stillTracked) continue;
+      const idx = this.sentMessages.findIndex((s) => s.messageId === m.messageId);
+      if (idx >= 0) this.sentMessages.splice(idx, 1);
+    }
+    return { attempted: slice.length, deleted, outOfWindow };
   }
 
   private handleUpdate(update: TelegramUpdate): void {

--- a/src/channels/telegram/api.ts
+++ b/src/channels/telegram/api.ts
@@ -146,6 +146,50 @@ export class TelegramApi {
     }
   }
 
+  async deleteMessage(chatId: number, messageId: number, timeoutMs = 5_000): Promise<void> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(this.url('deleteMessage'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, message_id: messageId }),
+        signal: ctrl.signal,
+      });
+      const json = (await res.json().catch(() => null)) as
+        | { ok: boolean; description?: string }
+        | null;
+      if (!res.ok || !json?.ok) {
+        const desc = json?.description ?? `HTTP ${res.status}`;
+        throw new ChannelError(`telegram: ${desc}`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async deleteForumTopic(chatId: number, messageThreadId: number, timeoutMs = 10_000): Promise<void> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(this.url('deleteForumTopic'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, message_thread_id: messageThreadId }),
+        signal: ctrl.signal,
+      });
+      const json = (await res.json().catch(() => null)) as
+        | { ok: boolean; description?: string }
+        | null;
+      if (!res.ok || !json?.ok) {
+        const desc = json?.description ?? `HTTP ${res.status}`;
+        throw new ChannelError(`telegram: ${desc}`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   async createForumTopic(chatId: number, name: string, timeoutMs = 10_000): Promise<number> {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);

--- a/src/channels/telegram/topics.ts
+++ b/src/channels/telegram/topics.ts
@@ -158,6 +158,16 @@ export class TopicManager {
     this.opts.audit?.({ source: 'topic-purged', key });
   }
 
+  /** Snapshot of every cached key + thread-id pair. */
+  entries(): Array<{ key: string; threadId: number }> {
+    return [...this.cache.entries()].map(([key, threadId]) => ({ key, threadId }));
+  }
+
+  /** Returns the cached thread-id for a key, or undefined when absent. */
+  get(key: string): number | undefined {
+    return this.cache.get(key);
+  }
+
   private async flushToDisk(): Promise<void> {
     const obj: Record<string, number> = {};
     for (const [k, v] of this.cache) obj[k] = v;

--- a/src/cli/chatClear.ts
+++ b/src/cli/chatClear.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk';
+import prompts from 'prompts';
+import { kuroFetch } from './http.js';
+
+export interface ChatClearOpts {
+  last?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+interface ClearResponse {
+  ok?: boolean;
+  attempted?: number;
+  deleted?: number;
+  outOfWindow?: number;
+  dryRun?: boolean;
+  error?: string;
+}
+
+export async function chatClearCommand(opts: ChatClearOpts): Promise<void> {
+  const last = opts.last ? Number.parseInt(opts.last, 10) : NaN;
+  if (!Number.isFinite(last) || last <= 0) {
+    console.error(chalk.red('--last <N> required (positive integer)'));
+    process.exit(1);
+  }
+
+  if (!opts.yes && !opts.dryRun) {
+    const confirm = await prompts({
+      type: 'confirm',
+      name: 'val',
+      message: `delete the last ${last} bot message${last === 1 ? '' : 's'}?`,
+      initial: false,
+    });
+    if (confirm.val !== true) {
+      console.log(chalk.dim('aborted'));
+      return;
+    }
+  }
+
+  const res = await kuroFetch<ClearResponse>('/v1/chat/clear', {
+    method: 'POST',
+    body: { last, dryRun: opts.dryRun === true },
+    timeoutMs: Math.max(15_000, last * 200),
+  });
+  if (!res.ok) {
+    console.error(chalk.red(res.body.error ?? `daemon HTTP ${res.status}`));
+    process.exit(1);
+  }
+
+  const attempted = res.body.attempted ?? 0;
+  const deleted = res.body.deleted ?? 0;
+  const outOfWindow = res.body.outOfWindow ?? 0;
+  if (res.body.dryRun) {
+    console.log(chalk.dim(`would attempt ${attempted} (${outOfWindow} outside 48h window)`));
+    return;
+  }
+  console.log(
+    chalk.green(`deleted ${deleted} of last ${attempted}`) +
+      (outOfWindow > 0 ? chalk.dim(` (${outOfWindow} outside 48h delete window)`) : ''),
+  );
+}

--- a/src/cli/gaming.ts
+++ b/src/cli/gaming.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
-import { loadConfig } from '../config/load.js';
 import { parseDuration } from '../daemon/gaming.js';
+import { kuroFetch } from './http.js';
 
 interface GamingSnapshot {
   active: boolean;
@@ -8,36 +8,22 @@ interface GamingSnapshot {
 }
 
 async function postGaming(body: { on: boolean; durationMs?: number }): Promise<GamingSnapshot> {
-  const config = await loadConfig();
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), 2_000);
-  try {
-    const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/gaming`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Kuroboto-Token': config.daemon.authToken,
-      },
-      body: JSON.stringify(body),
-      signal: ctrl.signal,
-    });
-    clearTimeout(timer);
-    if (!res.ok) throw new Error(`daemon HTTP ${res.status}`);
-    const json = (await res.json()) as { ok: boolean; active: boolean; until: number | null };
-    return { active: json.active, until: json.until };
-  } catch (e) {
-    clearTimeout(timer);
-    throw new Error(`daemon offline or unreachable: ${(e as Error).message}`);
+  const res = await kuroFetch<{ ok: boolean; active: boolean; until: number | null } | { error?: string }>(
+    '/v1/gaming',
+    { method: 'PUT', body, timeoutMs: 2_000 },
+  );
+  if (!res.ok) {
+    const err = res.body as { error?: string };
+    throw new Error(err?.error ?? `daemon HTTP ${res.status}`);
   }
+  const json = res.body as { active: boolean; until: number | null };
+  return { active: json.active, until: json.until };
 }
 
 async function getGaming(): Promise<GamingSnapshot> {
-  const config = await loadConfig();
-  const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/gaming`, {
-    headers: { 'X-Kuroboto-Token': config.daemon.authToken },
-  });
+  const res = await kuroFetch<GamingSnapshot>('/v1/gaming');
   if (!res.ok) throw new Error(`daemon HTTP ${res.status}`);
-  return (await res.json()) as GamingSnapshot;
+  return res.body;
 }
 
 function formatRemaining(untilMs: number): string {

--- a/src/cli/http.ts
+++ b/src/cli/http.ts
@@ -1,0 +1,110 @@
+import chalk from 'chalk';
+import { loadConfig } from '../config/load.js';
+
+export interface KuroFetchOptions {
+  /** HTTP method (GET when omitted). */
+  method?: string;
+  /** JSON-serialisable body — `Content-Type: application/json` is added automatically. */
+  body?: unknown;
+  /** Per-request timeout. Defaults to 5_000 ms; raise for long-running endpoints. */
+  timeoutMs?: number;
+}
+
+export interface KuroFetchResult<T = unknown> {
+  status: number;
+  ok: boolean;
+  body: T;
+}
+
+let debugFlag = false;
+
+/** Toggle debug tracing for every subsequent kuroFetch call. */
+export function setDebug(on: boolean): void {
+  debugFlag = on;
+}
+
+export function isDebug(): boolean {
+  return debugFlag;
+}
+
+/**
+ * Wrapper over `fetch` for daemon HTTP calls. Adds the auth header, prints a
+ * friendly "daemon offline" message on connection-refused (instead of letting
+ * `fetch failed` bubble up unannotated), and emits stderr trace lines when
+ * --debug is active.
+ *
+ * Returns the parsed JSON body alongside the status code; non-2xx responses
+ * are returned as-is — callers decide how to handle them.
+ */
+export async function kuroFetch<T = unknown>(
+  pathOrUrl: string,
+  opts: KuroFetchOptions = {},
+): Promise<KuroFetchResult<T>> {
+  const config = await loadConfig();
+  const url = pathOrUrl.startsWith('http')
+    ? pathOrUrl
+    : `http://127.0.0.1:${config.daemon.port}${pathOrUrl}`;
+  const method = opts.method ?? 'GET';
+  const headers: Record<string, string> = {
+    'X-Kuroboto-Token': config.daemon.authToken,
+  };
+  let body: string | undefined;
+  if (opts.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(opts.body);
+  }
+  const timeoutMs = opts.timeoutMs ?? 5_000;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+
+  if (debugFlag) {
+    process.stderr.write(`[debug] ${method} ${url}${body ? ` ${body}` : ''}\n`);
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, { method, headers, body, signal: ctrl.signal });
+  } catch (e) {
+    clearTimeout(timer);
+    handleFetchError(e);
+    // handleFetchError exits the process; this throw keeps TS happy.
+    throw e;
+  }
+  clearTimeout(timer);
+
+  let parsed: T;
+  const text = await res.text();
+  try {
+    parsed = (text ? JSON.parse(text) : {}) as T;
+  } catch {
+    parsed = text as unknown as T;
+  }
+
+  if (debugFlag) {
+    process.stderr.write(`[debug] ← ${res.status} ${typeof parsed === 'string' ? parsed : JSON.stringify(parsed)}\n`);
+  }
+
+  return { status: res.status, ok: res.ok, body: parsed };
+}
+
+/**
+ * Detect the connection-refused / timed-out / aborted family of errors that
+ * mean "daemon is not running" and exit with a clear message. Other errors
+ * propagate.
+ */
+function handleFetchError(e: unknown): never {
+  const err = e as Error & { code?: string; cause?: { code?: string } };
+  const codes = [err.code, err.cause?.code];
+  const offline =
+    codes.includes('ECONNREFUSED') ||
+    codes.includes('ETIMEDOUT') ||
+    err.name === 'AbortError';
+  if (offline) {
+    process.stderr.write(
+      chalk.red('✗ daemon offline. start it with `kuroboto start -d`.\n'),
+    );
+    process.exit(1);
+  }
+  process.stderr.write(chalk.red(`✗ daemon request failed: ${err.message}\n`));
+  process.exit(1);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -99,10 +99,11 @@ program
 
 program
   .command('ohayo')
-  .description('Morning ritual: tmux session "claude" + daemon + Claude Code, all wired')
-  .action(async () => {
+  .description('Morning ritual: daemon + Claude Code in this terminal (PTY). Use --tmux for the legacy detachable session.')
+  .option('--tmux', 'use the legacy tmux-attached flow (detachable session, intercepted bell)', false)
+  .action(async (opts: { tmux?: boolean }) => {
     try {
-      await ohayoCommand();
+      await ohayoCommand(opts);
     } catch (e) {
       console.error(`ohayo failed: ${(e as Error).message}`);
       process.exit(1);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,8 @@ const claudeShortcut =
 // `--debug` lives on every command (including subcommands) — scan argv once
 // up front so it's effective even when passed after a subcommand name. Strip
 // the flag from argv afterward so per-subcommand parsing doesn't choke on it.
+// (Hand-rolled rather than declared on `program` because Commander's `.option`
+// only parses flags that appear before the subcommand name.)
 if (process.argv.includes('--debug')) {
   setDebug(true);
   process.argv = process.argv.filter((a) => a !== '--debug');
@@ -44,9 +46,10 @@ const program = new Command();
 
 program
   .name('kuroboto')
-  .description('Respond to Claude Code prompts from your phone via chat (Telegram first).')
-  .version('0.1.0')
-  .option('--debug', 'trace daemon HTTP requests + responses on stderr', false);
+  .description(
+    'Respond to Claude Code prompts from your phone via chat (Telegram first). Pass --debug on any subcommand to trace daemon HTTP on stderr.',
+  )
+  .version('0.1.0');
 
 program
   .command('init')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,10 @@ import { allowlistList, allowlistExport } from './allowlist.js';
 import { auditList, auditExport } from './audit.js';
 import { gamingOnCommand, gamingOffCommand, gamingStatusCommand } from './gaming.js';
 import { sleepingStartCommand, sleepingCancelCommand, sleepingStatusCommand } from './sleeping.js';
+import { sleepingCleanupCommand } from './sleepingCleanup.js';
+import { topicsClearCommand } from './topicsClear.js';
+import { chatClearCommand } from './chatClear.js';
+import { setDebug } from './http.js';
 
 // Special-case: `kuroboto claude [...args]` forwards everything raw to Claude Code.
 // Commander would otherwise eat global flags like --version / --help before they
@@ -19,6 +23,14 @@ import { sleepingStartCommand, sleepingCancelCommand, sleepingStatusCommand } fr
 const claudeIdx = process.argv.indexOf('claude');
 const claudeShortcut =
   claudeIdx >= 2 && process.argv.slice(2, claudeIdx).every((a) => !a.startsWith('-'));
+
+// `--debug` lives on every command (including subcommands) — scan argv once
+// up front so it's effective even when passed after a subcommand name. Strip
+// the flag from argv afterward so per-subcommand parsing doesn't choke on it.
+if (process.argv.includes('--debug')) {
+  setDebug(true);
+  process.argv = process.argv.filter((a) => a !== '--debug');
+}
 
 if (claudeShortcut) {
   const forward = process.argv.slice(claudeIdx + 1);
@@ -33,7 +45,8 @@ const program = new Command();
 program
   .name('kuroboto')
   .description('Respond to Claude Code prompts from your phone via chat (Telegram first).')
-  .version('0.1.0');
+  .version('0.1.0')
+  .option('--debug', 'trace daemon HTTP requests + responses on stderr', false);
 
 program
   .command('init')
@@ -218,6 +231,51 @@ sleeping
       await sleepingStatusCommand();
     } catch (e) {
       console.error(`sleeping status failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  });
+sleeping
+  .command('cleanup')
+  .description('Remove worktrees + local branches + stale remotes for already-merged sleep PRs')
+  .option('--dry-run', 'list what would be cleaned without doing it', false)
+  .option('--yes', 'skip confirmation prompt', false)
+  .action(async (opts: { dryRun?: boolean; yes?: boolean }) => {
+    try {
+      await sleepingCleanupCommand(opts);
+    } catch (e) {
+      console.error(`sleeping cleanup failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+const topics = program.command('topics').description('Manage Telegram forum topics (supergroup/forum mode)');
+topics
+  .command('clear [slug]')
+  .description('Delete a topic by slug (or every topic with --all). System topic is preserved.')
+  .option('--all', 'clear every topic except kuroboto-system', false)
+  .option('--dry-run', 'list what would be deleted without doing it', false)
+  .option('--yes', 'skip confirmation prompt', false)
+  .action(async (slug: string | undefined, opts: { all?: boolean; dryRun?: boolean; yes?: boolean }) => {
+    try {
+      await topicsClearCommand(slug, opts);
+    } catch (e) {
+      console.error(`topics clear failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+const chat = program.command('chat').description('Manage Telegram chat messages');
+chat
+  .command('clear')
+  .description('Delete the last N outbound bot messages (bounded by Telegram\'s 48h delete window)')
+  .option('--last <n>', 'how many recent messages to delete')
+  .option('--dry-run', 'list what would be deleted without doing it', false)
+  .option('--yes', 'skip confirmation prompt', false)
+  .action(async (opts: { last?: string; dryRun?: boolean; yes?: boolean }) => {
+    try {
+      await chatClearCommand(opts);
+    } catch (e) {
+      console.error(`chat clear failed: ${(e as Error).message}`);
       process.exit(1);
     }
   });

--- a/src/cli/ohayo.ts
+++ b/src/cli/ohayo.ts
@@ -1,38 +1,52 @@
 import { spawn, spawnSync } from 'node:child_process';
 import chalk from 'chalk';
+import { checkHealth } from './util.js';
+import { startCommand } from './start.js';
+import { runInjectClient, installCrashSafety } from './injectClient.js';
 
-const SESSION = 'claude';
-const STARTUP_COMMAND = 'kuroboto claude';
+const TMUX_SESSION = 'claude';
+const TMUX_STARTUP_COMMAND = 'kuroboto claude';
 
-function tmuxAvailable(): boolean {
-  return spawnSync('tmux', ['-V'], { stdio: 'ignore' }).status === 0;
+export interface OhayoOpts {
+  tmux?: boolean;
 }
 
-function tmuxHasSession(session: string): boolean {
-  return spawnSync('tmux', ['has-session', '-t', session], { stdio: 'ignore' }).status === 0;
-}
-
-export async function ohayoCommand(): Promise<void> {
+export async function ohayoCommand(opts: OhayoOpts = {}): Promise<void> {
   console.log(chalk.bold('ohayo 🌅'));
 
-  if (!tmuxAvailable()) {
-    console.error(chalk.red('tmux not found on PATH. Install tmux first (or use `kuroboto claude` for the no-tmux flow).'));
-    process.exit(1);
+  const health = await checkHealth();
+  if (!health.ok) {
+    console.log(chalk.dim('[kuroboto] daemon offline, subindo em background…'));
+    await startCommand({ detach: true });
   }
 
-  if (!tmuxHasSession(SESSION)) {
-    console.log(chalk.dim(`creating tmux session "${SESSION}"…`));
-    // Step 1: detached empty session (avoids tmux-windows quirks with `-d -c`
-    // and with shell-command passed as a single arg to new-session).
-    const create = spawnSync('tmux', ['new-session', '-d', '-s', SESSION], { stdio: 'inherit' });
+  if (opts.tmux) {
+    runTmux();
+    return;
+  }
+
+  // Default: PTY-wrap claude in this terminal — no tmux overlay, no
+  // intercepted bell, daemon Q&A still works via the inject client.
+  installCrashSafety();
+  const result = await runInjectClient({ args: [] });
+  process.exit(result.exitCode);
+}
+
+function runTmux(): void {
+  if (!tmuxAvailable()) {
+    console.error(chalk.red('tmux not found on PATH. Install tmux first or drop the --tmux flag.'));
+    process.exit(1);
+  }
+  if (!tmuxHasSession(TMUX_SESSION)) {
+    console.log(chalk.dim(`creating tmux session "${TMUX_SESSION}"…`));
+    const create = spawnSync('tmux', ['new-session', '-d', '-s', TMUX_SESSION], { stdio: 'inherit' });
     if (create.status !== 0) {
       console.error(chalk.red(`failed to create tmux session (exit ${create.status})`));
       process.exit(1);
     }
-    // Step 2: paste the startup command into the session's first pane.
     const send = spawnSync(
       'tmux',
-      ['send-keys', '-t', SESSION, STARTUP_COMMAND, 'Enter'],
+      ['send-keys', '-t', TMUX_SESSION, TMUX_STARTUP_COMMAND, 'Enter'],
       { stdio: 'inherit' },
     );
     if (send.status !== 0) {
@@ -41,14 +55,20 @@ export async function ohayoCommand(): Promise<void> {
     }
     console.log(chalk.dim(`session ready, attaching…`));
   } else {
-    console.log(chalk.dim(`attaching to existing tmux session "${SESSION}"…`));
+    console.log(chalk.dim(`attaching to existing tmux session "${TMUX_SESSION}"…`));
   }
-
-  // Step 3: attach in foreground.
-  const child = spawn('tmux', ['attach-session', '-t', SESSION], { stdio: 'inherit' });
+  const child = spawn('tmux', ['attach-session', '-t', TMUX_SESSION], { stdio: 'inherit' });
   child.on('exit', (c) => process.exit(c ?? 0));
   child.on('error', (e) => {
     console.error(chalk.red(`tmux attach failed: ${e.message}`));
     process.exit(1);
   });
+}
+
+function tmuxAvailable(): boolean {
+  return spawnSync('tmux', ['-V'], { stdio: 'ignore' }).status === 0;
+}
+
+function tmuxHasSession(session: string): boolean {
+  return spawnSync('tmux', ['has-session', '-t', session], { stdio: 'ignore' }).status === 0;
 }

--- a/src/cli/sleeping.ts
+++ b/src/cli/sleeping.ts
@@ -2,8 +2,8 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import chalk from 'chalk';
 import prompts from 'prompts';
-import { loadConfig } from '../config/load.js';
 import { parseDuration } from '../daemon/gaming.js';
+import { kuroFetch } from './http.js';
 
 interface StartOpts {
   prompt?: string;
@@ -38,51 +38,37 @@ interface CapacityErrorBody {
 }
 
 async function postStart(body: { repo: string; prompt?: string; plan?: string; maxDurationMs?: number }) {
-  const config = await loadConfig();
-  const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/sleeping`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Kuroboto-Token': config.daemon.authToken,
-    },
-    body: JSON.stringify(body),
-  });
+  const res = await kuroFetch<{ slug: string; branch: string; worktreePath: string } | CapacityErrorBody | { error?: string }>(
+    '/v1/sleeping',
+    { method: 'POST', body },
+  );
   if (!res.ok) {
     if (res.status === 429) {
-      const cap = (await res.json().catch(() => ({}))) as CapacityErrorBody;
-      printCapacityReached(cap);
+      printCapacityReached(res.body as CapacityErrorBody);
       throw new Error('capacity reached');
     }
-    const err = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(err.error ?? `daemon HTTP ${res.status}`);
+    const err = res.body as { error?: string };
+    throw new Error(err?.error ?? `daemon HTTP ${res.status}`);
   }
-  return (await res.json()) as { slug: string; branch: string; worktreePath: string };
+  return res.body as { slug: string; branch: string; worktreePath: string };
 }
 
 async function getStatus(): Promise<SleepingSnapshot> {
-  const config = await loadConfig();
-  const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/sleeping`, {
-    headers: { 'X-Kuroboto-Token': config.daemon.authToken },
-  });
+  const res = await kuroFetch<SleepingSnapshot>('/v1/sleeping');
   if (!res.ok) throw new Error(`daemon HTTP ${res.status}`);
-  return (await res.json()) as SleepingSnapshot;
+  return res.body;
 }
 
 async function postCancel(body: { slug?: string; all?: boolean }): Promise<{ cancelled: string[] }> {
-  const config = await loadConfig();
-  const res = await fetch(`http://127.0.0.1:${config.daemon.port}/v1/sleeping/cancel`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Kuroboto-Token': config.daemon.authToken,
-    },
-    body: JSON.stringify(body),
-  });
+  const res = await kuroFetch<{ cancelled: string[] } | { error?: string }>(
+    '/v1/sleeping/cancel',
+    { method: 'POST', body },
+  );
   if (!res.ok) {
-    const err = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(err.error ?? `daemon HTTP ${res.status}`);
+    const err = res.body as { error?: string };
+    throw new Error(err?.error ?? `daemon HTTP ${res.status}`);
   }
-  return (await res.json()) as { cancelled: string[] };
+  return res.body as { cancelled: string[] };
 }
 
 function formatRemaining(snap: SessionSnap): string {

--- a/src/cli/sleepingCleanup.ts
+++ b/src/cli/sleepingCleanup.ts
@@ -1,0 +1,184 @@
+import os from 'node:os';
+import path from 'node:path';
+import chalk from 'chalk';
+import prompts from 'prompts';
+import { loadConfig } from '../config/load.js';
+
+export interface ExecResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type ExecFn = (cmd: string, args: string[]) => Promise<ExecResult>;
+
+export interface CleanupOpts {
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+interface PrJson {
+  number: number;
+  headRefName: string;
+  state: string;
+}
+
+export interface MergedSleep {
+  prNumber: number;
+  branch: string;
+  slug: string;
+  worktreePath: string;
+}
+
+export interface CleanupDeps {
+  exec: ExecFn;
+  workRoot: string;
+  confirm?: (msg: string) => Promise<boolean>;
+  log?: (line: string) => void;
+  warn?: (line: string) => void;
+}
+
+/**
+ * Pulls merged sleep PRs from `gh` and resolves each branch to its worktree
+ * path. Open PRs are skipped — cleanup only touches branches GitHub considers
+ * already merged.
+ */
+export async function listMergedSleeps(deps: Omit<CleanupDeps, 'confirm' | 'log' | 'warn'>): Promise<MergedSleep[]> {
+  const r = await deps.exec('gh', [
+    'pr',
+    'list',
+    '--state', 'merged',
+    '--head', 'sleep/',
+    '--json', 'number,headRefName,state',
+    '--limit', '100',
+  ]);
+  if (r.code !== 0) {
+    throw new Error(`gh pr list failed: ${r.stderr.trim() || `exit ${r.code}`}`);
+  }
+  let prs: PrJson[];
+  try {
+    prs = JSON.parse(r.stdout) as PrJson[];
+  } catch (e) {
+    throw new Error(`gh pr list returned invalid JSON: ${(e as Error).message}`);
+  }
+  return prs
+    .filter((p) => p.state === 'MERGED' && p.headRefName.startsWith('sleep/'))
+    .map((p) => {
+      const slug = p.headRefName.slice('sleep/'.length);
+      return {
+        prNumber: p.number,
+        branch: p.headRefName,
+        slug,
+        worktreePath: path.join(deps.workRoot, slug),
+      };
+    });
+}
+
+/**
+ * For each merged sleep, removes its worktree, deletes the local branch, and
+ * prunes the stale remote ref. Best-effort per step — a missing worktree
+ * doesn't stop the branch deletion. Returns the per-entry success summary so
+ * tests can assert on it.
+ */
+export async function cleanupMerged(
+  entries: MergedSleep[],
+  deps: CleanupDeps,
+): Promise<Array<{ slug: string; worktreeRemoved: boolean; branchDeleted: boolean; remotePruned: boolean; errors: string[] }>> {
+  const log = deps.log ?? ((l: string) => console.log(l));
+  const warn = deps.warn ?? ((l: string) => console.warn(l));
+  const results: Array<{ slug: string; worktreeRemoved: boolean; branchDeleted: boolean; remotePruned: boolean; errors: string[] }> = [];
+  for (const e of entries) {
+    const result = { slug: e.slug, worktreeRemoved: false, branchDeleted: false, remotePruned: false, errors: [] as string[] };
+
+    const wt = await deps.exec('git', ['worktree', 'remove', '--force', e.worktreePath]);
+    if (wt.code === 0) {
+      result.worktreeRemoved = true;
+    } else if (/not a working tree|No such|does not exist/i.test(wt.stderr)) {
+      // Already cleaned up — fine.
+    } else {
+      result.errors.push(`worktree remove: ${wt.stderr.trim() || `exit ${wt.code}`}`);
+      warn(chalk.yellow(`  ⚠ worktree remove failed for ${e.slug}: ${wt.stderr.trim()}`));
+    }
+
+    const br = await deps.exec('git', ['branch', '-D', e.branch]);
+    if (br.code === 0) {
+      result.branchDeleted = true;
+    } else if (/not found/i.test(br.stderr)) {
+      // Already gone — fine.
+    } else {
+      result.errors.push(`branch delete: ${br.stderr.trim() || `exit ${br.code}`}`);
+      warn(chalk.yellow(`  ⚠ branch delete failed for ${e.branch}: ${br.stderr.trim()}`));
+    }
+
+    log(`  • ${chalk.green('cleaned')} ${e.slug.padEnd(46)} PR #${e.prNumber}`);
+    results.push(result);
+  }
+  // One final prune pass to drop stale `origin/sleep/*` refs.
+  const prune = await deps.exec('git', ['fetch', '--prune']);
+  if (prune.code === 0) {
+    for (const r of results) r.remotePruned = true;
+  }
+  return results;
+}
+
+function expandHome(p: string): string {
+  if (p.startsWith('~/') || p === '~') {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+const exec: ExecFn = async (cmd, args) => {
+  const { spawn } = await import('node:child_process');
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { windowsHide: true });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (d) => { stdout += String(d); });
+    child.stderr?.on('data', (d) => { stderr += String(d); });
+    child.on('error', (err) => resolve({ code: -1, stdout, stderr: err.message }));
+    child.on('exit', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+};
+
+export async function sleepingCleanupCommand(opts: CleanupOpts): Promise<void> {
+  const config = await loadConfig();
+  const workRoot = expandHome(config.policy.sleepWorktreeDir);
+  const merged = await listMergedSleeps({ exec, workRoot });
+
+  if (merged.length === 0) {
+    console.log(chalk.dim('(nenhum sleep mergeado para limpar)'));
+    return;
+  }
+
+  console.log(chalk.bold(`${merged.length} merged sleep branch${merged.length === 1 ? '' : 'es'} to clean:`));
+  for (const e of merged) {
+    console.log(`  • ${e.slug.padEnd(46)} PR #${e.prNumber}`);
+  }
+
+  if (opts.dryRun) {
+    console.log(chalk.dim('(--dry-run; nothing removed)'));
+    return;
+  }
+
+  if (!opts.yes) {
+    const confirm = await prompts({
+      type: 'confirm',
+      name: 'val',
+      message: 'cleanup?',
+      initial: false,
+    });
+    if (confirm.val !== true) {
+      console.log(chalk.dim('aborted'));
+      return;
+    }
+  }
+
+  const results = await cleanupMerged(merged, { exec, workRoot });
+  const failed = results.filter((r) => r.errors.length > 0);
+  if (failed.length > 0) {
+    console.error(chalk.red(`${failed.length} entry/entries had errors`));
+    process.exit(1);
+  }
+  console.log(chalk.green(`✓ cleaned ${results.length} sleep branch${results.length === 1 ? '' : 'es'}`));
+}

--- a/src/cli/sleepingCleanup.ts
+++ b/src/cli/sleepingCleanup.ts
@@ -117,6 +117,8 @@ export async function cleanupMerged(
   const prune = await deps.exec('git', ['fetch', '--prune']);
   if (prune.code === 0) {
     for (const r of results) r.remotePruned = true;
+  } else {
+    warn(chalk.yellow(`  ⚠ git fetch --prune failed: ${prune.stderr.trim() || `exit ${prune.code}`}`));
   }
   return results;
 }

--- a/src/cli/topicsClear.ts
+++ b/src/cli/topicsClear.ts
@@ -1,0 +1,86 @@
+import chalk from 'chalk';
+import prompts from 'prompts';
+import { kuroFetch } from './http.js';
+
+export interface TopicsClearOpts {
+  all?: boolean;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+interface ClearResponse {
+  ok?: boolean;
+  cleared?: string[];
+  failed?: Array<{ key: string; error: string }>;
+  dryRun?: boolean;
+  error?: string;
+}
+
+export async function topicsClearCommand(slug: string | undefined, opts: TopicsClearOpts): Promise<void> {
+  if (!slug && !opts.all) {
+    console.error(chalk.red('pass <slug> or --all'));
+    process.exit(1);
+  }
+  if (slug && opts.all) {
+    console.error(chalk.red('<slug> and --all are mutually exclusive'));
+    process.exit(1);
+  }
+
+  const body: { slug?: string; all?: boolean; dryRun?: boolean } = { dryRun: opts.dryRun };
+  if (opts.all) body.all = true;
+  if (slug) body.slug = slug;
+
+  if (!opts.yes && !opts.dryRun) {
+    const target = opts.all ? 'all topics (system topic preserved)' : `topic "${slug}"`;
+    const confirm = await prompts({
+      type: 'confirm',
+      name: 'val',
+      message: `delete ${target}?`,
+      initial: false,
+    });
+    if (confirm.val !== true) {
+      console.log(chalk.dim('aborted'));
+      return;
+    }
+  }
+
+  const res = await kuroFetch<ClearResponse>('/v1/topics/clear', {
+    method: 'POST',
+    body,
+  });
+  if (!res.ok) {
+    const err = res.body.error ?? `daemon HTTP ${res.status}`;
+    if (/forum topics/i.test(err)) {
+      console.error(chalk.red(err));
+      console.error(chalk.dim('use `kuroboto chat clear` in DM mode'));
+    } else {
+      console.error(chalk.red(err));
+    }
+    process.exit(1);
+  }
+
+  const cleared = res.body.cleared ?? [];
+  const failed = res.body.failed ?? [];
+  if (res.body.dryRun) {
+    if (cleared.length === 0) {
+      console.log(chalk.dim('(no topics would be cleared)'));
+    } else {
+      console.log(chalk.bold(`would clear ${cleared.length} topic${cleared.length === 1 ? '' : 's'}:`));
+      for (const k of cleared) console.log(`  • ${k}`);
+    }
+    return;
+  }
+  if (cleared.length === 0 && failed.length === 0) {
+    console.log(chalk.dim('(nothing to clear)'));
+    return;
+  }
+  if (cleared.length > 0) {
+    console.log(chalk.green(`✓ cleared ${cleared.length} topic${cleared.length === 1 ? '' : 's'}`));
+    for (const k of cleared) console.log(`  • ${k}`);
+  }
+  if (failed.length > 0) {
+    console.error(chalk.yellow(`⚠ ${failed.length} failed:`));
+    for (const f of failed) console.error(`  • ${f.key}: ${f.error}`);
+    process.exit(1);
+  }
+}

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -20,6 +20,7 @@ import { injectViaPty } from '../inject/pty.js';
 import type { SessionSnap } from './sleeping.js';
 import { topicContextFromHook } from './topicContext.js';
 import type { ChannelContext } from '../channels/Channel.js';
+import { SYSTEM_TOPIC_KEY } from '../channels/telegram/topics.js';
 
 export function registerRoutes(app: Express, ctx: DaemonContext): void {
   const fmtCtx = (): PromptFormatContext => ({
@@ -178,6 +179,51 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
       ctx.logger.warn('saveMode failed', { err: (e as Error).message });
     });
     res.json({ ok: true, mode: ctx.state.mode });
+  });
+
+  app.post('/v1/topics/clear', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as { slug?: unknown; all?: unknown; dryRun?: unknown };
+    if (!ctx.channel.clearTopics) {
+      res.status(400).json({ error: 'channel does not support forum topics' });
+      return;
+    }
+    const opts: { keys?: string[]; all?: boolean; except?: string[]; dryRun?: boolean } = {};
+    if (typeof body.slug === 'string' && body.slug) {
+      opts.keys = [body.slug];
+    } else if (body.all === true) {
+      opts.all = true;
+      opts.except = [SYSTEM_TOPIC_KEY];
+    } else {
+      res.status(400).json({ error: 'either slug (string) or all (true) required' });
+      return;
+    }
+    if (body.dryRun === true) opts.dryRun = true;
+    try {
+      const result = await ctx.channel.clearTopics(opts);
+      res.json({ ok: true, ...result, dryRun: opts.dryRun === true });
+    } catch (e) {
+      res.status(400).json({ error: (e as Error).message });
+    }
+  });
+
+  app.post('/v1/chat/clear', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as { last?: unknown; dryRun?: unknown };
+    if (!ctx.channel.clearLastMessages) {
+      res.status(400).json({ error: 'channel does not support message deletion' });
+      return;
+    }
+    if (typeof body.last !== 'number' || !Number.isInteger(body.last) || body.last <= 0) {
+      res.status(400).json({ error: 'last must be a positive integer' });
+      return;
+    }
+    try {
+      const result = await ctx.channel.clearLastMessages(body.last, {
+        dryRun: body.dryRun === true,
+      });
+      res.json({ ok: true, ...result, dryRun: body.dryRun === true });
+    } catch (e) {
+      res.status(400).json({ error: (e as Error).message });
+    }
   });
 
   app.post('/v1/heartbeat', (req: Request, res: Response) => {

--- a/src/daemon/sleepFinish.ts
+++ b/src/daemon/sleepFinish.ts
@@ -24,6 +24,26 @@ function humanise(slug: string): string {
   return slug.replace(/-/g, ' ');
 }
 
+const PR_TITLE_MAX_LEN = 70;
+const H1_SCAN_MAX_LINES = 50;
+
+/**
+ * Pulls the spec title from the first non-empty Markdown H1 in `prompt`. Falls
+ * back to humanising the slug when no H1 lives in the first 50 lines (e.g.
+ * sessions started with `--prompt`, or specs that lead with prose).
+ */
+function deriveTitle(prompt: string, slug: string): string {
+  const lines = prompt.split('\n', H1_SCAN_MAX_LINES + 1).slice(0, H1_SCAN_MAX_LINES);
+  for (const line of lines) {
+    const m = /^#\s+(.+?)\s*$/.exec(line);
+    if (m && m[1]) {
+      const title = m[1].trim();
+      if (title) return title.slice(0, PR_TITLE_MAX_LEN);
+    }
+  }
+  return humanise(slug).slice(0, PR_TITLE_MAX_LEN);
+}
+
 function buildBody(session: SleepingSession): string {
   return [
     '## Summary',
@@ -79,7 +99,7 @@ export async function finishSleep(session: SleepingSession, deps: FinishDeps): P
   }
 
   // 3. Create PR via gh
-  const title = humanise(session.slug);
+  const title = deriveTitle(session.prompt, session.slug);
   const body = buildBody(session);
   const create = await deps.exec(
     'gh',

--- a/test/helpers/mockChannel.ts
+++ b/test/helpers/mockChannel.ts
@@ -3,6 +3,8 @@ import type {
   ChannelContext,
   ChannelEventHandlers,
   ChannelEventName,
+  ClearTopicsResult,
+  ClearMessagesResult,
 } from '../../src/channels/Channel.js';
 import type { PromptRequest, QuestionRequest, Decision } from '../../src/core/types.js';
 
@@ -71,6 +73,24 @@ export class MockChannel implements Channel {
 
   on<K extends ChannelEventName>(event: K, handler: ChannelEventHandlers[K]): void {
     this.handlers[event].push(handler);
+  }
+
+  /** Stub config — set by tests to make clearTopics / clearLastMessages testable. */
+  public clearTopicsImpl: ((opts: { keys?: string[]; all?: boolean; except?: string[]; dryRun?: boolean }) => Promise<ClearTopicsResult>) | undefined;
+  public clearLastMessagesImpl: ((n: number, opts?: { dryRun?: boolean }) => Promise<ClearMessagesResult>) | undefined;
+  public clearTopicsCalls: Array<{ keys?: string[]; all?: boolean; except?: string[]; dryRun?: boolean }> = [];
+  public clearLastMessagesCalls: Array<{ n: number; dryRun?: boolean }> = [];
+
+  async clearTopics(opts: { keys?: string[]; all?: boolean; except?: string[]; dryRun?: boolean }): Promise<ClearTopicsResult> {
+    this.clearTopicsCalls.push(opts);
+    if (this.clearTopicsImpl) return this.clearTopicsImpl(opts);
+    return { cleared: opts.keys ?? [], failed: [] };
+  }
+
+  async clearLastMessages(n: number, opts: { dryRun?: boolean } = {}): Promise<ClearMessagesResult> {
+    this.clearLastMessagesCalls.push({ n, dryRun: opts.dryRun });
+    if (this.clearLastMessagesImpl) return this.clearLastMessagesImpl(n, opts);
+    return { attempted: n, deleted: n, outOfWindow: 0 };
   }
 
   emitDecision(requestId: string, decision: Decision): void {

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -481,6 +481,115 @@ describe('sleep mode endpoints', () => {
   });
 });
 
+describe('topics + chat clear endpoints', () => {
+  it('POST /v1/topics/clear { slug } forwards keys: [slug]', async () => {
+    const { ctx, channel } = makeContext();
+    channel.clearTopicsImpl = async (opts) => ({ cleared: opts.keys ?? [], failed: [] });
+    const res = await request(createServer(ctx))
+      .post('/v1/topics/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ slug: 'feat-x' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, cleared: ['feat-x'], failed: [], dryRun: false });
+    expect(channel.clearTopicsCalls).toHaveLength(1);
+    expect(channel.clearTopicsCalls[0]).toEqual({ keys: ['feat-x'] });
+  });
+
+  it('POST /v1/topics/clear { all: true } sets except: [kuroboto-system]', async () => {
+    const { ctx, channel } = makeContext();
+    channel.clearTopicsImpl = async (opts) => ({
+      cleared: opts.all ? ['a', 'b'] : [],
+      failed: [],
+    });
+    const res = await request(createServer(ctx))
+      .post('/v1/topics/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ all: true });
+    expect(res.status).toBe(200);
+    expect(channel.clearTopicsCalls[0]).toEqual({ all: true, except: ['kuroboto-system'] });
+  });
+
+  it('POST /v1/topics/clear with empty body returns 400', async () => {
+    const { ctx } = makeContext();
+    const res = await request(createServer(ctx))
+      .post('/v1/topics/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/slug.*all/);
+  });
+
+  it('POST /v1/topics/clear { dryRun: true } passes dryRun through', async () => {
+    const { ctx, channel } = makeContext();
+    const res = await request(createServer(ctx))
+      .post('/v1/topics/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ slug: 'foo', dryRun: true });
+    expect(res.status).toBe(200);
+    expect(res.body.dryRun).toBe(true);
+    expect(channel.clearTopicsCalls[0].dryRun).toBe(true);
+  });
+
+  it('POST /v1/topics/clear returns 400 when channel does not implement clearTopics', async () => {
+    const { ctx, channel } = makeContext();
+    // remove the implementation defined on MockChannel
+    (channel as unknown as { clearTopics?: unknown }).clearTopics = undefined;
+    const res = await request(createServer(ctx))
+      .post('/v1/topics/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ slug: 'foo' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/forum topics/);
+  });
+
+  it('POST /v1/chat/clear { last: 10 } forwards last and returns counts', async () => {
+    const { ctx, channel } = makeContext();
+    channel.clearLastMessagesImpl = async (n) => ({ attempted: n, deleted: n - 2, outOfWindow: 2 });
+    const res = await request(createServer(ctx))
+      .post('/v1/chat/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ last: 10 });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, attempted: 10, deleted: 8, outOfWindow: 2, dryRun: false });
+    expect(channel.clearLastMessagesCalls).toHaveLength(1);
+    expect(channel.clearLastMessagesCalls[0]).toEqual({ n: 10, dryRun: false });
+  });
+
+  it('POST /v1/chat/clear rejects last <= 0', async () => {
+    const { ctx } = makeContext();
+    const res = await request(createServer(ctx))
+      .post('/v1/chat/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ last: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /v1/chat/clear rejects non-integer last', async () => {
+    const { ctx } = makeContext();
+    const res = await request(createServer(ctx))
+      .post('/v1/chat/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ last: 'ten' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /v1/chat/clear { dryRun: true } passes dryRun through', async () => {
+    const { ctx, channel } = makeContext();
+    channel.clearLastMessagesImpl = async (n, opts) => ({
+      attempted: n,
+      deleted: 0,
+      outOfWindow: opts?.dryRun ? 1 : 0,
+    });
+    const res = await request(createServer(ctx))
+      .post('/v1/chat/clear')
+      .set('X-Kuroboto-Token', TEST_TOKEN)
+      .send({ last: 5, dryRun: true });
+    expect(res.status).toBe(200);
+    expect(res.body.dryRun).toBe(true);
+    expect(channel.clearLastMessagesCalls[0]).toEqual({ n: 5, dryRun: true });
+  });
+});
+
 describe('allowlist match (daemon-side)', () => {
   let tmpRepo: string;
 

--- a/test/unit/cli/chatClear.test.ts
+++ b/test/unit/cli/chatClear.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../../src/config/load.js', () => ({
+  loadConfig: async () => ({
+    daemon: { port: 47891, authToken: 'a'.repeat(64) },
+  }),
+}));
+
+vi.mock('prompts', () => ({
+  default: vi.fn(async () => ({ val: true })),
+}));
+
+import { chatClearCommand } from '../../../src/cli/chatClear.js';
+
+interface CapturedRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+function captureFetch(responder: (req: CapturedRequest) => Response | Promise<Response>): {
+  calls: CapturedRequest[];
+  restore: () => void;
+} {
+  const calls: CapturedRequest[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const req = { url: typeof input === 'string' ? input : input.toString(), init };
+    calls.push(req);
+    return responder(req);
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('chatClearCommand', () => {
+  let restoreFetch: (() => void) | null = null;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = null;
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs { last: N } and prints "deleted X of last Y"', async () => {
+    const cap = captureFetch(() => jsonResponse({
+      ok: true, attempted: 100, deleted: 87, outOfWindow: 13, dryRun: false,
+    }));
+    restoreFetch = cap.restore;
+    await chatClearCommand({ last: '100', yes: true });
+    expect(cap.calls).toHaveLength(1);
+    expect(JSON.parse(String(cap.calls[0].init?.body))).toEqual({ last: 100, dryRun: false });
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toMatch(/deleted 87 of last 100/);
+    expect(printed).toMatch(/13 outside 48h/);
+  });
+
+  it('refuses non-positive --last', async () => {
+    await expect(chatClearCommand({ last: '0' })).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('refuses missing --last', async () => {
+    await expect(chatClearCommand({})).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('refuses non-numeric --last', async () => {
+    await expect(chatClearCommand({ last: 'abc' })).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('--dry-run reports attempted + outside-window without deleting', async () => {
+    const cap = captureFetch(() => jsonResponse({
+      ok: true, attempted: 50, deleted: 0, outOfWindow: 5, dryRun: true,
+    }));
+    restoreFetch = cap.restore;
+    await chatClearCommand({ last: '50', dryRun: true });
+    expect(JSON.parse(String(cap.calls[0].init?.body)).dryRun).toBe(true);
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toMatch(/would attempt 50/);
+    expect(printed).toMatch(/5 outside 48h/);
+  });
+
+  it('exits 1 on daemon error', async () => {
+    const cap = captureFetch(() => jsonResponse({ error: 'channel does not support message deletion' }, 400));
+    restoreFetch = cap.restore;
+    await expect(chatClearCommand({ last: '5', yes: true })).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/unit/cli/kuroFetch.test.ts
+++ b/test/unit/cli/kuroFetch.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../../src/config/load.js', () => ({
+  loadConfig: async () => ({
+    daemon: { port: 47891, authToken: 'a'.repeat(64) },
+  }),
+}));
+
+import { kuroFetch, setDebug } from '../../../src/cli/http.js';
+
+interface CapturedRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+function captureFetch(responder: (req: CapturedRequest) => Response | Promise<Response>): {
+  calls: CapturedRequest[];
+  restore: () => void;
+} {
+  const calls: CapturedRequest[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const req = { url: typeof input === 'string' ? input : input.toString(), init };
+    calls.push(req);
+    return responder(req);
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('kuroFetch', () => {
+  let restoreFetch: (() => void) | null = null;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setDebug(false);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = null;
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('builds full URL from path, attaches auth header, returns parsed body', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true, value: 42 }));
+    restoreFetch = cap.restore;
+    const result = await kuroFetch<{ ok: boolean; value: number }>('/v1/health');
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ ok: true, value: 42 });
+    expect(cap.calls[0].url).toBe('http://127.0.0.1:47891/v1/health');
+    const headers = cap.calls[0].init?.headers as Record<string, string>;
+    expect(headers['X-Kuroboto-Token']).toBe('a'.repeat(64));
+  });
+
+  it('serialises body as JSON and adds Content-Type header on POST', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true }));
+    restoreFetch = cap.restore;
+    await kuroFetch('/v1/topics/clear', { method: 'POST', body: { slug: 'foo' } });
+    expect(cap.calls[0].init?.method).toBe('POST');
+    expect(JSON.parse(String(cap.calls[0].init?.body))).toEqual({ slug: 'foo' });
+    const headers = cap.calls[0].init?.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('returns non-2xx responses as ok=false without throwing', async () => {
+    const cap = captureFetch(() => jsonResponse({ error: 'bad' }, 400));
+    restoreFetch = cap.restore;
+    const result = await kuroFetch<{ error: string }>('/v1/whatever');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.body).toEqual({ error: 'bad' });
+  });
+
+  it('ECONNREFUSED → prints "daemon offline" and exits 1', async () => {
+    restoreFetch = (() => {
+      const original = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        const err = new Error('fetch failed') as Error & { cause?: { code?: string } };
+        err.cause = { code: 'ECONNREFUSED' };
+        throw err;
+      }) as typeof fetch;
+      return () => { globalThis.fetch = original; };
+    })();
+    await expect(kuroFetch('/v1/health')).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toMatch(/daemon offline/i);
+    expect(written).toMatch(/kuroboto start -d/);
+  });
+
+  it('ETIMEDOUT → prints "daemon offline" and exits 1', async () => {
+    restoreFetch = (() => {
+      const original = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        const err = new Error('fetch failed') as Error & { code?: string };
+        err.code = 'ETIMEDOUT';
+        throw err;
+      }) as typeof fetch;
+      return () => { globalThis.fetch = original; };
+    })();
+    await expect(kuroFetch('/v1/health')).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toMatch(/daemon offline/i);
+  });
+
+  it('unrelated fetch error → exits 1 with the original message (not "daemon offline")', async () => {
+    restoreFetch = (() => {
+      const original = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        throw new Error('TLS cert expired');
+      }) as typeof fetch;
+      return () => { globalThis.fetch = original; };
+    })();
+    await expect(kuroFetch('/v1/health')).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toMatch(/TLS cert expired/);
+    expect(written).not.toMatch(/daemon offline/);
+  });
+
+  it('debug mode → traces request and response on stderr', async () => {
+    const cap = captureFetch(() => jsonResponse({ value: 7 }));
+    restoreFetch = cap.restore;
+    setDebug(true);
+    try {
+      await kuroFetch('/v1/health', { method: 'POST', body: { x: 1 } });
+    } finally {
+      setDebug(false);
+    }
+    const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toMatch(/\[debug\] POST http:\/\/127\.0\.0\.1:47891\/v1\/health/);
+    expect(written).toMatch(/\{"x":1\}/);
+    expect(written).toMatch(/← 200/);
+    expect(written).toMatch(/"value":7/);
+  });
+
+  it('debug off → no stderr trace lines', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true }));
+    restoreFetch = cap.restore;
+    setDebug(false);
+    await kuroFetch('/v1/health');
+    const written = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toBe('');
+  });
+});

--- a/test/unit/cli/sleepingCleanup.test.ts
+++ b/test/unit/cli/sleepingCleanup.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+  listMergedSleeps,
+  cleanupMerged,
+  type ExecFn,
+  type ExecResult,
+} from '../../../src/cli/sleepingCleanup.js';
+
+interface ExecCall {
+  cmd: string;
+  args: string[];
+}
+
+function makeExec(handlers: Record<string, ExecResult | ((args: string[]) => ExecResult)>): {
+  exec: ExecFn;
+  calls: ExecCall[];
+} {
+  const calls: ExecCall[] = [];
+  const exec: ExecFn = async (cmd, args) => {
+    calls.push({ cmd, args });
+    const key = `${cmd} ${args[0]}${args[1] ? ' ' + args[1] : ''}`;
+    const handler = handlers[key] ?? handlers[`${cmd} ${args[0]}`] ?? handlers[cmd];
+    if (!handler) return { code: 0, stdout: '', stderr: '' };
+    return typeof handler === 'function' ? handler(args) : handler;
+  };
+  return { exec, calls };
+}
+
+const PR_LIST = JSON.stringify([
+  { number: 10, headRefName: 'sleep/feat-x-abc123', state: 'MERGED' },
+  { number: 11, headRefName: 'sleep/feat-y-def456', state: 'MERGED' },
+  { number: 12, headRefName: 'sleep/in-flight-ghi789', state: 'OPEN' },
+  { number: 13, headRefName: 'main', state: 'MERGED' },
+]);
+
+describe('listMergedSleeps', () => {
+  it('returns only merged PRs whose branch starts with sleep/', async () => {
+    const { exec } = makeExec({ 'gh pr': { code: 0, stdout: PR_LIST, stderr: '' } });
+    const merged = await listMergedSleeps({ exec, workRoot: '/wk' });
+    expect(merged.map((m) => m.slug)).toEqual(['feat-x-abc123', 'feat-y-def456']);
+    expect(merged[0]).toMatchObject({
+      prNumber: 10,
+      branch: 'sleep/feat-x-abc123',
+      slug: 'feat-x-abc123',
+      worktreePath: expect.stringContaining('feat-x-abc123'),
+    });
+  });
+
+  it('passes --state merged + --head sleep/ to gh', async () => {
+    const { exec, calls } = makeExec({ 'gh pr': { code: 0, stdout: '[]', stderr: '' } });
+    await listMergedSleeps({ exec, workRoot: '/wk' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toContain('--state');
+    expect(calls[0].args).toContain('merged');
+    expect(calls[0].args).toContain('--head');
+    expect(calls[0].args).toContain('sleep/');
+  });
+
+  it('throws a clear error when gh fails', async () => {
+    const { exec } = makeExec({ 'gh pr': { code: 1, stdout: '', stderr: 'auth error' } });
+    await expect(listMergedSleeps({ exec, workRoot: '/wk' })).rejects.toThrow(/auth error/);
+  });
+
+  it('throws when gh returns invalid JSON', async () => {
+    const { exec } = makeExec({ 'gh pr': { code: 0, stdout: 'not json', stderr: '' } });
+    await expect(listMergedSleeps({ exec, workRoot: '/wk' })).rejects.toThrow(/invalid JSON/i);
+  });
+
+  it('returns empty list when no merged sleeps exist', async () => {
+    const { exec } = makeExec({ 'gh pr': { code: 0, stdout: '[]', stderr: '' } });
+    expect(await listMergedSleeps({ exec, workRoot: '/wk' })).toEqual([]);
+  });
+});
+
+describe('cleanupMerged', () => {
+  const ENTRIES = [
+    { prNumber: 10, branch: 'sleep/feat-x-abc123', slug: 'feat-x-abc123', worktreePath: '/wk/feat-x-abc123' },
+    { prNumber: 11, branch: 'sleep/feat-y-def456', slug: 'feat-y-def456', worktreePath: '/wk/feat-y-def456' },
+  ];
+
+  it('removes worktree, deletes local branch, prunes remote for each entry', async () => {
+    const { exec, calls } = makeExec({ git: { code: 0, stdout: '', stderr: '' } });
+    const log: string[] = [];
+    const results = await cleanupMerged(ENTRIES, { exec, workRoot: '/wk', log: (l) => log.push(l) });
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.worktreeRemoved && r.branchDeleted && r.remotePruned)).toBe(true);
+    // expected calls: 2× worktree remove, 2× branch -D, 1× fetch --prune
+    const wtCalls = calls.filter((c) => c.args[0] === 'worktree');
+    expect(wtCalls).toHaveLength(2);
+    expect(wtCalls[0].args).toEqual(['worktree', 'remove', '--force', '/wk/feat-x-abc123']);
+    const brCalls = calls.filter((c) => c.args[0] === 'branch');
+    expect(brCalls).toHaveLength(2);
+    expect(brCalls[0].args).toEqual(['branch', '-D', 'sleep/feat-x-abc123']);
+    const prune = calls.filter((c) => c.args[0] === 'fetch');
+    expect(prune).toHaveLength(1);
+    expect(prune[0].args).toEqual(['fetch', '--prune']);
+  });
+
+  it('treats "not a working tree" as already-clean (no error)', async () => {
+    const exec: ExecFn = async (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'worktree') {
+        return { code: 1, stdout: '', stderr: 'fatal: not a working tree' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    };
+    const results = await cleanupMerged([ENTRIES[0]], { exec, workRoot: '/wk', log: () => {}, warn: () => {} });
+    expect(results[0].errors).toEqual([]);
+    expect(results[0].worktreeRemoved).toBe(false);
+    expect(results[0].branchDeleted).toBe(true);
+  });
+
+  it('treats "branch not found" as already-deleted (no error)', async () => {
+    const exec: ExecFn = async (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'branch') {
+        return { code: 1, stdout: '', stderr: 'error: branch sleep/foo not found' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    };
+    const results = await cleanupMerged([ENTRIES[0]], { exec, workRoot: '/wk', log: () => {}, warn: () => {} });
+    expect(results[0].errors).toEqual([]);
+    expect(results[0].branchDeleted).toBe(false);
+  });
+
+  it('records a real worktree-remove failure as an error', async () => {
+    const exec: ExecFn = async (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'worktree') {
+        return { code: 1, stdout: '', stderr: 'permission denied' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    };
+    const results = await cleanupMerged([ENTRIES[0]], { exec, workRoot: '/wk', log: () => {}, warn: () => {} });
+    expect(results[0].errors[0]).toMatch(/permission denied/);
+  });
+});

--- a/test/unit/cli/topicsClear.test.ts
+++ b/test/unit/cli/topicsClear.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../../src/config/load.js', () => ({
+  loadConfig: async () => ({
+    daemon: { port: 47891, authToken: 'a'.repeat(64) },
+  }),
+}));
+
+vi.mock('prompts', () => ({
+  default: vi.fn(async () => ({ val: true })),
+}));
+
+import { topicsClearCommand } from '../../../src/cli/topicsClear.js';
+
+interface CapturedRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+function captureFetch(responder: (req: CapturedRequest) => Response | Promise<Response>): {
+  calls: CapturedRequest[];
+  restore: () => void;
+} {
+  const calls: CapturedRequest[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const req = { url: typeof input === 'string' ? input : input.toString(), init };
+    calls.push(req);
+    return responder(req);
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('topicsClearCommand', () => {
+  let restoreFetch: (() => void) | null = null;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = null;
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs { slug } when given a slug', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true, cleared: ['feat-x'], failed: [], dryRun: false }));
+    restoreFetch = cap.restore;
+    await topicsClearCommand('feat-x', { yes: true });
+    expect(cap.calls).toHaveLength(1);
+    expect(cap.calls[0].url).toContain('/v1/topics/clear');
+    expect(JSON.parse(String(cap.calls[0].init?.body))).toEqual({ slug: 'feat-x', dryRun: undefined });
+  });
+
+  it('POSTs { all: true } with --all', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true, cleared: ['a', 'b'], failed: [], dryRun: false }));
+    restoreFetch = cap.restore;
+    await topicsClearCommand(undefined, { all: true, yes: true });
+    expect(JSON.parse(String(cap.calls[0].init?.body))).toEqual({ all: true, dryRun: undefined });
+  });
+
+  it('refuses when neither slug nor --all is given', async () => {
+    await expect(topicsClearCommand(undefined, {})).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('refuses when both slug and --all are given', async () => {
+    await expect(topicsClearCommand('foo', { all: true })).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('--dry-run sends dryRun:true and prints would-clear list', async () => {
+    const cap = captureFetch(() => jsonResponse({ ok: true, cleared: ['a', 'b'], failed: [], dryRun: true }));
+    restoreFetch = cap.restore;
+    await topicsClearCommand(undefined, { all: true, dryRun: true });
+    const body = JSON.parse(String(cap.calls[0].init?.body));
+    expect(body.dryRun).toBe(true);
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toMatch(/would clear 2 topics/);
+  });
+
+  it('prints actionable message when daemon reports forumMode off', async () => {
+    const cap = captureFetch(() => jsonResponse({ error: 'channel does not support forum topics' }, 400));
+    restoreFetch = cap.restore;
+    await expect(topicsClearCommand('foo', { yes: true })).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const printed = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(printed).toMatch(/forum topics/);
+    expect(printed).toMatch(/chat clear/);
+  });
+
+  it('exits non-zero when some topics failed', async () => {
+    const cap = captureFetch(() => jsonResponse({
+      ok: true,
+      cleared: ['a'],
+      failed: [{ key: 'b', error: 'topic not found' }],
+      dryRun: false,
+    }));
+    restoreFetch = cap.restore;
+    await expect(topicsClearCommand(undefined, { all: true, yes: true })).rejects.toThrow(/process\.exit/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/unit/sleepFinish.test.ts
+++ b/test/unit/sleepFinish.test.ts
@@ -81,11 +81,73 @@ describe('finishSleep', () => {
     expect(calls.notify[0]).toMatch(/pr create failed|sleep finalize failed/i);
   });
 
-  it('PR title comes from the slug (humanised)', async () => {
+  it('PR title falls back to humanised slug when prompt has no H1', async () => {
     const { deps, calls } = makeDeps();
     await finishSleep(SESSION, deps);
     const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
     expect(ghCall).toBeDefined();
+    const title = ghCall!.args[ghCall!.args.indexOf('--title') + 1];
+    expect(title.toLowerCase()).toContain('add feature x');
+  });
+
+  it('PR title comes from the first H1 in the prompt when present', async () => {
+    const { deps, calls } = makeDeps();
+    const sessionWithH1: SleepingSession = {
+      ...SESSION,
+      prompt: 'Execute this implementation plan.\n\n# Bot prompt free-text Q&A (tmux inject)\n\n> Status: planned',
+    };
+    await finishSleep(sessionWithH1, deps);
+    const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
+    const title = ghCall!.args[ghCall!.args.indexOf('--title') + 1];
+    expect(title).toBe('Bot prompt free-text Q&A (tmux inject)');
+  });
+
+  it('PR title prefers the first H1, ignoring later ## headings', async () => {
+    const { deps, calls } = makeDeps();
+    const sessionWithH1: SleepingSession = {
+      ...SESSION,
+      prompt: '# Real title\n\n## Subheading\n\n# Second H1',
+    };
+    await finishSleep(sessionWithH1, deps);
+    const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
+    const title = ghCall!.args[ghCall!.args.indexOf('--title') + 1];
+    expect(title).toBe('Real title');
+  });
+
+  it('PR title is truncated to 70 chars when H1 is overlong', async () => {
+    const { deps, calls } = makeDeps();
+    const longH1 = 'a'.repeat(120);
+    const sessionWithH1: SleepingSession = {
+      ...SESSION,
+      prompt: `# ${longH1}`,
+    };
+    await finishSleep(sessionWithH1, deps);
+    const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
+    const title = ghCall!.args[ghCall!.args.indexOf('--title') + 1];
+    expect(title.length).toBe(70);
+  });
+
+  it('PR title falls back to humanised slug when only ## headings exist', async () => {
+    const { deps, calls } = makeDeps();
+    const sessionNoH1: SleepingSession = {
+      ...SESSION,
+      prompt: '## Not a top-level heading\n\n### Nor this',
+    };
+    await finishSleep(sessionNoH1, deps);
+    const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
+    const title = ghCall!.args[ghCall!.args.indexOf('--title') + 1];
+    expect(title.toLowerCase()).toContain('add feature x');
+  });
+
+  it('PR title falls back when H1 lives past the first 50 lines', async () => {
+    const { deps, calls } = makeDeps();
+    const filler = Array(60).fill('preamble line').join('\n');
+    const sessionWithH1: SleepingSession = {
+      ...SESSION,
+      prompt: `${filler}\n# Buried title`,
+    };
+    await finishSleep(sessionWithH1, deps);
+    const ghCall = calls.exec.find((c) => c.cmd === 'gh' && c.args[0] === 'pr' && c.args[1] === 'create');
     const title = ghCall!.args[ghCall!.args.indexOf('--title') + 1];
     expect(title.toLowerCase()).toContain('add feature x');
   });

--- a/test/unit/telegramChannel.test.ts
+++ b/test/unit/telegramChannel.test.ts
@@ -16,6 +16,11 @@ class FakeApi {
   public callbacksAnswered: string[] = [];
   public editKeyboardCalls: Array<{ messageId: number; keyboard: unknown }> = [];
   public createTopicCalls: Array<{ chatId: number; name: string }> = [];
+  public deleteMessageCalls: Array<{ chatId: number; messageId: number }> = [];
+  public deleteForumTopicCalls: Array<{ chatId: number; threadId: number }> = [];
+  /** Per-call programmable errors for deleteMessage / deleteForumTopic. */
+  public deleteMessageErrors: Error[] = [];
+  public deleteForumTopicErrors: Error[] = [];
   private nextMessageId = 100;
   private nextThreadId = 200;
   /** Per-call programmable error: pop the next error before each sendMessage. */
@@ -42,6 +47,14 @@ class FakeApi {
   async createForumTopic(chatId: number, name: string): Promise<number> {
     this.createTopicCalls.push({ chatId, name });
     return this.nextThreadId++;
+  }
+  async deleteMessage(chatId: number, messageId: number): Promise<void> {
+    this.deleteMessageCalls.push({ chatId, messageId });
+    if (this.deleteMessageErrors.length > 0) throw this.deleteMessageErrors.shift()!;
+  }
+  async deleteForumTopic(chatId: number, threadId: number): Promise<void> {
+    this.deleteForumTopicCalls.push({ chatId, threadId });
+    if (this.deleteForumTopicErrors.length > 0) throw this.deleteForumTopicErrors.shift()!;
   }
   async getUpdates(): Promise<never[]> { return []; }
 }
@@ -211,5 +224,154 @@ describe('TelegramChannel topic routing', () => {
     await ch.sendNotification('hi', { slug: 'fix-bot-ux' });
     expect(api.messages).toHaveLength(1);
     expect(api.messages[0].opts?.messageThreadId).toBeUndefined();
+  });
+});
+
+describe('TelegramChannel.clearTopics', () => {
+  let tmpDir: string;
+  let api: FakeApi;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-cleartopics-'));
+    api = new FakeApi();
+  });
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function makeChannelWithTm(seed: Record<string, number> = {}): Promise<{
+    ch: TelegramChannel;
+    tm: TopicManager;
+  }> {
+    const storagePath = path.join(tmpDir, 'topics.json');
+    await fsp.writeFile(storagePath, JSON.stringify(seed));
+    const tm = new TopicManager({
+      api: api as never,
+      chatId: -100,
+      forumMode: true,
+      storagePath,
+      logger: noopLogger,
+    });
+    await tm.loadFromDisk();
+    const ch = new TelegramChannel({ token: 't', chatId: -100, logger: noopLogger, topicManager: tm });
+    (ch as unknown as { api: unknown }).api = api;
+    return { ch, tm };
+  }
+
+  it('throws when forumMode is off (no topicManager)', async () => {
+    const ch = new TelegramChannel({ token: 't', chatId: -100, logger: noopLogger });
+    await expect(ch.clearTopics({ all: true })).rejects.toThrow(/forumMode is off/i);
+  });
+
+  it('keys: [slug] calls deleteForumTopic on each cached threadId and purges', async () => {
+    const { ch, tm } = await makeChannelWithTm({ 'feat-x': 11, 'feat-y': 22 });
+    const result = await ch.clearTopics({ keys: ['feat-x'] });
+    expect(result.cleared).toEqual(['feat-x']);
+    expect(api.deleteForumTopicCalls).toEqual([{ chatId: -100, threadId: 11 }]);
+    expect(tm.get('feat-x')).toBeUndefined();
+    expect(tm.get('feat-y')).toBe(22);
+  });
+
+  it('all: true with except: [kuroboto-system] preserves the system topic', async () => {
+    const { ch, tm } = await makeChannelWithTm({ 'feat-x': 11, 'kuroboto-system': 99 });
+    const result = await ch.clearTopics({ all: true, except: ['kuroboto-system'] });
+    expect(result.cleared).toEqual(['feat-x']);
+    expect(api.deleteForumTopicCalls).toEqual([{ chatId: -100, threadId: 11 }]);
+    expect(tm.get('kuroboto-system')).toBe(99);
+  });
+
+  it('dryRun returns the would-clear keys without calling the API', async () => {
+    const { ch } = await makeChannelWithTm({ 'feat-x': 11, 'feat-y': 22 });
+    const result = await ch.clearTopics({ all: true, dryRun: true });
+    expect(result.cleared.sort()).toEqual(['feat-x', 'feat-y']);
+    expect(api.deleteForumTopicCalls).toHaveLength(0);
+  });
+
+  it('treats "thread not found" as already-cleared and purges anyway', async () => {
+    const { ch, tm } = await makeChannelWithTm({ 'feat-x': 11 });
+    api.deleteForumTopicErrors.push(new Error('telegram: Bad Request: message thread not found'));
+    const result = await ch.clearTopics({ keys: ['feat-x'] });
+    expect(result.cleared).toEqual(['feat-x']);
+    expect(result.failed).toEqual([]);
+    expect(tm.get('feat-x')).toBeUndefined();
+  });
+
+  it('records real API failures in result.failed', async () => {
+    const { ch } = await makeChannelWithTm({ 'feat-x': 11 });
+    api.deleteForumTopicErrors.push(new Error('telegram: Forbidden'));
+    const result = await ch.clearTopics({ keys: ['feat-x'] });
+    expect(result.cleared).toEqual([]);
+    expect(result.failed).toEqual([{ key: 'feat-x', error: expect.stringContaining('Forbidden') }]);
+  });
+
+  it('skips unknown keys silently', async () => {
+    const { ch } = await makeChannelWithTm({ 'feat-x': 11 });
+    const result = await ch.clearTopics({ keys: ['feat-x', 'never-existed'] });
+    expect(result.cleared).toEqual(['feat-x']);
+    expect(api.deleteForumTopicCalls).toHaveLength(1);
+  });
+});
+
+describe('TelegramChannel.clearLastMessages', () => {
+  let api: FakeApi;
+  let ch: TelegramChannel;
+
+  beforeEach(() => {
+    api = new FakeApi();
+    ch = makeChannel(api);
+  });
+
+  it('returns zero counts when nothing has been sent', async () => {
+    const r = await ch.clearLastMessages(10);
+    expect(r).toEqual({ attempted: 0, deleted: 0, outOfWindow: 0 });
+  });
+
+  it('takes the last N tracked outbound messages and deletes each', async () => {
+    await ch.sendNotification('a');
+    await ch.sendNotification('b');
+    await ch.sendNotification('c');
+    const r = await ch.clearLastMessages(2);
+    expect(r).toEqual({ attempted: 2, deleted: 2, outOfWindow: 0 });
+    expect(api.deleteMessageCalls.map((c) => c.messageId)).toEqual([101, 102]);
+  });
+
+  it('counts messages older than 48h as outOfWindow without calling the API', async () => {
+    await ch.sendNotification('old');
+    // Reach into the ring buffer and backdate the entry.
+    const ring = (ch as unknown as { sentMessages: Array<{ messageId: number; sentAt: number }> }).sentMessages;
+    ring[0]!.sentAt = Date.now() - 49 * 3600 * 1000;
+    const r = await ch.clearLastMessages(1);
+    expect(r).toEqual({ attempted: 1, deleted: 0, outOfWindow: 1 });
+    expect(api.deleteMessageCalls).toHaveLength(0);
+  });
+
+  it('counts "can\'t be deleted" errors as outOfWindow', async () => {
+    await ch.sendNotification('old');
+    api.deleteMessageErrors.push(new Error("telegram: Bad Request: message can't be deleted"));
+    const r = await ch.clearLastMessages(1);
+    expect(r.outOfWindow).toBe(1);
+    expect(r.deleted).toBe(0);
+  });
+
+  it('dryRun reports counts without calling deleteMessage', async () => {
+    await ch.sendNotification('a');
+    const r = await ch.clearLastMessages(1, { dryRun: true });
+    expect(r).toEqual({ attempted: 1, deleted: 0, outOfWindow: 0 });
+    expect(api.deleteMessageCalls).toHaveLength(0);
+  });
+
+  it('non-positive n is a no-op', async () => {
+    await ch.sendNotification('a');
+    const r = await ch.clearLastMessages(0);
+    expect(r).toEqual({ attempted: 0, deleted: 0, outOfWindow: 0 });
+  });
+
+  it('drops successfully-deleted ids from the tracker so a second call does not retry', async () => {
+    await ch.sendNotification('a');
+    await ch.sendNotification('b');
+    await ch.clearLastMessages(2);
+    expect(ch.getSentMessages()).toHaveLength(0);
+    const r2 = await ch.clearLastMessages(2);
+    expect(r2.attempted).toBe(0);
   });
 });

--- a/test/unit/telegramChannel.test.ts
+++ b/test/unit/telegramChannel.test.ts
@@ -370,7 +370,8 @@ describe('TelegramChannel.clearLastMessages', () => {
     await ch.sendNotification('a');
     await ch.sendNotification('b');
     await ch.clearLastMessages(2);
-    expect(ch.getSentMessages()).toHaveLength(0);
+    const tracker = (ch as unknown as { sentMessages: unknown[] }).sentMessages;
+    expect(tracker).toHaveLength(0);
     const r2 = await ch.clearLastMessages(2);
     expect(r2.attempted).toBe(0);
   });


### PR DESCRIPTION
## Summary

Automated implementation via `kuroboto sleeping` (sleep mode).

## Original prompt

```
Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.

# CLI improvements bundle

> Status: planned. Spec I. A bundle of UX / housekeeping improvements that surfaced from real dogfood. Sized for one autonomous sleep run. None of these are urgent (the gaming-FYI flood was already hotfixed in PR #20); they're papercuts that compound.

## Problem (the papercuts)

Witnessed live in this dogfood week:

1. **PR titles from sleep mode are ugly slugs** — `bot prompt free text q a tmux inject yafbdj`, `cli layer tests status planned spec h npc6ub`. Every PR needs a manual rename before merge. The spec already has a clean title in its H1 (`# Bot prompt free-text Q&A (tmux inject)`).
2. **Worktree + branch cleanup is manual** — after `gh pr merge --delete-branch`, the local branch is held by the worktree → delete fails → manual `git worktree remove` + `git branch -D` every time.
3. **`ohayo` is locked into tmux** — Spec E shipped PTY-based wrapping; `ohayo` should drop tmux for a cleaner UX (no green status bar, no intercepted bell).
4. **Telegram-flood control is incomplete** — PR #20 stopped per-tool gaming FYIs during sleep, but there's no command to clean up flood damage that already happened.
5. **Daemon-down errors are silent** — when the daemon isn't running, every CLI command times out or shows "fetch failed" with no actionable message.
6. **No debug mode for diagnostics** — when something flooded Telegram or a CLI command misbehaved, there was no `--debug` to see HTTP traffic.

## Solution

A bundle of small, isolated commands and flags. Each is independently shippable but cheaper to build together (shared CLI plumbing, shared tests, single PR review).

### M1 — Slug → spec H1 for PR titles

`src/daemon/sleepFinish.ts:humanise(slug)` is currently:

```ts
function humanise(slug: string): string {
  return slug.replace(/-/g, ' ');
}
```

Replace with: read the first non-empty Markdown H1 from the spec content (passed via `prompt`/`plan`), strip the leading `# `, use that as the title. Fall back to `humanise(slug)` if no H1 is found (e.g., `--prompt` instead of `--plan`).

The slug already lives in branch + worktree paths and remains the slug (those are git-friendly identifiers); only the human-facing PR title changes.

### M2 — `kuroboto sleeping cleanup`

New CLI subcommand. Reads `gh pr list --state merged --head sleep/*` to find merged sleep PRs; for each:

- Run `git worktree remove <worktree-path>` (force if needed)
- `git branch -D <local-branch>` (force, since squash merge leaves the branch unmerged from main's POV)
- `git fetch --prune` to drop the stale remote ref

`--dry-run` flag lists what would be cleaned without doing it.

Output:

```
$ kuroboto sleeping cleanup
3 merged sleep branches to clean:
  • sleep/feat-x-abc123     PR #N (merged)  → worktree, local branch, remote
  • sleep/feat-y-def456     PR #M (merged)  → worktree, local branch
  • sleep/feat-z-ghi789     PR #K (merged)  → already partially clean
cleanup? [y/N]
```

`--yes` to skip the prompt. Non-zero exit on any failure.

### M3 — `kuroboto topics clear` (supergroup mode only)

Two variants:

- `kuroboto topics clear <slug>` — calls `deleteForumTopic` API for the slug's `message_thread_id`, purges the entry from `topics.json`. Next outbound message for that slug recreates the topic fresh.
- `kuroboto topics clear --all` — same for every entry in `topics.json` except `kuroboto-system` (system topic stays). Confirmation prompt lists everything before delete.

Refuses with a clear message when `forumMode: false` (DM mode has no topics; use `kuroboto chat clear` instead).

`--dry-run` shows what would be deleted.

### M4 — `kuroboto chat clear --last N` (any mode)

Deletes the last N messages the bot sent (tracked from outbound message IDs the daemon already collects for keyboard editing). Bounded by Telegram's 48h delete window — older messages can't be deleted by bots.

Output:

```
$ kuroboto chat clear --last 100
deleted 87 of last 100 (13 outside 48h delete window)
```

### M5 — `ohayo` in PTY mode (drop tmux)

Refactor `src/cli/ohayo.ts`:

- Remove `tmuxAvailable`, `tmuxHasSession`, send-keys, attach-session
- Print `ohayo 🌅` greeting
- Ensure daemon is up (existing logic from `src/cli/claude.ts`'s daemon-ensure)
- Call `runInjectClient({ args: [] })` directly (PTY wrapper from Spec E)
- `--tmux` flag for legacy users who want the detachable session

Trade-off: closing the terminal kills the claude session (vs. tmux's detachable behavior). Acceptable for v1; users who want detachability use `--tmux`.

### M6 — Daemon-down errors

When any CLI HTTP call fails with `ECONNREFUSED` (or fetch's equivalent), CLI prints:

```
✗ daemon offline. start it with `kuroboto start -d`.
```

…and exits 1. No more silent timeouts or generic "fetch failed".

Helper in `src/cli/http.ts` (new): `kuroFetch(url, init)` wraps `fetch`, catches connection errors, prints the message + exits.

### M7 — `--debug` global flag

Every CLI subcommand accepts `--debug`. When set:
- HTTP request URL + method + body printed to stderr before each fetch
- Response status + body printed after
- Daemon-side: not affected (daemon already logs)

Implementation: a `debug` boolean threaded through `kuroFetch` from M6. No environment-variable form for now (YAGNI).

### M8 — `--dry-run` on destructive commands

`sleeping cleanup`, `topics clear`, `chat clear` accept `--dry-run` flag. When set, list what would be done; no API calls or fs writes. Exit 0.

## Files

**Create:**
- `src/cli/sleepingCleanup.ts` — M2 logic
- `src/cli/topicsClear.ts` — M3 logic
- `src/cli/chatClear.ts` — M4 logic
- `src/cli/http.ts` — `kuroFetch` helper (M6 + M7)
- `test/unit/cli/sleepingCleanup.test.ts`
- `test/unit/cli/topicsClear.test.ts`
- `test/unit/cli/chatClear.test.ts`
- `test/unit/cli/kuroFetch.test.ts`

**Modify:**
- `src/cli/index.ts` — register new subcommands + `--debug` global option
- `src/cli/sleeping.ts` / `gaming.ts` / `audit.ts` / `allowlist.ts` / `mode.ts` — switch to `kuroFetch` for daemon-down errors + debug
- `src/cli/ohayo.ts` — M5 refactor
- `src/daemon/sleepFinish.ts` — M1: `humanise` → spec H1 extraction
- `src/channels/telegram/topics.ts` — M3 backend: `purge(key)` already exists; add `purgeAll()` if not, expose for CLI to call via daemon HTTP endpoint
- `src/daemon/routes.ts` — new endpoints:
  - `POST /v1/topics/clear` body `{ slug?: string, all?: boolean }` → returns deleted count
  - `POST /v1/chat/clear` body `{ last: number }` → returns deleted count
- `src/channels/telegram/api.ts` — `deleteMessage(chatId, messageId)` wrapper for M4
- `src/channels/Channel.ts` — interface extension for `deleteMessage` + `clearTopics`

## Behavior details

- **PR title H1 extraction:** scan plan content (or PLAN_INTRO + plan), find first line matching `^#\s+(.+)$`, capture group → trim → use as title. If no H1 in first 50 lines, fall back to humanised slug. Truncate to 70 chars (GitHub PR title limit is generous but keep it sane).
- **Cleanup safety:** `sleeping cleanup` only acts on `sleep/*` branches whose corresponding PR is merged. Open PRs are skipped (printed as "skipped: PR open"). Never deletes `main` or other non-sleep branches.
- **Topics clear behavior:** when topic is deleted via API, Telegram fires no event back; the daemon trusts the success response and removes from `topics.json` immediately. Next message recreates lazily (existing behavior).
- **Chat clear bounded:** Telegram's `deleteMessage` only succeeds for messages < 48h old when called by a bot. Older messages return `Bad Request: message can't be deleted`. CLI counts successes vs failures, reports both.
- **`--debug` output:** to stderr, not stdout, so command output remains pipeable. Format: `[debug] POST http://127.0.0.1:47891/v1/sleeping {body...} → 200 {response...}`.
- **Daemon-down detection:** matches on `ECONNREFUSED` (Node fetch) and `ETIMEDOUT` (slow network); prints actionable error and exits 1. Other HTTP errors keep current behavior.

## Out of scope

- **Auto-cleanup hook on PR merge** — `kuroboto sleeping cleanup` is invoked manually for now. Auto-detection (file watch on `gh` API webhooks) would close the loop but adds complexity. Promote to spec only if manual cleanup feels recurring.
- **Sleep state persistence** (daemon restart kills autonomous claude) — deferred to its own spec; bigger lift than the rest of this bundle.
- **Per-tool FYI denylist** during manual gaming — PR #20 stopped sleep flood; user-armed gaming still floods if they run a script. Add config option `policy.gamingFyiSkip: string[]` if it bites.
- **Status aggregator** (`kuroboto status` showing sleeps + clients + topics in one view) — independent improvement, deserves its own thinking.

## Test plan

**Unit:**
- `sleepingCleanup.test.ts` — mock `gh` + `git` calls; verify it filters merged-only, runs the right commands, respects `--dry-run`
- `topicsClear.test.ts` — mock daemon HTTP; verify it POSTs the right body, prints the right output
- `chatClear.test.ts` — mock daemon HTTP; verify count parsing
- `kuroFetch.test.ts` — mock fetch with ECONNREFUSED; verify the error message + exit code

**Integration (`daemon.test.ts` extension):**
- `POST /v1/topics/clear { slug }` → calls `topicManager.purge(slug)` once with the right key
- `POST /v1/topics/clear { all: true }` → calls purge on every key except `kuroboto-system`
- `POST /v1/chat/clear { last: 10 }` → calls `deleteMessage` 10 times with last 10 sent IDs

**Smoke (post-merge, manual):**
1. Open a PR via sleep dispatch — verify the title is the spec's H1, not the slug
2. Merge a sleep PR; run `kuroboto sleeping cleanup` — worktree + branches deleted
3. In supergroup mode, dispatch a sleep that floods a topic; run `kuroboto topics clear <slug>` — topic disappears, next message recreates
4. Stop the daemon; run `kuroboto sleeping status` — clear "daemon offline" error, exit 1
5. Run `kuroboto sleeping status --debug` — see HTTP request/response on stderr
6. Run `kuroboto ohayo` — claude opens in current terminal directly, no tmux session created

## Tasks

1. **M1**: Implement spec-H1 PR title extraction in `sleepFinish.ts` + unit test. Independent of others; can ship first.
2. **M2 + M3 + M4**: New CLI commands (`sleeping cleanup`, `topics clear`, `chat clear`) + new daemon endpoints + tests. The three share most plumbing.
3. **M5**: `ohayo` PTY refactor. Drops tmux dependency from that path.
4. **M6 + M7 + M8**: `kuroFetch` helper, `--debug` global, `--dry-run` flags. Wire through every existing CLI command.
5. **Final**: Run full suite (target: ~330 tests), manual smokes, PR.

```

## Test plan

- [ ] Review the diff against the original prompt
- [ ] Run the test suite locally
- [ ] Smoke-test the new behavior end-to-end

_Generated by kuroboto sleep mode._