### PR TITLE
fix(cli): surface daemon startup errors from start --detach

### DIFF
--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,9 +1,12 @@
 import { spawn } from 'node:child_process';
+import { openSync } from 'node:fs';
+import fsp from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import chalk from 'chalk';
 import { startDaemon } from '../daemon/lifecycle.js';
 import { loadConfig } from '../config/load.js';
+import { CONFIG_DIR, STARTUP_LOG_FILE } from '../config/paths.js';
 import { checkHealth, sleep } from './util.js';
 
 export interface StartOptions {
@@ -33,12 +36,25 @@ async function startForeground(): Promise<void> {
 async function startDetached(): Promise<void> {
   const here = path.dirname(fileURLToPath(import.meta.url));
   const daemonEntry = path.join(here, '..', 'daemon', 'index.js');
+
+  // Truncate before each start so a stale crash log from an earlier run
+  // doesn't get surfaced as the cause of a new failure.
+  await fsp.mkdir(CONFIG_DIR, { recursive: true });
+  await fsp.writeFile(STARTUP_LOG_FILE, '');
+  const out = openSync(STARTUP_LOG_FILE, 'a');
+  const err = openSync(STARTUP_LOG_FILE, 'a');
+
   const child = spawn(process.execPath, [daemonEntry], {
     detached: true,
-    stdio: 'ignore',
+    stdio: ['ignore', out, err],
     windowsHide: true,
   });
   child.unref();
+
+  let exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+  child.on('exit', (code, signal) => {
+    exitInfo = { code, signal };
+  });
 
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
@@ -47,7 +63,31 @@ async function startDetached(): Promise<void> {
       console.log(chalk.green(`daemon iniciado (PID=${child.pid})`));
       return;
     }
+    if (exitInfo !== null) {
+      throw new Error(await formatStartupCrash(exitInfo));
+    }
     await sleep(250);
   }
-  throw new Error('daemon não respondeu em 10s');
+  throw new Error(
+    `daemon não respondeu em 10s. tail do startup log:\n${await readStartupLogTail()}\n\nfull log: ${STARTUP_LOG_FILE}`,
+  );
+}
+
+async function formatStartupCrash(
+  exitInfo: { code: number | null; signal: NodeJS.Signals | null },
+): Promise<string> {
+  const why = exitInfo.code !== null ? `exit code ${exitInfo.code}` : `signal ${exitInfo.signal}`;
+  const tail = await readStartupLogTail();
+  return `daemon crashed during startup (${why}):\n${tail}\n\nfull log: ${STARTUP_LOG_FILE}`;
+}
+
+async function readStartupLogTail(maxLines = 30): Promise<string> {
+  try {
+    const content = await fsp.readFile(STARTUP_LOG_FILE, 'utf-8');
+    const lines = content.trim().split('\n');
+    const tail = lines.slice(-maxLines).join('\n');
+    return tail || '(no output captured)';
+  } catch {
+    return '(startup log unavailable)';
+  }
 }

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -8,3 +8,4 @@ export const DAEMON_SENTINEL_FILE = path.join(CONFIG_DIR, 'daemon.pid.json');
 export const LOG_DIR = path.join(CONFIG_DIR, 'logs');
 export const AUDIT_FILE = path.join(CONFIG_DIR, 'audit.jsonl');
 export const TOPICS_FILE = path.join(CONFIG_DIR, 'topics.json');
+export const STARTUP_LOG_FILE = path.join(CONFIG_DIR, 'daemon.startup.log');


### PR DESCRIPTION
## Summary
- `kuroboto start -d` previously masked all daemon startup failures behind a generic `daemon não respondeu em 10s` — `stdio: 'ignore'` discarded the child's stderr and there was no `exit` listener, so users had to re-run in foreground to see what actually broke
- Redirect detached daemon stdout/stderr to `~/.config/kuroboto/daemon.startup.log`, listen for `exit`, and surface the log tail in the thrown error on early exit or polling timeout

## Context
Hit this debugging a real failure today: daemon was crashing with `tmux session 'claude' not found` (legacy config, strategy was still `tmux` after default flipped to `pty`), but `start -d` just said "10s timeout" — required a foreground rerun to see the real message. Same masking happens for any startup-time failure (port busy, telegram auth, validate hooks, etc).

## Test plan
- [x] All 437 existing tests still pass (`npm test`)
- [x] Manually validated stdio capture mechanism: spawned a node child that writes to stderr and exits non-zero, confirmed (a) `exit` event fires with `{code, signal}`, (b) stderr lands in the log file, (c) tail is readable
- [ ] Next time the daemon actually fails to start, error message should contain real cause + path to full log

🤖 Generated with [Claude Code](https://claude.com/claude-code)