### PR TITLE
fix(daemon): persist crash details on unhandled exception/rejection

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -9,3 +9,4 @@ export const LOG_DIR = path.join(CONFIG_DIR, 'logs');
 export const AUDIT_FILE = path.join(CONFIG_DIR, 'audit.jsonl');
 export const TOPICS_FILE = path.join(CONFIG_DIR, 'topics.json');
 export const STARTUP_LOG_FILE = path.join(CONFIG_DIR, 'daemon.startup.log');
+export const CRASH_LOG_FILE = path.join(CONFIG_DIR, 'daemon.crash.log');

--- a/src/daemon/crashHandlers.ts
+++ b/src/daemon/crashHandlers.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type CrashKind = 'uncaughtException' | 'unhandledRejection' | 'startupError';
+
+export interface CrashLogDeps {
+  // Sync writers — handlers must complete before `process.exit` returns,
+  // and async fs operations are not guaranteed to flush in that window.
+  appendSync?: (file: string, data: string) => void;
+  mkdirSync?: (dir: string) => void;
+  stderrWrite?: (msg: string) => void;
+}
+
+/**
+ * Format and persist a crash entry. Sync I/O so the entry lands even if the
+ * process is about to exit. Failures while writing the file fall back to
+ * stderr (which `kuroboto start --detach` captures into the startup log).
+ */
+export function logCrashSync(
+  crashLogFile: string,
+  kind: CrashKind,
+  err: unknown,
+  deps: CrashLogDeps = {},
+): void {
+  const append = deps.appendSync ?? ((f, d) => fs.appendFileSync(f, d));
+  const mkdir = deps.mkdirSync ?? ((d) => fs.mkdirSync(d, { recursive: true }));
+  const stderr = deps.stderrWrite ?? ((m) => process.stderr.write(m));
+
+  const ts = new Date().toISOString();
+  const stack = err instanceof Error ? err.stack ?? err.message : String(err);
+  const line = `${ts} [${kind}] ${stack}\n`;
+
+  try {
+    mkdir(path.dirname(crashLogFile));
+    append(crashLogFile, line);
+  } catch (e) {
+    stderr(`[kuroboto daemon] crash log write failed: ${(e as Error).message}\n`);
+  }
+  stderr(`[kuroboto daemon] ${kind}: ${stack}\n`);
+}
+
+/**
+ * Wire up `uncaughtException` and `unhandledRejection` to log a structured
+ * crash entry before exiting. Without this the process dies silently and the
+ * daemon log shows nothing — the only evidence is the absence of a shutdown
+ * message.
+ */
+export function installCrashHandlers(crashLogFile: string): void {
+  process.on('uncaughtException', (err) => {
+    logCrashSync(crashLogFile, 'uncaughtException', err);
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (reason) => {
+    logCrashSync(crashLogFile, 'unhandledRejection', reason);
+    process.exit(1);
+  });
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,9 @@
 import { loadConfig } from '../config/load.js';
 import { startDaemon } from './lifecycle.js';
+import { CRASH_LOG_FILE } from '../config/paths.js';
+import { installCrashHandlers, logCrashSync } from './crashHandlers.js';
+
+installCrashHandlers(CRASH_LOG_FILE);
 
 async function main(): Promise<void> {
   const config = await loadConfig();
@@ -9,6 +13,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((e) => {
-  console.error(`[kuroboto daemon] fatal: ${(e as Error).message}`);
+  logCrashSync(CRASH_LOG_FILE, 'startupError', e);
   process.exit(1);
 });

--- a/test/unit/crashHandlers.test.ts
+++ b/test/unit/crashHandlers.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { logCrashSync } from '../../src/daemon/crashHandlers.js';
+
+interface Captured {
+  appends: Array<{ file: string; data: string }>;
+  mkdirs: string[];
+  stderr: string[];
+}
+
+function captured(): Captured & {
+  deps: Parameters<typeof logCrashSync>[3];
+} {
+  const c: Captured = { appends: [], mkdirs: [], stderr: [] };
+  return {
+    ...c,
+    deps: {
+      appendSync: (file, data) => {
+        c.appends.push({ file, data });
+      },
+      mkdirSync: (dir) => {
+        c.mkdirs.push(dir);
+      },
+      stderrWrite: (msg) => {
+        c.stderr.push(msg);
+      },
+    },
+  };
+}
+
+describe('crashHandlers/logCrashSync', () => {
+  it('writes a timestamped entry with the error stack to the crash log', () => {
+    const c = captured();
+    const err = new Error('boom');
+    logCrashSync('/tmp/crash.log', 'uncaughtException', err, c.deps);
+
+    expect(c.appends).toHaveLength(1);
+    expect(c.appends[0].file).toBe('/tmp/crash.log');
+    const line = c.appends[0].data;
+    expect(line).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z \[uncaughtException\] /);
+    expect(line).toContain('boom');
+    expect(line.endsWith('\n')).toBe(true);
+  });
+
+  it('mirrors the crash to stderr so detached startup capture sees it', () => {
+    const c = captured();
+    logCrashSync('/tmp/crash.log', 'unhandledRejection', new Error('x'), c.deps);
+    expect(c.stderr.some((s) => s.includes('[kuroboto daemon] unhandledRejection: '))).toBe(true);
+  });
+
+  it('mkdirs the parent directory before appending', () => {
+    const c = captured();
+    logCrashSync('/var/state/kuroboto/daemon.crash.log', 'uncaughtException', new Error('x'), c.deps);
+    expect(c.mkdirs).toEqual(['/var/state/kuroboto']);
+  });
+
+  it('falls back to stderr when the append fails', () => {
+    const c = captured();
+    const failing: typeof c.deps = {
+      ...c.deps,
+      appendSync: () => {
+        throw new Error('disk full');
+      },
+    };
+    logCrashSync('/tmp/crash.log', 'uncaughtException', new Error('boom'), failing);
+    expect(c.stderr.some((s) => s.includes('crash log write failed: disk full'))).toBe(true);
+    expect(c.stderr.some((s) => s.includes('[kuroboto daemon] uncaughtException: '))).toBe(true);
+  });
+
+  it('handles non-Error throws by stringifying them', () => {
+    const c = captured();
+    logCrashSync('/tmp/crash.log', 'unhandledRejection', 'plain string reason', c.deps);
+    expect(c.appends[0].data).toContain('plain string reason');
+  });
+});


### PR DESCRIPTION
## Summary
- Daemon dies silently — `daemon.log` shows no shutdown line and there's no stack trace anywhere
- `unhandledRejection` and `uncaughtException` bypass `main().catch`, so any error not surfaced through the awaited promise chain kills the process with zero diagnostic
- Wire process-level handlers that sync-append the timestamped kind+stack to `~/.config/kuroboto/daemon.crash.log` and mirror to stderr (captured by the startup log when run via `start --detach` from #23)
- Sync I/O is intentional — `process.exit` returns immediately, async fs ops are not guaranteed to flush

## Context
We've watched the daemon vanish at least twice today (during sleep agents overnight and again ~13min after a fresh start). Without crash evidence the bug is unworkable. This PR doesn't *fix* the underlying instability — it makes the next death actionable. Pairs naturally with #23 (startup log) and #24 (tmux fallback) merged earlier today.

## Test plan
- [x] 5 new unit tests for `logCrashSync` cover the happy path, stderr mirroring, mkdir, fallback when append fails, and non-Error throws
- [x] All 442 tests pass (`npm test`)
- [x] Build clean (`npm run build`)
- [x] Manually validated end-to-end: spawned a node process that calls `installCrashHandlers` then triggers `Promise.reject` 100ms later. Confirmed (a) crash log file gets the timestamped line with full stack, (b) stderr receives the mirror line, (c) process exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)