### PR TITLE
fix(daemon): fall back to pty when tmux unavailable

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -31,20 +31,14 @@ export interface RunningDaemon {
   stop(): Promise<void>;
 }
 
-export async function startDaemon(config: ConfigT): Promise<RunningDaemon> {
+export async function startDaemon(initialConfig: ConfigT): Promise<RunningDaemon> {
   await fsp.mkdir(CONFIG_DIR, { recursive: true });
   await fsp.mkdir(LOG_DIR, { recursive: true });
 
   await ensureNoExistingDaemon();
 
-  // Tmux validation only applies to the legacy strategy. PTY-strategy clients
-  // self-host their own PTY in `kuroboto claude`, so the daemon needs no
-  // multiplexer to start.
-  if (config.inject.enabled && config.inject.strategy === 'tmux') {
-    await validateTmuxAvailable(config.inject.session ?? 'claude');
-  }
-
   const logger = createLogger(LOG_DIR);
+  const config = await applyRuntimeFallbacks(initialConfig, logger);
   logger.info('daemon starting', { port: config.daemon.port });
 
   const channel = await makeChannel(config, logger);
@@ -224,6 +218,27 @@ function isProcessAlive(pid: number): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+// Tmux is a legacy inject strategy. PTY-strategy clients self-host their own
+// PTY in `kuroboto claude`, so the daemon doesn't need a multiplexer at all.
+// When the user's persisted config still says `tmux` but tmux isn't available
+// (server died, session not running, binary missing), fall back to pty for
+// this run instead of refusing to start. The config file is left alone — a
+// transient tmux outage shouldn't rewrite their preference.
+async function applyRuntimeFallbacks(config: ConfigT, logger: Logger): Promise<ConfigT> {
+  if (!config.inject.enabled || config.inject.strategy !== 'tmux') return config;
+  try {
+    await validateTmuxAvailable(config.inject.session ?? 'claude');
+    return config;
+  } catch (e) {
+    const reason = (e as Error).message;
+    logger.warn('tmux strategy unavailable, falling back to pty', { err: reason });
+    process.stderr.write(
+      `[kuroboto] tmux unavailable (${reason}); falling back to pty for this run\n`,
+    );
+    return { ...config, inject: { ...config.inject, strategy: 'pty', session: undefined } };
   }
 }
 


### PR DESCRIPTION
## Summary
- Daemon used to hard-fail with `tmux session 'X' not found` when persisted config has `inject.strategy: tmux` but the tmux server/session isn't running
- Wrap the tmux validation in a runtime fallback: on failure, log a warn (also mirrored to stderr so `kuroboto start --detach` captures it via the startup log from #23) and continue with strategy=pty for this run
- Persisted config is untouched — transient tmux outage shouldn't rewrite the user's preference

## Context
Companion to #23. Real failure today: legacy config still had `strategy: tmux` from a pre-v0.2 init, tmux server had died, and the daemon refused to come up. Pty strategy works without any multiplexer (the `kuroboto claude` CLI self-hosts its own PTY), so falling back is strictly better than refusing to start.

The `effectiveConfig` is plumbed through the rest of `startDaemon` via the existing `config` const, so `createInjectStrategy`, `routes.ts`'s `ctx.config.inject.strategy === 'tmux'` checks, and the `DaemonContext` all see the post-fallback strategy consistently.

## Test plan
- [x] All 437 existing tests pass (`npm test`)
- [x] Build clean (`npm run build`)
- [ ] Manual verification: with `inject.strategy: tmux` and tmux server down, daemon starts with pty fallback (warn visible in foreground / startup log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)