### PR TITLE
fix(cli): sleeping cleanup detects merged sleeps (drop bogus --head filter)

### DIFF
--- a/src/cli/sleepingCleanup.ts
+++ b/src/cli/sleepingCleanup.ts
@@ -44,11 +44,12 @@ export interface CleanupDeps {
  * already merged.
  */
 export async function listMergedSleeps(deps: Omit<CleanupDeps, 'confirm' | 'log' | 'warn'>): Promise<MergedSleep[]> {
+  // gh's --head is exact-match, not prefix-match, so we list all merged PRs
+  // and rely on the headRefName.startsWith('sleep/') filter below.
   const r = await deps.exec('gh', [
     'pr',
     'list',
     '--state', 'merged',
-    '--head', 'sleep/',
     '--json', 'number,headRefName,state',
     '--limit', '100',
   ]);

--- a/test/unit/cli/sleepingCleanup.test.ts
+++ b/test/unit/cli/sleepingCleanup.test.ts
@@ -46,15 +46,16 @@ describe('listMergedSleeps', () => {
     });
   });
 
-  it('passes --state merged + --head sleep/ to gh', async () => {
+  it('passes --state merged to gh and does not pass --head', async () => {
     const { exec, calls } = makeExec({ 'gh pr': { code: 0, stdout: '[]', stderr: '' } });
     await listMergedSleeps({ exec, workRoot: '/wk' });
     expect(calls).toHaveLength(1);
     expect(calls[0].cmd).toBe('gh');
     expect(calls[0].args).toContain('--state');
     expect(calls[0].args).toContain('merged');
-    expect(calls[0].args).toContain('--head');
-    expect(calls[0].args).toContain('sleep/');
+    // Regression guard: gh's --head is exact-match, so passing 'sleep/' would
+    // always return []. The startsWith('sleep/') filter handles prefix matching.
+    expect(calls[0].args).not.toContain('--head');
   });
 
   it('throws a clear error when gh fails', async () => {


### PR DESCRIPTION
## Summary
- `gh pr list --head sleep/` is exact-match, not prefix, so it always returned `[]` and `kuroboto sleeping cleanup` reported `(nenhum sleep mergeado para limpar)` even when merged `sleep/*` PRs existed.
- Drop the `--head sleep/` arg; the existing client-side `headRefName.startsWith('sleep/')` filter handles prefix matching correctly.
- Updated the args-assertion test to guard against re-introducing the bug (asserts `--head` is **not** passed).

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — all 442 tests green
- [ ] Manual smoke post-merge: create a `sleep/test-XXX` branch, open + merge a PR, leave a stub worktree, run `kuroboto sleeping cleanup` and confirm it picks the merged sleep up.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)