### PR TITLE
feat: sleep/gaming noise filter + progress relay (Spec J)

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -79,6 +79,7 @@ export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
     createWorktree,
     removeWorktree,
     notifyDesktop: desktopNotifyDep,
+    logger,
     maxConcurrent: config.policy.maxConcurrentSleeps,
     onSuccess: (session) =>
       finishSleep(session, {

--- a/src/daemon/notificationDetect.ts
+++ b/src/daemon/notificationDetect.ts
@@ -9,3 +9,14 @@ export function isQAPrompt(message: string | undefined | null): boolean {
   if (typeof message !== 'string') return false;
   return QA_PATTERNS.includes(message);
 }
+
+// Sleep sessions emit single-line `[[KUROBOTO]] <text>` markers on stdout for
+// mid-flight visibility (Spec J3). Same regex as the stdout parser in
+// sleeping.ts; defending in depth here so a stray marker arriving via the
+// Notification hook still bypasses the gaming/sleep filter.
+export const PROGRESS_MARKER_RE = /^\s*\[\[KUROBOTO\]\]\s+(.+?)\s*$/;
+
+export function isProgressMarker(message: string | undefined | null): boolean {
+  if (typeof message !== 'string') return false;
+  return PROGRESS_MARKER_RE.test(message);
+}

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -15,7 +15,7 @@ import {
   formatQAPrompt,
   type PromptFormatContext,
 } from './promptFormat.js';
-import { isQAPrompt } from './notificationDetect.js';
+import { isQAPrompt, isProgressMarker } from './notificationDetect.js';
 import { injectViaPty } from '../inject/pty.js';
 import type { SessionSnap } from './sleeping.js';
 import { topicContextFromHook } from './topicContext.js';
@@ -308,6 +308,25 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
       ctx.injectClients.bindSessionByCwd(payload.session_id, payload.cwd);
     }
     const topicCtx = hookTopicCtx(payload);
+    // J1: gaming or sleep silences the Notification hook stream. Q&A prompts
+    // (matched on message text, not handler routing — so stuck-claude inside
+    // a sleep worktree still surfaces via the regular notif fallback) and
+    // explicit `[[KUROBOTO]]` progress markers bypass.
+    const gamingActive = ctx.state.gaming.snapshot().active;
+    const sleepActive = ctx.state.sleeping.snapshot().active.length > 0;
+    if (
+      (gamingActive || sleepActive) &&
+      !isQAPrompt(payload.message) &&
+      !isProgressMarker(payload.message)
+    ) {
+      ctx.logger.info('notify suppressed (gaming/sleep, non-Q&A)', {
+        cwd: payload.cwd,
+        gaming: gamingActive,
+        sleep: sleepActive,
+      });
+      res.json({ ok: true, suppressed: true });
+      return;
+    }
     if (shouldHandleAsQA(payload, ctx)) {
       // Fire-and-forget: the Q&A flow runs end-to-end (send question, await
       // reply, inject, audit) in the background. The hook just gets ack.

--- a/src/daemon/sleepReportRelay.ts
+++ b/src/daemon/sleepReportRelay.ts
@@ -1,0 +1,55 @@
+import readline from 'node:readline';
+import type { ChildProcess } from 'node:child_process';
+import type { Readable } from 'node:stream';
+import type { ChannelContext } from '../channels/Channel.js';
+
+// Sleep claude emits structured progress markers on stdout for mid-flight
+// visibility (Spec J3). Format: a single line by itself, exact prefix
+// `[[KUROBOTO]]`, then whitespace, then a one-line message. Lazy capture +
+// `\s*$` strips trailing whitespace.
+export const MARKER_RE = /^\s*\[\[KUROBOTO\]\]\s+(.+?)\s*$/;
+
+export interface MarkerRelayLogger {
+  warn(msg: string, meta?: Record<string, unknown>): void;
+  debug?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface MarkerRelayDeps {
+  slug: string;
+  notify: (msg: string, ctx?: ChannelContext) => Promise<void>;
+  logger?: MarkerRelayLogger;
+}
+
+export function parseMarkerLine(line: string): string | null {
+  const m = MARKER_RE.exec(line);
+  return m ? m[1] : null;
+}
+
+export function attachMarkerRelay(child: ChildProcess, deps: MarkerRelayDeps): void {
+  if (child.stdout) attachStream(child.stdout, deps);
+  if (child.stderr) attachStream(child.stderr, deps);
+}
+
+function attachStream(stream: Readable, deps: MarkerRelayDeps): void {
+  const rl = readline.createInterface({ input: stream });
+  rl.on('line', (line) => {
+    try {
+      const marker = parseMarkerLine(line);
+      if (marker !== null) {
+        void deps.notify(`📍 ${marker}`, { slug: deps.slug, isSleep: true }).catch((e) => {
+          deps.logger?.warn('marker relay notify failed', {
+            slug: deps.slug,
+            err: (e as Error).message,
+          });
+        });
+      } else if (deps.logger?.debug) {
+        deps.logger.debug('sleep stdout (non-marker)', { slug: deps.slug, line });
+      }
+    } catch (e) {
+      deps.logger?.warn('marker relay handler error', {
+        slug: deps.slug,
+        err: (e as Error).message,
+      });
+    }
+  });
+}

--- a/src/daemon/sleeping.ts
+++ b/src/daemon/sleeping.ts
@@ -3,6 +3,7 @@ import { GamingState, type GamingSnapshot } from './gaming.js';
 import { slugify } from './worktree.js';
 import type { DesktopNotifyOpts } from '../notify/desktop.js';
 import type { ChannelContext } from '../channels/Channel.js';
+import { attachMarkerRelay, type MarkerRelayLogger } from './sleepReportRelay.js';
 
 export type SpawnFn = (cmd: string, args: string[], opts: SpawnOptions) => ChildProcess;
 
@@ -15,6 +16,9 @@ export interface SleepingDeps {
   removeWorktree: (repo: string, dir: string) => Promise<void>;
   onSuccess: (session: SleepingSession) => Promise<void>;
   notifyDesktop?: (opts: DesktopNotifyOpts) => Promise<void>;
+  /** Used by the [[KUROBOTO]] stdout-marker relay (Spec J3). Optional so test
+   *  fakes can stay terse; production wires the daemon logger. */
+  logger?: MarkerRelayLogger;
   /** Maximum concurrent sleep sessions. Spec D — defaults to 3 in config. */
   maxConcurrent: number;
 }
@@ -75,8 +79,26 @@ interface InternalSession extends SleepingSession {
   terminated: boolean;
 }
 
+const MARKER_PROTOCOL =
+  'You are running unattended in a sleep session. Emit progress markers so the dev can\n' +
+  'follow along without seeing every tool call. Use this exact format, one per line, on\n' +
+  'a line by itself:\n' +
+  '\n' +
+  '[[KUROBOTO]] <one-line update>\n' +
+  '\n' +
+  'Emit a marker:\n' +
+  '- after each task is committed: "[[KUROBOTO]] task N done: <what changed>"\n' +
+  '- when you hit a blocker that needs human intervention: "[[KUROBOTO]] blocked: <why>"\n' +
+  '- at the very end as the final summary: "[[KUROBOTO]] summary: <bullets>"\n' +
+  '\n' +
+  'Keep markers short — one line each, no markdown. They land directly in Telegram.\n';
+
 const PLAN_INTRO =
-  'Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.\n\n';
+  'Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.\n\n' +
+  MARKER_PROTOCOL +
+  '\n';
+
+const PROMPT_OUTRO = '\n\n' + MARKER_PROTOCOL;
 
 export class SleepingOrchestrator {
   private readonly sessions = new Map<string, InternalSession>();
@@ -117,7 +139,9 @@ export class SleepingOrchestrator {
     }
     const branch = `sleep/${slug}`;
     const worktreePath = `${req.workRoot}/${slug}`;
-    const finalPrompt = req.plan ? PLAN_INTRO + req.plan : (req.prompt as string);
+    const finalPrompt = req.plan
+      ? PLAN_INTRO + req.plan
+      : (req.prompt as string) + PROMPT_OUTRO;
 
     // createWorktree first — if it fails, we want zero side effects (no
     // gaming arm leak, no half-state). Throws propagate to the caller.
@@ -133,7 +157,25 @@ export class SleepingOrchestrator {
     const startedAt = Date.now();
     const expectedEndAt = startedAt + req.maxDurationMs;
 
-    const child = this.deps.spawn('claude', ['-p', finalPrompt], { cwd: worktreePath });
+    // J2: --dangerously-skip-permissions short-circuits claude's PreToolUse
+    // hook entirely. Sleep is autonomous and pre-approved (gaming auto-allows
+    // anyway), so the round-trip is wasted bandwidth — and skipping the hook
+    // also stops claude's own "Claude needs permission..." Notification hook
+    // from firing on every tool call.
+    const child = this.deps.spawn(
+      'claude',
+      ['--dangerously-skip-permissions', '-p', finalPrompt],
+      { cwd: worktreePath },
+    );
+
+    // J3: relay [[KUROBOTO]] markers from claude's stdout/stderr to Telegram.
+    // Also drains the OS pipe buffer so claude doesn't block on a full pipe
+    // during long autonomous runs.
+    attachMarkerRelay(child, {
+      slug,
+      notify: this.deps.notify,
+      logger: this.deps.logger,
+    });
 
     const maxDurationTimer = setTimeout(() => {
       this.handleTimeout(slug);

--- a/test/unit/notifyFilter.test.ts
+++ b/test/unit/notifyFilter.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { createServer, type DaemonContext } from '../../src/daemon/server.js';
+import { PendingMap } from '../../src/daemon/pending.js';
+import { PendingNotifications } from '../../src/daemon/pendingNotifications.js';
+import { PendingReplies } from '../../src/daemon/pendingReplies.js';
+import type { ConfigT } from '../../src/config/schema.js';
+import * as stateModule from '../../src/daemon/state.js';
+import { GamingState } from '../../src/daemon/gaming.js';
+import { SleepingOrchestrator } from '../../src/daemon/sleeping.js';
+import { InjectClients } from '../../src/daemon/injectClients.js';
+import { MockChannel, noopLogger } from '../helpers/mockChannel.js';
+
+// Don't touch host state during these tests.
+const saveModeSpy = vi.spyOn(stateModule, 'saveMode').mockResolvedValue(undefined);
+afterAll(() => {
+  saveModeSpy.mockRestore();
+});
+
+const TEST_TOKEN = 'a'.repeat(64);
+
+function makeContext(): { ctx: DaemonContext; channel: MockChannel } {
+  const channel = new MockChannel();
+  const config: ConfigT = {
+    channel: { type: 'telegram', token: 'x', chatId: 1 },
+    daemon: { port: 47892, authToken: TEST_TOKEN },
+    inject: { enabled: false, replyTimeoutMs: 7_200_000 },
+    policy: {
+      permissionTimeoutMs: 1_000,
+      // Immediate-send so the channel call is synchronous-enough for assertions.
+      notifyDelayMs: 0,
+      permissionMatchers: ['Bash'],
+      rememberGranularity: 'tight',
+      gamingAlwaysAsk: [],
+      sleepMaxDurationMs: 7_200_000,
+      sleepWorktreeDir: '/tmp/kuroboto-test-worktrees',
+      maxConcurrentSleeps: 3,
+      failOpen: true,
+    },
+  };
+  const gaming = new GamingState();
+  const sleeping = new SleepingOrchestrator({
+    spawn: () => ({ on: () => {}, kill: () => {}, pid: 0, stdout: null, stderr: null } as never),
+    gaming,
+    notify: async () => {},
+    audit: async () => {},
+    createWorktree: async () => {},
+    removeWorktree: async () => {},
+    onSuccess: async () => {},
+    maxConcurrent: 3,
+  });
+  const ctx: DaemonContext = {
+    config,
+    channel,
+    pending: new PendingMap(),
+    pendingNotifications: new PendingNotifications(),
+    pendingReplies: new PendingReplies(),
+    inject: null,
+    injectClients: new InjectClients(),
+    state: { mode: 'away', gaming, sleeping },
+    logger: noopLogger,
+    startedAt: Date.now(),
+    hostname: 'test-host',
+  };
+  return { ctx, channel };
+}
+
+async function postNotify(
+  ctx: DaemonContext,
+  body: Record<string, unknown>,
+): Promise<request.Response> {
+  return request(createServer(ctx))
+    .post('/v1/notify')
+    .set('X-Kuroboto-Token', TEST_TOKEN)
+    .send({ hook_event_name: 'Notification', ...body });
+}
+
+const QA_MESSAGE = 'Claude is waiting for your input';
+const NOISY_MESSAGE = 'Claude needs your permission to use Bash';
+const PROGRESS_MESSAGE = '[[KUROBOTO]] task 1 done: filter wired';
+
+describe('/v1/notify gaming/sleep filter (Spec J1)', () => {
+  let ctx: DaemonContext;
+  let channel: MockChannel;
+
+  beforeEach(() => {
+    ({ ctx, channel } = makeContext());
+  });
+
+  describe('neither gaming nor sleep', () => {
+    it('lets a noisy non-Q&A notification through', async () => {
+      const res = await postNotify(ctx, { message: NOISY_MESSAGE, cwd: '/x/proj' });
+      expect(res.status).toBe(200);
+      expect(res.body.suppressed).toBeUndefined();
+      await new Promise((r) => setImmediate(r));
+      expect(channel.sentNotifications.length).toBe(1);
+    });
+  });
+
+  describe('gaming active', () => {
+    beforeEach(() => {
+      ctx.state.gaming.arm();
+    });
+
+    it('suppresses non-Q&A notifications', async () => {
+      const res = await postNotify(ctx, { message: NOISY_MESSAGE, cwd: '/x/proj' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, suppressed: true });
+      await new Promise((r) => setImmediate(r));
+      expect(channel.sentNotifications).toEqual([]);
+    });
+
+    it('lets progress markers through', async () => {
+      const res = await postNotify(ctx, { message: PROGRESS_MESSAGE, cwd: '/x/proj' });
+      expect(res.status).toBe(200);
+      expect(res.body.suppressed).toBeUndefined();
+      await new Promise((r) => setImmediate(r));
+      expect(channel.sentNotifications.length).toBe(1);
+    });
+  });
+
+  describe('sleep active', () => {
+    beforeEach(() => {
+      vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
+        active: [
+          {
+            slug: 'demo-abc123',
+            branch: 'sleep/demo-abc123',
+            worktreePath: '/y/demo-abc123',
+            startedAt: 0,
+            expectedEndAt: 0,
+          },
+        ],
+        capacity: 3,
+      });
+    });
+
+    it('suppresses non-Q&A notifications from outside the sleep worktree', async () => {
+      // Different cwd: not the autonomous-sleep stuck-session bypass.
+      const res = await postNotify(ctx, { message: NOISY_MESSAGE, cwd: '/x/other' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, suppressed: true });
+      await new Promise((r) => setImmediate(r));
+      expect(channel.sentNotifications).toEqual([]);
+    });
+
+    it('lets progress markers through', async () => {
+      const res = await postNotify(ctx, { message: PROGRESS_MESSAGE, cwd: '/y/demo-abc123' });
+      expect(res.status).toBe(200);
+      expect(res.body.suppressed).toBeUndefined();
+      await new Promise((r) => setImmediate(r));
+      expect(channel.sentNotifications.length).toBe(1);
+    });
+  });
+
+  describe('both gaming and sleep active', () => {
+    beforeEach(() => {
+      ctx.state.gaming.arm();
+      vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
+        active: [
+          {
+            slug: 'demo-abc123',
+            branch: 'sleep/demo-abc123',
+            worktreePath: '/y/demo-abc123',
+            startedAt: 0,
+            expectedEndAt: 0,
+          },
+        ],
+        capacity: 3,
+      });
+    });
+
+    it('suppresses non-Q&A non-marker notifications', async () => {
+      const res = await postNotify(ctx, { message: NOISY_MESSAGE, cwd: '/x/other' });
+      expect(res.body).toEqual({ ok: true, suppressed: true });
+    });
+
+    it('lets progress markers through', async () => {
+      const res = await postNotify(ctx, { message: PROGRESS_MESSAGE, cwd: '/y/demo-abc123' });
+      expect(res.body.suppressed).toBeUndefined();
+    });
+  });
+
+  describe('Q&A bypass', () => {
+    it('gaming on + Q&A message → bypasses filter (regular notif path, since inject is off here)', async () => {
+      ctx.state.gaming.arm();
+      const res = await postNotify(ctx, { message: QA_MESSAGE, cwd: '/x/proj' });
+      expect(res.status).toBe(200);
+      expect(res.body.suppressed).toBeUndefined();
+      await new Promise((r) => setImmediate(r));
+      expect(channel.sentNotifications.length).toBe(1);
+    });
+
+    it('sleep on + Q&A message inside sleep worktree → bypasses filter (stuck-claude visibility preserved)', async () => {
+      // shouldHandleAsQA returns false for sleep-cwd Q&A messages, but the
+      // filter must not silence them — they're how the dev learns claude got
+      // stuck mid-sleep.
+      vi.spyOn(ctx.state.sleeping, 'snapshot').mockReturnValue({
+        active: [
+          {
+            slug: 'stuck-abc123',
+            branch: 'sleep/stuck-abc123',
+            worktreePath: '/y/stuck-abc123',
+            startedAt: 0,
+            expectedEndAt: 0,
+          },
+        ],
+        capacity: 3,
+      });
+      const res = await postNotify(ctx, { message: QA_MESSAGE, cwd: '/y/stuck-abc123' });
+      expect(res.body.suppressed).toBeUndefined();
+      await new Promise((r) => setImmediate(r));
+      expect(channel.sentNotifications.length).toBe(1);
+    });
+  });
+});

--- a/test/unit/sleepReportRelay.test.ts
+++ b/test/unit/sleepReportRelay.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+import type { ChildProcess } from 'node:child_process';
+import {
+  attachMarkerRelay,
+  parseMarkerLine,
+  MARKER_RE,
+} from '../../src/daemon/sleepReportRelay.js';
+import type { ChannelContext } from '../../src/channels/Channel.js';
+
+class FakeChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  constructor() {
+    super();
+    this.stdout = new Readable({ read() {} });
+    this.stderr = new Readable({ read() {} });
+  }
+  push(stream: 'stdout' | 'stderr', chunk: string): void {
+    this[stream].push(chunk);
+  }
+  end(stream: 'stdout' | 'stderr'): void {
+    this[stream].push(null);
+  }
+}
+
+interface Notif {
+  msg: string;
+  ctx: ChannelContext | undefined;
+}
+
+function setupRelay(slug = 'demo'): {
+  child: FakeChild;
+  notifs: Notif[];
+  warns: { msg: string; meta?: Record<string, unknown> }[];
+  debugs: { msg: string; meta?: Record<string, unknown> }[];
+} {
+  const child = new FakeChild();
+  const notifs: Notif[] = [];
+  const warns: { msg: string; meta?: Record<string, unknown> }[] = [];
+  const debugs: { msg: string; meta?: Record<string, unknown> }[] = [];
+  attachMarkerRelay(child as unknown as ChildProcess, {
+    slug,
+    notify: async (msg, ctx) => {
+      notifs.push({ msg, ctx });
+    },
+    logger: {
+      warn: (msg, meta) => warns.push({ msg, meta }),
+      debug: (msg, meta) => debugs.push({ msg, meta }),
+    },
+  });
+  return { child, notifs, warns, debugs };
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+}
+
+describe('parseMarkerLine', () => {
+  it('extracts the message from a well-formed marker', () => {
+    expect(parseMarkerLine('[[KUROBOTO]] task 1 done: filter wired')).toBe(
+      'task 1 done: filter wired',
+    );
+  });
+
+  it('tolerates leading whitespace', () => {
+    expect(parseMarkerLine('   [[KUROBOTO]] hello')).toBe('hello');
+  });
+
+  it('tolerates trailing whitespace (lazy capture)', () => {
+    expect(parseMarkerLine('[[KUROBOTO]] hello   ')).toBe('hello');
+  });
+
+  it('returns null when the marker is not a line on its own', () => {
+    expect(parseMarkerLine('I will emit a [[KUROBOTO]] marker now')).toBeNull();
+  });
+
+  it('returns null when the marker has no message', () => {
+    expect(parseMarkerLine('[[KUROBOTO]]')).toBeNull();
+    expect(parseMarkerLine('[[KUROBOTO]] ')).toBeNull();
+  });
+
+  it('returns null on a non-marker line', () => {
+    expect(parseMarkerLine('Running tests…')).toBeNull();
+    expect(parseMarkerLine('')).toBeNull();
+  });
+
+  it('case-sensitive and bracket-strict', () => {
+    expect(parseMarkerLine('[[kuroboto]] x')).toBeNull();
+    expect(parseMarkerLine('[KUROBOTO] x')).toBeNull();
+  });
+
+  it('exported regex matches the shape', () => {
+    expect(MARKER_RE.test('[[KUROBOTO]] x')).toBe(true);
+  });
+});
+
+describe('attachMarkerRelay', () => {
+  it('relays a single marker line as a notify call with 📍 + slug ctx', async () => {
+    const { child, notifs } = setupRelay('demo');
+    child.push('stdout', '[[KUROBOTO]] task 1 done\n');
+    await flush();
+    expect(notifs).toEqual([
+      { msg: '📍 task 1 done', ctx: { slug: 'demo', isSleep: true } },
+    ]);
+  });
+
+  it('handles split chunks (a line that arrives in two writes)', async () => {
+    const { child, notifs } = setupRelay();
+    child.push('stdout', '[[KUROBOTO]] task ');
+    await flush();
+    expect(notifs).toEqual([]); // no newline yet
+    child.push('stdout', '1 done\n');
+    await flush();
+    expect(notifs.map((n) => n.msg)).toEqual(['📍 task 1 done']);
+  });
+
+  it('handles multiple markers in one chunk', async () => {
+    const { child, notifs } = setupRelay();
+    child.push('stdout', '[[KUROBOTO]] a\n[[KUROBOTO]] b\n[[KUROBOTO]] c\n');
+    await flush();
+    expect(notifs.map((n) => n.msg)).toEqual(['📍 a', '📍 b', '📍 c']);
+  });
+
+  it('ignores non-matching lines (pass through to debug log only)', async () => {
+    const { child, notifs, debugs } = setupRelay();
+    child.push('stdout', 'Running tests…\nDone.\n[[KUROBOTO]] task 1 done\n');
+    await flush();
+    expect(notifs.map((n) => n.msg)).toEqual(['📍 task 1 done']);
+    expect(debugs.length).toBeGreaterThanOrEqual(2);
+    expect(debugs[0].msg).toMatch(/non-marker/);
+  });
+
+  it('reads stderr too', async () => {
+    const { child, notifs } = setupRelay();
+    child.push('stderr', '[[KUROBOTO]] err-side marker\n');
+    await flush();
+    expect(notifs.map((n) => n.msg)).toEqual(['📍 err-side marker']);
+  });
+
+  it('keeps slug context per session (no cross-talk between concurrent relays)', async () => {
+    const a = setupRelay('aaa');
+    const b = setupRelay('bbb');
+    a.child.push('stdout', '[[KUROBOTO]] from-a\n');
+    b.child.push('stdout', '[[KUROBOTO]] from-b\n');
+    await flush();
+    expect(a.notifs).toHaveLength(1);
+    expect(a.notifs[0].ctx).toEqual({ slug: 'aaa', isSleep: true });
+    expect(a.notifs[0].msg).toBe('📍 from-a');
+    expect(b.notifs).toHaveLength(1);
+    expect(b.notifs[0].ctx).toEqual({ slug: 'bbb', isSleep: true });
+    expect(b.notifs[0].msg).toBe('📍 from-b');
+  });
+
+  it('a notify rejection logs a warn, does not crash the line handler', async () => {
+    const child = new FakeChild();
+    const warns: string[] = [];
+    const failingNotify = vi.fn(async () => {
+      throw new Error('telegram down');
+    });
+    attachMarkerRelay(child as unknown as ChildProcess, {
+      slug: 'demo',
+      notify: failingNotify,
+      logger: {
+        warn: (msg) => warns.push(msg),
+      },
+    });
+    child.push('stdout', '[[KUROBOTO]] one\n[[KUROBOTO]] two\n');
+    await flush();
+    // Both lines processed (parser didn't crash); warns logged for both.
+    expect(failingNotify).toHaveBeenCalledTimes(2);
+    expect(warns.length).toBeGreaterThanOrEqual(2);
+    expect(warns[0]).toMatch(/notify failed/);
+  });
+
+  it('no-op when stdout/stderr are null (defensive against custom stdio)', () => {
+    const fake = { stdout: null, stderr: null } as unknown as ChildProcess;
+    const notifs: string[] = [];
+    expect(() =>
+      attachMarkerRelay(fake, {
+        slug: 's',
+        notify: async (m) => {
+          notifs.push(m);
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/test/unit/sleeping.test.ts
+++ b/test/unit/sleeping.test.ts
@@ -314,6 +314,48 @@ describe('SleepingOrchestrator', () => {
     expect(promptArg).toContain('# Plan');
   });
 
+  it('spawn args include --dangerously-skip-permissions before -p (Spec J2)', async () => {
+    const { deps } = makeDeps();
+    const orch = new SleepingOrchestrator(deps);
+    const spawnSpy = vi.spyOn(deps, 'spawn');
+    await orch.start({ repo: '/x', prompt: 'p', workRoot: '/y', maxDurationMs: 60_000 });
+    const [cmd, args] = spawnSpy.mock.calls[0];
+    expect(cmd).toBe('claude');
+    const flagIdx = args.indexOf('--dangerously-skip-permissions');
+    const pIdx = args.indexOf('-p');
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    expect(pIdx).toBeGreaterThan(flagIdx);
+  });
+
+  it('PLAN_INTRO carries the [[KUROBOTO]] marker protocol (Spec J3)', async () => {
+    const { deps } = makeDeps();
+    const orch = new SleepingOrchestrator(deps);
+    const spawnSpy = vi.spyOn(deps, 'spawn');
+    await orch.start({ repo: '/x', plan: '# Plan\n\nDo X', workRoot: '/y', maxDurationMs: 60_000 });
+    const args = spawnSpy.mock.calls[0][1];
+    const promptArg = args[args.indexOf('-p') + 1];
+    expect(promptArg).toContain('[[KUROBOTO]]');
+    expect(promptArg).toContain('progress markers');
+    expect(promptArg).toContain('task N done');
+  });
+
+  it('PROMPT_OUTRO is appended to prompt-mode prompts (Spec J3)', async () => {
+    const { deps } = makeDeps();
+    const orch = new SleepingOrchestrator(deps);
+    const spawnSpy = vi.spyOn(deps, 'spawn');
+    await orch.start({
+      repo: '/x',
+      prompt: 'fix the auth bug',
+      workRoot: '/y',
+      maxDurationMs: 60_000,
+    });
+    const args = spawnSpy.mock.calls[0][1];
+    const promptArg = args[args.indexOf('-p') + 1];
+    expect(promptArg.startsWith('fix the auth bug')).toBe(true);
+    expect(promptArg).toContain('[[KUROBOTO]]');
+    expect(promptArg).toContain('progress markers');
+  });
+
   it('gaming snapshot restored to its prior on-state if it was already on', async () => {
     const { deps, state } = makeDeps();
     deps.gaming.arm(); // gaming already on, no timer


### PR DESCRIPTION
## Summary

Automated implementation via `kuroboto sleeping` (sleep mode).

## Original prompt

```
Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.

# Sleep/gaming noise filter + progress relay

> Status: planned. Spec J. Two paired changes that fix the same papercut: during gaming/sleep, the daemon currently floods Telegram with notifications that aren't actionable, and the dev simultaneously has zero mid-flight visibility into what claude is doing. Suppress the noise; restore visibility through structured progress markers.

## Problem (the flood + the blackout)

Witnessed live during recent dogfood:

1. **Notifications pour through during gaming/sleep.** `src/daemon/routes.ts:305` (`/v1/notify`) only special-cases Q&A typing prompts (`isQAPrompt(message)`); everything else — "Claude needs your permission to use Bash", progress notes, etc. — falls through to `sendNotification` and lands in Telegram. PR #20 already suppressed *gaming-FYIs during sleep*, but `/v1/notify` was untouched. Net effect: gaming/sleep don't quiet the channel the way the user expects from a "shift-tab" mode.
2. **Sleep claude is launched in default permission mode.** `src/daemon/sleeping.ts:136` spawns `claude -p <prompt>` with no permission flag. Claude fires PreToolUse for every tool — daemon auto-allows because gaming is armed, but the round-trip is wasted, and claude's *own* notification hook still fires "Claude needs permission..." style messages that route to Telegram via point 1.
3. **Dev goes blind during long sleeps.** `sleepFinish.ts` only notifies on completion ("✅ sleep done — PR: …") or failure. Nothing in between. With the filter from points 1+2 enabled the channel goes silent for the whole run; without it, it floods. Neither is what the dev wants — they want a small, structured trickle of "what's happening now."

## Solution

Three small, coordinated changes:

### J1 — Filter `/v1/notify` during gaming or sleep

In `/v1/notify` (`src/daemon/routes.ts:305`), before the existing branch:

```ts
const gamingActive = ctx.state.gaming.snapshot().active;
const sleepActive = ctx.state.sleeping.snapshot().active.length > 0;
if ((gamingActive || sleepActive) && !shouldHandleAsQA(payload, ctx) && !isProgressMarker(payload.message)) {
  ctx.logger.info('notify suppressed (gaming/sleep, non-Q&A)', { cwd: payload.cwd });
  res.json({ ok: true, suppressed: true });
  return;
}
```

Q&A typing prompts (the user explicitly asked for these to keep coming through) bypass the filter. Progress markers (J3 below) also bypass — they are the explicit visibility signal. Everything else is dropped with a daemon-side log entry so it can be diagnosed without spamming the user.

### J2 — `--dangerously-skip-permissions` on sleep spawn

`src/daemon/sleeping.ts:136`:

```ts
const child = this.deps.spawn(
  'claude',
  ['--dangerously-skip-permissions', '-p', finalPrompt],
  { cwd: worktreePath },
);
```

Equivalent to the user hitting shift-tab twice in interactive mode: claude doesn't fire the PreToolUse hook at all. Daemon stops receiving permission round-trips during sleep. `--dangerously-skip-permissions` is the documented Claude Code CLI flag for this; verify in the implementing run that the flag still exists at the current claude version (test by running `claude --help` on the sleep host).

The daemon's `policy.permissionMatchers` and gaming auto-allow logic remain in place for *non-sleep* use (manual gaming, away mode); only the sleep spawn path opts out.

### J3 — Stdout-marker progress relay

The daemon already spawns claude with default `stdio: 'pipe'` (Node default), so `child.stdout` is a Readable stream — currently nobody reads from it, which is also a latent bug because once the OS pipe buffer fills, claude blocks. Wire it up properly:

1. Attach a line-buffered reader on `child.stdout` (and `child.stderr` for completeness).
2. Each line is matched against:

   ```ts
   const MARKER_RE = /^\s*\[\[KUROBOTO\]\]\s+(.+?)\s*$/;
   ```

3. If a line matches, capture group 1 is the message. Forward it as a Telegram notification in the slug's topic context (`{ slug, isSleep: true }`), prefixed with `📍` so it's visually distinct from start/done.
4. Lines that don't match are ignored (claude's normal output remains uncaptured — the existing fire-and-forget behavior). Log them at debug level for diagnosis.

Embed in `PLAN_INTRO` (top of `sleeping.ts`):

```text
Execute this implementation plan. Follow it task-by-task. Run tests, commit per task,
and create a final summary at the end.

You are running unattended in a sleep session. Emit progress markers so the dev can
follow along without seeing every tool call. Use this exact format, one per line, on
a line by itself:

[[KUROBOTO]] <one-line update>

Emit a marker:
- after each task is committed: "[[KUROBOTO]] task N done: <what changed>"
- when you hit a blocker that needs human intervention: "[[KUROBOTO]] blocked: <why>"
- at the very end as the final summary: "[[KUROBOTO]] summary: <bullets>"

Keep markers short — one line each, no markdown. They land directly in Telegram.

```

For prompt-mode (no plan), append the same instruction block after the user's prompt so claude has the same protocol regardless of entry point.

## Files

**Modify:**
- `src/daemon/sleeping.ts` —
  - Update `PLAN_INTRO`; introduce `PROMPT_OUTRO` with the marker protocol; append it when `req.prompt` is used (so prompt mode also reports).
  - Spawn args: prepend `--dangerously-skip-permissions` (J2).
  - Wire `child.stdout` + `child.stderr` to a line-buffered parser; on `[[KUROBOTO]] <msg>` match call `deps.notify(\`📍 ${msg}\`, { slug, isSleep: true })` for the session.
- `src/daemon/routes.ts` — add gaming/sleep filter at the top of `/v1/notify` (J1).
- `src/daemon/notificationDetect.ts` — add `isProgressMarker(message)` helper (matches the same `[[KUROBOTO]]` regex on a single line). The notification hook itself shouldn't carry markers (claude prints them to stdout, not to Notification hook), but defending in depth is cheap.

**Create:**
- `test/unit/sleepReportRelay.test.ts` — line-buffered parser unit test: chunked stdout (split mid-line, multiple markers per chunk, mixed with non-marker lines) all parse correctly; non-matching lines are ignored; multiple concurrent sessions don't cross-contaminate.
- `test/unit/notifyFilter.test.ts` — `/v1/notify` integration: gaming-only active → non-Q&A suppressed, Q&A passes; sleep-only active → same; both-off → all pass; progress-marker payload → passes regardless of mode.

**Modify:**
- `test/unit/sleeping.test.ts` — extend with: spawn args include `--dangerously-skip-permissions`; PLAN_INTRO contains marker protocol; PROMPT_OUTRO appended for prompt-mode.

## Behavior details

- **Filter granularity:** gaming OR sleep is enough to enable the filter. The dev can still get noisy notifications during normal `here`/`away` mode — those are the modes where Telegram volume is acceptable because the dev armed them deliberately.
- **Marker regex strictness:** `^\s*\[\[KUROBOTO\]\]\s+(.+?)\s*$` requires the marker on a line by itself. Avoids false positives in claude's narrative output ("I'll emit a [[KUROBOTO]] marker now…"). Tests cover that.
- **Buffer safety:** the line-buffered reader uses `readline.createInterface({ input: child.stdout })`. Lines longer than the default 64KB threshold are truncated by readline silently — acceptable for one-line markers.
- **Backpressure:** consuming stdout fixes the latent buffer-fill bug. No code today depends on stdout being unread.
- **Crash isolation:** if the parser throws (it shouldn't — readline + regex), it must not bring down the orchestrator. Wrap the line handler in try/catch with a `logger.warn`.
- **Concurrent sessions:** each `InternalSession` owns its own `child` and therefore its own stdout. The slug is captured in the session closure, so cross-talk is structurally impossible. Test asserts this anyway.
- **Markers during cancellation:** if a session is cancelled mid-run, a final marker emitted by claude before the SIGTERM lands could race the cancel notification. Acceptable — the cancel notification ("sleep cancelled: <slug>") and a final marker are both useful information.

## Out of scope

- **Per-tool denylist for non-sleep gaming.** PR #20 already discussed this; if manual gaming (no sleep) becomes noisy again it's a separate, smaller spec.
- **`kuroboto report` CLI as an alternative relay** (Approach A in the design discussion). Approach B (stdout markers) was chosen because the daemon already owns the spawn — adding a CLI relay would mean a Bash call per report, polluting the audit log.
- **Streaming claude's full stdout to Telegram.** Considered and rejected — the whole point is to filter noise. The marker protocol is the explicit channel.
- **Replacing the final PR-summary notification** in `sleepFinish.ts`. The "✅ sleep done — PR: <url>" remains; the marker-based "summary" is supplementary, not a replacement.

## Test plan

**Unit:**
- `sleepReportRelay.test.ts` — line-buffered parser (chunked input, split lines, multiple markers per chunk, non-matches ignored, error handling).
- `notifyFilter.test.ts` — gaming-only / sleep-only / both / neither × Q&A-vs-not vs progress-marker matrix.
- `sleeping.test.ts` extension — spawn args, PLAN_INTRO content, PROMPT_OUTRO appended.

**Integration (`daemon.test.ts` extension):**
- POST `/v1/notify` with `gaming.active = true` and `message = "Claude needs your permission to use Bash"` → returns `{ ok: true, suppressed: true }`, no `sendNotification` called.
- POST `/v1/notify` with `gaming.active = true` and `message = "Claude is waiting for your input"` → handled as Q&A (existing behavior).
- POST `/v1/notify` with `sleeping.active = [<one>]` and `message = "[[KUROBOTO]] task 1 done"` → passes through (progress markers bypass the filter).

**Smoke (post-merge, manual):**
1. Start a sleep session that runs ≥3 tasks with commits. Telegram should receive ~3 `📍 task N done: …` markers + the existing start/done notifications. No "Claude needs permission" noise.
2. Run `kuroboto gaming on 5m` standalone (no sleep). Telegram should still go silent for non-Q&A notifications during the 5 minutes.
3. Confirm `--dangerously-skip-permissions` actually short-circuits the PreToolUse hook by tailing the daemon log during a sleep — no `permission` route hits should appear.

## Tasks

1. **J1**: `/v1/notify` filter + `notifyFilter.test.ts`. Independent; ships first.
2. **J2 + J3**: `sleeping.ts` changes — `--dangerously-skip-permissions` flag, line-buffered marker parser, PLAN_INTRO/PROMPT_OUTRO updates — and the matching tests (`sleepReportRelay.test.ts`, `sleeping.test.ts` extensions).
3. **Final**: full suite green (target ~415 tests after additions), manual smokes 1–3, single PR.

```

## Test plan

- [ ] Review the diff against the original prompt
- [ ] Run the test suite locally
- [ ] Smoke-test the new behavior end-to-end

_Generated by kuroboto sleep mode._