### PR TITLE
Bug C watchdog — daemon auto-recovery

### DIFF
--- a/docs/specs-backlog.md
+++ b/docs/specs-backlog.md
@@ -4,8 +4,20 @@ Loose collection of feature ideas worth a spec eventually. Not prioritized; prom
 
 ## Active queue (specced, ready to dispatch)
 
-- **Spec D — parallel sleep sessions** (`docs/specs/parallel-sleeps.md`). Was deferred behind Spec E (PTY injection); E shipped in PR #12, so D is now unblocked. Will need a quick rebase since Spec E touched `sleeping.ts` for late-binding integration.
-- **Spec F — Telegram supergroup + topics** (`docs/specs/supergroup-topics.md`). Designed in the same session as Spec E. Independent of D in terms of code — they touch different layers (D = `sleeping.ts` + cli; F = `TelegramChannel` + topic manager + every channel call site). Both can dispatch sequentially or even in parallel with care.
+- **Spec G — Bug C watchdog** (`docs/specs/bug-c-watchdog.md`, 2026-04-29). Daemon auto-recovery via parent-child watchdog process. Foundational for status UI integration; touches `start.ts`/`stop.ts`/`status.ts`. v1 magro: respawns daemon on death, sleeps in-flight orphaned with cleanup notif.
+- **Spec H — Daemon health UI** (`docs/specs/daemon-health-ui.md`, 2026-04-29). `kuroboto status` enriched with gaming/sleeps/inject/topics/watchdog. New `/v1/status` endpoint, `--json`/`--watch`/`--quiet` flags. Has overlap with Spec G in `cli/status.ts` — dispatch Spec G first, then rebase Spec H atop merged G to avoid conflicts.
+
+## ForumMode v2 rollout (consolidated follow-ups)
+
+Three small follow-ups from Spec F (`docs/specs/supergroup-topics.md`, merged in PR #14) that are good candidates for one consolidated spec when forumMode is actually enabled in production and the real ergonomic gaps surface:
+
+- **Per-host slug prefix** (multi-machine: prepend `mac-juan/` or `win-juan/` to slug) — natural extension once multi-machine setup proves the need. Today the user develops between mac and Windows (per memory `project_multi_machine.md`); enabling forumMode without per-host prefix means same slug across hosts collides into the same topic. Becomes pressing the day forumMode is flipped on.
+- **`kuroboto topics list/prune` CLI helpers** — manual inspection/cleanup of `topics.json` when it drifts from actual Telegram state (topic deleted in client, topics.json out of sync). Today the recovery path is hand-edit JSON; not ideal but rare.
+- **Auto-archive on Stop hook** — when a Claude session ends (Stop hook fires), close the corresponding topic so the user's topic list doesn't grow unbounded across days/weeks of work. Cosmetic but the "close" action in Telegram already exists; just needs wiring.
+
+These three touch the same `TopicManager` + `topics.json` + slug derivation surface and would naturally fit one PR. Consolidate into `docs/specs/forum-mode-v2.md` when (a) the user has been on forumMode for a few days and (b) at least one of the three has surfaced a concrete annoyance worth fixing.
+
+Out of scope of this consolidated spec (kept separate for complexity reasons): **Migration tool DM→supergroup** — automated migration including reposting recent history. Heavier; manual migration is fine for now since it's a one-time operation.
 
 ## Extensible sleep finish-hooks (Level 2 of desktop notifications)
 

--- a/docs/specs/bug-c-watchdog.md
+++ b/docs/specs/bug-c-watchdog.md
@@ -1,0 +1,217 @@
+# Bug C watchdog — daemon auto-recovery
+
+> Status: planned. Spec G. Targets the long-standing "Bug C" — daemon dies silently and stays dead until the user notices and runs `kuroboto ohayo`. PR #26 covered JS exceptions via `installCrashHandlers`; this spec covers everything that bypasses Node-level handlers (external SIGKILL, OOM killer, OS sleep/hibernate, segfault, power loss).
+
+## Problem
+
+The daemon is a single long-lived Node process. Today it dies for several reasons:
+
+1. **JS exception** — covered by `installCrashHandlers` in PR #26: writes `daemon.crash.log` before exit. Solved.
+2. **External SIGKILL** — Windows logoff, `taskkill /F`, OOM killer, force-quit, `kill -9`. Bypasses every Node handler. No log, no signal, daemon just vanishes.
+3. **OS sleep / hibernate** — laptop closes lid; on wake, Telegram polling connection is dead and never recovers in some cases. Process is alive but functionally dead.
+4. **Native crash** — segfault inside libuv or a native dependency. No JS-level recovery.
+5. **Power loss** — same as SIGKILL from the daemon's perspective.
+
+Observed at least 3× in the 2026-04-29 session: daemon disappeared between 10–30 min after start with **no entry** in `daemon.log` (no shutdown line) and **no entry** in `daemon.crash.log` (PR #26's coverage). The only evidence was the *absence* of activity. User had to manually re-run `kuroboto ohayo` each time, losing whatever in-flight Telegram polling state existed.
+
+The fix is a separate **watchdog process** that supervises the daemon, detects death instantly via parent-child `child.on('exit')`, and respawns with bounded retries.
+
+## Solution
+
+`kuroboto start --detach` spawns a watchdog process (detached). The watchdog spawns the daemon as **its own child**, listens for `exit`, and respawns with exponential backoff. The watchdog stays simple (~200 LOC, no Telegram polling, no HTTP server, no business logic) so its own failure surface is minimal.
+
+Auto-recovery is **default-on**. There is no "opt-in flag" — Bug C is the entire reason the watchdog exists; making it opt-in would underdeliver on the feature. An opt-out flag `--no-watchdog` is provided for debugging (foreground / direct daemon spawn, current behavior).
+
+In-flight sleeps that die alongside the daemon are **out of scope for v1**. This spec focuses on daemon-level recovery only. Sleep recovery (persistence, re-attach) is deferred to a follow-up spec — see "Future / v2 roadmap" below — and informed by empirical data this v1 will produce.
+
+## Architecture
+
+```
+kuroboto start --detach
+        │ spawn detached
+        ▼
+┌──────────────────┐  child.spawn(daemon)   ┌─────────────────────┐
+│ watchdog process │ ──────────────────────▶│ daemon process      │
+│ (~200 LOC)       │  child.on('exit')      │ (existing lifecycle)│
+│  - parent-child  │ ◀──────────────────────┤                     │
+│  - backoff       │  poll /v1/health       │ HTTP :47891         │
+│  - notify        │ ◀──────────────────────┤                     │
+└──────┬───────────┘                        └─────────────────────┘
+       │ writes
+       ▼
+~/.config/kuroboto/watchdog.pid
+~/.config/kuroboto/watchdog.log
+```
+
+State machine (watchdog):
+
+```
+   [STARTING_DAEMON] ──spawn ok──▶ [WAITING_HEALTHY] ──/health 200──▶ [RUNNING]
+          │                              │                                 │
+          │ spawn fail                   │ timeout 10s                     │ child exit
+          ▼                              ▼                                 ▼
+   [GIVING_UP]                    [GIVING_UP]                    everHealthy?
+                                                                          │
+                                                       ┌──────────────────┴────────────────┐
+                                                       ▼                                   ▼
+                                                  no → [GIVING_UP]                 yes → backoff,
+                                                                                          re-spawn,
+                                                                                          back to
+                                                                                  [STARTING_DAEMON]
+```
+
+`everHealthy` is a single boolean per watchdog lifetime: once the daemon's `/v1/health` returns 200 even one time, every subsequent crash is treated as runtime (respawn-eligible). A daemon that never reached healthy is a startup failure (config wrong, port in use) and should not loop.
+
+## Files
+
+**Create:**
+- `src/watchdog/index.ts` — entry point. Reads config (port, channel for notifications), spawns daemon as child, manages state machine, handles SIGTERM cleanup.
+- `src/watchdog/policy.ts` — pure functions, easy to unit test:
+  - `nextBackoff(attempt: number): number` — returns ms (1000, 2000, 4000, 8000, 16000, 30000, 30000…).
+  - `shouldRespawn(state: WatchdogState): { respawn: boolean; reason: string }` — encapsulates the everHealthy / max-retries / window logic.
+- `src/watchdog/notify.ts` — minimal Telegram sender (subset of `TelegramApi.sendMessage`, plus topic context for `kuroboto-system`). Cannot reuse `TelegramChannel` because the daemon may be dead and the watchdog must remain independent. Best-effort: failures log to watchdog.log and continue.
+- `test/unit/watchdog/policy.test.ts`
+- `test/unit/watchdog/lifecycle.test.ts`
+- `test/integration/watchdog-bugC.test.ts`
+- `test/integration/watchdog-startup.test.ts`
+- `test/integration/watchdog-stop.test.ts`
+
+**Modify:**
+- `src/cli/start.ts` — `startDetached` now spawns the watchdog (not the daemon directly). The `--no-watchdog` flag preserves the legacy direct-spawn path for debug/foreground. Foreground `startForeground` is unchanged.
+- `src/cli/stop.ts` — read `WATCHDOG_PID_FILE` first; if present, SIGTERM the watchdog and let it clean up the daemon. If absent (legacy or `--no-watchdog`), fall back to current direct-daemon-kill path.
+- `src/cli/status.ts` — show both processes. Detect and clearly flag the split-brain case where watchdog is dead but daemon is alive (rare; happens if the watchdog was killed by hand).
+- `src/config/paths.ts` — add `WATCHDOG_PID_FILE = path.join(CONFIG_DIR, 'watchdog.pid')` and `WATCHDOG_LOG_FILE = path.join(CONFIG_DIR, 'watchdog.log')`.
+- `src/daemon/lifecycle.ts` — at startup, scan `~/.kuroboto/worktrees/sleep-*` for orphaned worktrees (see "Sleep behavior on crash" below). Notify if found.
+
+## Behavior details
+
+### Startup flow
+
+1. `kuroboto start --detach` runs `checkHealth()`. If daemon already alive → "já está rodando", return.
+2. Otherwise spawn the **watchdog** detached, sharing `STARTUP_LOG_FILE` for stdout/stderr (same path used by PR #23 to surface startup errors).
+3. Watchdog writes `WATCHDOG_PID_FILE`.
+4. Watchdog spawns the daemon as its child, again sharing `STARTUP_LOG_FILE` stdio so any startup error is captured for the parent CLI to tail.
+5. Watchdog enters `WAITING_HEALTHY`: polls `http://127.0.0.1:<port>/v1/health` every 250ms for up to 10s.
+6. On 200 within 10s → `everHealthy = true`, state → `RUNNING`. Telegram notif `✅ kuroboto online` is sent by the daemon itself (existing behavior). No additional notif from the watchdog on first start.
+7. On 10s timeout without 200 → `GIVING_UP`. Watchdog sends notif (best-effort) `❌ daemon não respondeu em 10s — investigar config`, exits non-zero. The CLI parent times out its own wait, reads `STARTUP_LOG_FILE` tail, and prints the error — same UX as PR #23 today.
+
+### Runtime crash flow (Bug C)
+
+1. Daemon dies (any cause: SIGKILL, OOM, segfault, escaped JS exception).
+2. Watchdog receives `child.on('exit', (code, signal) => ...)` instantly.
+3. `shouldRespawn` consults state:
+   - `everHealthy === false` → `{ respawn: false, reason: 'startup-failure' }`. Notif + exit. (Already covered by startup flow above; this path is for the rare case where /health 200'd then immediately died — still treat as runtime since `everHealthy === true`.)
+   - 5 respawns within the last 60s (rolling window — count of respawn timestamps where `now - ts < 60_000`) and none reached "healthy ≥30s consecutive" → `{ respawn: false, reason: 'gave-up' }`. Notif `❌ watchdog deu up — 5 falhas em 60s. Última: <signal/code>. Rode kuroboto ohayo quando puder.`. Exits.
+   - Otherwise → `{ respawn: true }`. Increment attempt, wait `nextBackoff(attempt)`, spawn again. State → `STARTING_DAEMON`.
+4. Per respawn: notif `🔄 daemon respawnado (#N) — exit code <X> / signal <Y>` to the `kuroboto-system` topic if forumMode is on; main chat otherwise.
+5. New daemon healthy ≥30s consecutively → reset `attempt = 0`. The 30s threshold means "the daemon stabilized" and unlocks the full backoff budget for any future crash.
+
+### Stop flow
+
+1. `kuroboto stop` reads `WATCHDOG_PID_FILE`. If present → SIGTERM the watchdog. Wait up to 10s for both PID files to disappear.
+2. Watchdog SIGTERM handler: SIGTERM the daemon child; wait up to 5s; SIGKILL fallback. Delete `WATCHDOG_PID_FILE` and `PID_FILE`. Exit cleanly.
+3. If `WATCHDOG_PID_FILE` is absent (legacy install pre-watchdog, or `--no-watchdog` was used): fall back to current `stop.ts` behavior (read `PID_FILE`, SIGTERM the daemon, polling).
+
+### Sleep behavior on crash (v1 scope)
+
+Sleeps spawned via `SleepingOrchestrator` are children of the **daemon**, not of the watchdog. When the daemon dies, sleep behavior is platform-dependent:
+
+- **Windows**: child cascade-dies via job object inheritance — sleep is killed too. Worktree remains, branch `sleep/<slug>` exists, no PR opened.
+- **Linux/macOS**: child may survive (re-parented to init/launchd) but its stdout pipe is orphaned, so `[[KUROBOTO]]` markers are lost. The respawned daemon has no in-memory record of the sleep.
+
+v1 does not attempt to attach to or persist these. Instead, the **respawned daemon scans worktrees on startup**:
+
+- Look for directories matching `~/.kuroboto/worktrees/sleep-*`.
+- For each, check the corresponding `sleep/<slug>` branch: if no open PR exists for it AND the worktree's mtime is older than 5 minutes (indicating no recent activity), notify `⚠️ sleep <slug> ficou órfão durante restart; investigar manualmente`.
+- The user runs `kuroboto sleeping cancel <slug>` (existing) or `kuroboto sleeping cleanup` (existing, fixed in PR #28) to reclaim.
+
+This is the **scope-limited v1 path**. Empirical observation in production will tell us whether sleeps cascade-die universally on Windows, frequently survive on Linux, etc. — input for v2 design.
+
+### Configuration
+
+No new config keys. `--no-watchdog` is a CLI flag on `start --detach` only. The watchdog reads `~/.config/kuroboto/config.json` once at its own startup (chatId/token/port) and **does not reload across respawns**. If the user edits config while the watchdog is running, they should `kuroboto stop && kuroboto start --detach` to pick it up — same model as the daemon today. Avoiding mid-flight reload keeps the watchdog's state machine deterministic.
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Daemon startup crash (port in use, bad token, broken config) | Watchdog stays in `WAITING_HEALTHY`, times out at 10s, notifies, exits != 0. CLI parent surfaces tail of `STARTUP_LOG_FILE` (PR #23 path). |
+| Daemon JS uncaughtException/unhandledRejection | `installCrashHandlers` (PR #26) writes `daemon.crash.log` and exits 1. Watchdog detects exit, respawns. The two coverage paths cooperate. |
+| Daemon SIGKILL (Windows logoff, taskkill /F, OOM) | Watchdog `child.on('exit', signal: 'SIGKILL')`. Respawns. Exact bug-C path. |
+| Daemon hang (deadlock, infinite loop, stuck in syscall) | **Not covered by v1.** Watchdog only reacts to `exit`. Detection requires active health-check + force-kill — separate feature, see backlog. |
+| Watchdog hits 5 respawns in 60s | Notif (Telegram + desktop best-effort), append `daemon.crash.log` "watchdog gave up after N attempts", exit. `kuroboto status` thereafter shows everything dead. User runs `kuroboto ohayo`. |
+| Watchdog itself crashes | Daemon child cascade-dies (Windows) or is orphaned (Unix). PID files become stale. `kuroboto status` detects (alive PID check) and shows the state. No auto-recovery — watchdog is simple enough that this should be rare; if it happens repeatedly, that's a bug to fix in code, not patch in process. |
+| Telegram unreachable during respawn notif | Notif fail logged to `watchdog.log`. Desktop notif fallback (best-effort, swallows errors). Watchdog logic continues unaffected. |
+| Port already in use when daemon respawns | Daemon fails startup (bind error). Watchdog sees daemon's exit before /health ever 200's during this respawn cycle. Already-true `everHealthy` from prior cycle still allows another retry, but if 5 of these happen in 60s → gives up. Reasonable: port-in-use is a real condition that won't self-resolve, and gave-up notif tells the user. |
+| Stale `WATCHDOG_PID_FILE` from a crashed prior run | `start.ts` checks `isProcessAlive` on the recorded PID before spawning a new watchdog (mirrors current `ensureNoExistingDaemon` logic). Stale → unlink and proceed. |
+
+## Audit
+
+Three new `source` values in `audit.jsonl` (file at `AUDIT_FILE`, written via existing `appendAudit`):
+
+- `watchdog-respawn` — `decision: 'allow'`, `reason: 'exit code N'` or `'signal SIGKILL'`. Per respawn.
+- `watchdog-gave-up` — `decision: 'deny'`, `reason: 'N retries in window M'`. Once per gave-up event.
+- `watchdog-startup-failure` — `decision: 'deny'`, `reason: '...'`. When daemon never reaches healthy.
+
+Audit entries from the watchdog use a `requestId` of `watchdog:<isotimestamp>` so they don't collide with daemon's permission-decision entries.
+
+## Out of scope (follow-ups)
+
+- **Sleep persistence and recovery (v2)** — persist active sleeps to `~/.config/kuroboto/sleeps.json` (PID, slug, started, expectedEnd). Respawned daemon reads file, checks each PID with `process.kill(pid, 0)`, marks alive ones as "recovered (markers lost)" or dead ones as failed. Cross-platform behavior (cascade vs orphan) gathered from v1 production data informs the design. Watchdog v1 should expose an `onDaemonRespawn(pid)` interface so v2 can plug in non-invasively. Tracking entry: `docs/specs-backlog.md` — "Spec G2 — sleep recovery".
+- **Hang detection** — daemon alive but unresponsive (stuck in deadlock, infinite loop). Requires the watchdog to actively poll `/health` continuously, not just rely on `exit`, and force-SIGKILL when N consecutive polls fail. v1 deliberately ignores this case — it's a real but separate failure mode and folding it in here would double the watchdog's complexity.
+- **Self-watchdog** — supervising the watchdog itself with another process. Explicitly rejected: the watchdog is small enough that "watch the watchdog" adds more failure surface than it removes. If the watchdog crashes, the user runs `kuroboto ohayo`.
+- **OS service integration (NSSM/systemd/launchd)** — wrapping the daemon as a real OS-managed service. Powerful but requires admin/root, OS-specific install steps, and breaks the `npm i -g kuroboto` simplicity. Not aligned with the project's "single binary, user-mode" stance.
+
+## Test plan
+
+### Unit (`policy.test.ts`)
+
+- `nextBackoff(0..6)` returns `[1000, 2000, 4000, 8000, 16000, 30000, 30000]`.
+- `shouldRespawn` with `everHealthy: false` → `{ respawn: false, reason: 'startup-failure' }`.
+- `shouldRespawn` with 5 attempts in last 60s and none reached healthy ≥30s → `{ respawn: false, reason: 'gave-up' }`.
+- `shouldRespawn` with attempts that include a "healthy ≥30s" reset → counter is back to 0, respawn allowed.
+- `shouldRespawn` happy path → `{ respawn: true }`.
+
+### Unit (`lifecycle.test.ts` — mock `spawn`, mock `fetch`, mock `fs`)
+
+- Watchdog spawns daemon, child exits before /health ever 200's → does not respawn, exits non-zero.
+- Watchdog spawns daemon, /health 200's, child exits later → respawns after correct backoff delay.
+- Watchdog SIGTERM handler → SIGTERM-then-SIGKILL the child, deletes both PID files.
+- Watchdog crash notif goes to `kuroboto-system` topic when `forumMode: true`, main chat otherwise.
+
+### Integration / anti-regression
+
+Each of these references a real bug or PR; the test name carries the reference so a future refactor doesn't silently regress it.
+
+**`watchdog-bugC.test.ts`** — covers the original Bug C from the 2026-04-29 sessions:
+
+- `'respawns after external SIGKILL (bug C from 2026-04-29 sessions)'` — spawn a real foreground daemon process, then `process.kill(daemonPid, 'SIGKILL')`. Assert the watchdog (under test) detects the exit, waits ~1s backoff, respawns, and the new daemon's `/health` returns 200 within 10s.
+- `'respawns after daemon JS crash + crashHandlers fired (bug C path 2 — PR #26 integration)'` — spawn a daemon-mock that throws after 2s. Assert (a) `daemon.crash.log` contains the entry (PR #26 path still works) AND (b) the watchdog respawned (new path). Cross-coverage of the two.
+- `'does NOT respawn when daemon never becomes healthy (avoids infinite loop on bad config)'` — daemon-mock that exits immediately on startup. Assert watchdog gives up without retrying, and `daemon.crash.log` mentions startup failure.
+- `'gives up after 5 rapid respawns in 60s window'` — daemon-mock that exits 1s after each healthy check. Assert: 5 respawns happen, then `watchdog-gave-up` audit entry, then watchdog exit non-zero.
+
+**`watchdog-startup.test.ts`** — covers PR #23 regression:
+
+- `'surfaces startup errors via STARTUP_LOG_FILE (PR #23 regression coverage)'` — start with a config that fails to bind (port already in use). Assert the CLI parent receives the error with tail of `STARTUP_LOG_FILE` formatted the same way as today.
+- `'falls back to direct daemon spawn with --no-watchdog flag'` — assert legacy path: no watchdog process, only daemon, behaves like pre-spec.
+
+**`watchdog-stop.test.ts`** — covers stop-flow correctness:
+
+- `'kuroboto stop kills both watchdog and daemon, cleans both PID files'`.
+- `'kuroboto stop with stale watchdog PID file falls back to direct daemon kill (legacy path)'`.
+- `'kuroboto stop times out after 10s if watchdog hangs'` — error path; assert clear error to user.
+
+### Manual smoke (post-merge)
+
+1. `kuroboto start --detach` → `kuroboto status` shows `watchdog: alive (PID=A)` and `daemon: alive (PID=B)`.
+2. `taskkill /F /PID <B>` (Windows) or `kill -9 <B>` (Unix) → Telegram receives `🔄 daemon respawnado (#1)` within ~1–2 seconds; status reports a new daemon PID.
+3. Loop-kill the daemon 6× rapidly within 60s → after the 5th, `❌ watchdog deu up` notif arrives, status shows everything dead.
+4. `kuroboto stop` → both processes terminate in order, PID files cleaned.
+5. Edit config to set `daemon.port` to an in-use port. `kuroboto start --detach` → expect clear startup error with log tail, no infinite respawn loop.
+6. `kuroboto start --detach --no-watchdog` → only daemon spawns; legacy behavior preserved; status correctly shows `watchdog: (none)` without flagging it as a problem.
+
+## Tasks (milestones)
+
+1. **M1**: `policy.ts` (pure) + `policy.test.ts`. `paths.ts` adds `WATCHDOG_PID_FILE` and `WATCHDOG_LOG_FILE`. No daemon code touched yet. Mergeable on its own.
+2. **M2**: `index.ts` (watchdog runtime) + `notify.ts` (minimal Telegram client) + `lifecycle.test.ts`. Functional standalone — can be exercised manually by running it directly. No CLI integration yet.
+3. **M3**: Wire into `start.ts`, `stop.ts`, `status.ts`. Daemon-side worktree-orphan scan in `lifecycle.ts`. All anti-regression integration tests. Manual smoke. PR.

--- a/docs/specs/daemon-health-ui.md
+++ b/docs/specs/daemon-health-ui.md
@@ -1,0 +1,276 @@
+# Daemon health UI — `kuroboto status` enriched
+
+> Status: planned. Spec H. Promotes `kuroboto status` from a 4-line liveness check into the canonical "what is my daemon doing right now" surface. Triggered by a confirmed bug observed 2026-04-29: `kuroboto gaming on` succeeds but the next `kuroboto status` does not surface gaming state, hiding the result. Backend already exposes the data; the CLI throws it away.
+
+## Problem
+
+Current `kuroboto status` (`src/cli/status.ts`) shows: PID liveness, HTTP health (`uptime`, `pending`), `mode` read directly from disk, and which Claude Code hooks are installed. That's it.
+
+The daemon already tracks much more state — gaming, active sleeps with timers, registered PTY clients, topic mappings — and exposes most of it via dedicated endpoints (`/v1/gaming`, `/v1/sleeping`, `/v1/inject-clients`). None of that is visible in the canonical "give me a snapshot" command.
+
+Confirmed in production 2026-04-29:
+
+```
+$ kuroboto status
+  daemon: alive (PID=20652)
+  health: ok uptime=2850s pending=0
+  mode: here
+  hooks: Notification, PreToolUse, Stop
+
+$ kuroboto gaming on
+gaming on (no timer — off only via `kuroboto gaming off`)
+
+$ kuroboto status
+  (identical output — no indication gaming is armed)
+```
+
+The information is in the daemon (`/v1/gaming` returns `{ active: true, until: null }`); the CLI just doesn't ask. There is also a latent consistency bug: `mode` is read from `~/.config/kuroboto/state.json` directly via `loadMode()`, ignoring whatever the daemon has in memory. If the two diverge (e.g., during a write), the CLI lies.
+
+The fix is a richer, single-shot `kuroboto status` that queries the daemon for everything, falls back gracefully when the daemon is offline, and supports `--json` for scripting and `--watch` for live monitoring.
+
+## Solution
+
+Three pieces:
+
+1. **New endpoint `GET /v1/status`** returns the full daemon state in one response. `/v1/health` shrinks to `{ ok, uptimeSec }` — pure liveness, suitable for the watchdog (Spec G) polling loop.
+2. **`kuroboto status` rewritten** as a single command that aggregates daemon state + local-only info (watchdog PID file, hooks settings, config path) and renders via pure formatter functions.
+3. **Flags:** `--json` (machine-readable), `--watch [N]` (live refresh), `--quiet` (one-liner liveness for scripts).
+
+The single-command approach won out over per-domain subcommands (`kuroboto sleeps`, `kuroboto gaming`) because the primary use case is "glance and check everything" — splitting forces the user to remember 5 commands. Existing subcommands (`kuroboto gaming on/off`, `kuroboto sleeping start`) stay as **mutators**; `status` is the read surface.
+
+The endpoint split (rather than fattening `/v1/health`) decouples liveness probes from display payload. The watchdog (Spec G) polls `/v1/health` continuously; keeping that endpoint trivial means future status growth doesn't penalize the watchdog hot path.
+
+## Architecture
+
+```
+        ┌──────────────────────────────────────┐
+        │ kuroboto status [--json|--watch|...] │
+        └────────────────┬─────────────────────┘
+                         │
+           ┌─────────────┼──────────────┬───────────────────┐
+           │             │              │                   │
+           ▼             ▼              ▼                   ▼
+    GET /v1/status  WATCHDOG_PID_FILE  ~/.claude/        CONFIG_FILE
+    (auth required) (local read)      settings.json     (path string)
+           │             │              │                   │
+           └─────────────┴──────┬───────┴───────────────────┘
+                                ▼
+                  ┌─────────────────────────┐
+                  │ statusFormat.ts (pure)  │
+                  │  - formatHumanReadable  │
+                  │  - formatJson           │
+                  │  - formatQuiet          │
+                  └─────────────────────────┘
+                                │
+                                ▼
+                            stdout
+```
+
+`/v1/health` (shrunk) and `/v1/status` (new) both bind to loopback only and inherit the existing auth model: `/health` stays auth-bypass (liveness probe should be free), `/status` requires the standard `X-Kuroboto-Token` header.
+
+## Files
+
+**Create:**
+- `src/cli/statusFormat.ts` — pure formatter functions and humanization helpers. No I/O, no side effects.
+- `test/unit/statusFormat.test.ts` — covers helpers (`humanizeDuration`, `formatCountdown`, `truncatePath`) and each formatter against fixtures.
+- `test/integration/statusCommand.test.ts` — end-to-end tests covering all anti-regression cases.
+
+**Modify:**
+- `src/daemon/routes.ts`:
+  - Shrink `GET /v1/health` to `{ ok: true, uptimeSec }`. **This is a breaking change** for any existing client of `/v1/health` that consumed `pending`/`mode`/`gaming` from it. Today the only consumer is `src/cli/util.ts:checkHealth()`, used by `cli/status.ts` and `cli/start.ts`; both are updated in this spec.
+  - Add `GET /v1/status` returning the full state shape (see Schema below).
+- `src/cli/util.ts`:
+  - `HealthData` interface narrows to `{ ok: boolean; uptimeSec: number }`.
+  - New `StatusData` interface mirroring the new endpoint shape.
+  - New `fetchStatus(timeoutMs?): Promise<StatusResult>` — parallel to `checkHealth` but with auth header from loaded config.
+- `src/cli/status.ts`:
+  - Parse flags via existing CLI parser convention (whatever pattern `start.ts` etc. use).
+  - Aggregate: `Promise.allSettled([readPid, readWatchdogPid, fetchStatus, detectInstalledHooks])`.
+  - Delegate output to `statusFormat.ts`.
+  - `--watch` loop with ANSI clear; SIGINT handler for clean exit.
+
+## Schema (StatusResponse)
+
+```ts
+interface StatusResponse {
+  daemon: {
+    pid: number;
+    uptimeSec: number;
+    startedAt: string;        // ISO timestamp
+    hostname: string;
+    port: number;
+  };
+  pending: {
+    permissions: number;      // ctx.pending.size()
+    notifications: number;    // ctx.pendingNotifications.size()
+    replies: number;          // ctx.pendingReplies.size()
+  };
+  mode: 'here' | 'away';
+  gaming: { active: boolean; until: number | null };  // ms epoch
+  sleeping: {
+    active: SessionSnap[];    // existing type, slug/branch/worktreePath/startedAt/expectedEndAt
+    capacity: number;
+  };
+  injectClients: ClientListEntry[];  // existing type
+  topics?: {                  // omitted entirely if channel.type !== 'telegram'
+    forumMode: boolean;
+    count: number;            // TopicManager.size() if forumMode, else 0
+  };
+}
+```
+
+Note: `topics.count` requires a new `TopicManager.size()` method (single line). Acceptable surface addition.
+
+## Output mockup (default text)
+
+```
+kuroboto status
+  config: C:\Users\juanj\.config\kuroboto\config.json
+  watchdog: alive (PID=12345)
+  daemon: alive (PID=20652) uptime=47m, started 14:23
+  health: ok pending=0 pendingNotifications=0
+  mode: here
+  gaming: armed (sem timer)
+  sleeps: 2 active (capacity 3)
+    💤 fix-bot-ux            12m ago, expira em 1h48m
+    💤 daemon-health-ui      3m ago, expira em 1h57m
+  inject clients: 1 registered
+    poe-alt-crafter (PID=9876, cwd=C:\Users\juanj\work\PoeAltCrafter)
+  topics: forumMode on, 5 mapeados
+  hooks: Notification, PreToolUse, Stop
+```
+
+Empty states (always rendered, never silently elided):
+
+```
+  gaming: off
+  sleeps: none active
+  inject clients: none
+  topics: DM mode (forumMode off)
+```
+
+Watchdog row condition: present only if `WATCHDOG_PID_FILE` exists. Pre-Spec G or `--no-watchdog`, the row is simply omitted (not "watchdog: not configured" — silent omission keeps output clean and decouples specs).
+
+## Behavior details
+
+### Flags
+
+- `--json` — emits `JSON.stringify(merged, null, 2)`. Schema is the union of `StatusResponse` plus locally-merged fields (`watchdog`, `hooks`, `configPath`). Snapshot-tested for stability.
+- `--watch [N]` — repaints every N seconds (default 1, min 0.5). ANSI clear (`\x1B[2J\x1B[0f`), header includes `(live, refresh ${N}s, Ctrl+C pra sair) — ${time}`. Tolerates daemon transitions: a frame where the daemon dies renders the offline state without aborting the loop. SIGINT exits cleanly.
+- `--quiet` — single line `daemon: alive` or `daemon: dead`. Exit code 0/1 for shell pipelines.
+- Default text output also exits 1 if daemon is dead (preserves `kuroboto status && do_thing` ergonomics).
+
+### Humanization
+
+- `uptimeSec` rendered via `humanizeDuration`: `<60s → 47s`, `<60m → 47m`, `<24h → 2h15m`, `≥24h → 1d4h`.
+- `daemon.startedAt` shown as time-of-day if today, ISO date+time otherwise.
+- Sleep `expectedEndAt - now` rendered as countdown: `expira em 1h48m`. Past expiration: `(expirou há Xs — em cleanup?)`.
+- Inject client `cwd` truncated at 60 chars with leading `…/` if longer.
+
+### Daemon offline path
+
+When `fetchStatus` fails (ECONNREFUSED, ETIMEDOUT, 401, malformed JSON):
+
+```
+kuroboto status
+  config: C:\Users\juanj\.config\kuroboto\config.json
+  daemon: dead (stale PID=20652)
+  health: unreachable (ECONNREFUSED)
+  mode: here (from disk — daemon offline)
+  hooks: Notification, PreToolUse, Stop
+  (daemon offline — gaming/sleeps/inject/topics indisponíveis)
+```
+
+Mode falls back to `loadMode()` (disk read) only in this path — explicitly labeled `(from disk — daemon offline)` so the user knows it's a fallback, not authoritative. Other state-derived fields are explicitly omitted with the trailing line.
+
+### Auth handling
+
+`/v1/status` requires `X-Kuroboto-Token`. CLI loads config to grab `daemon.authToken`. If config is missing or malformed:
+
+```
+  daemon: alive
+  status: auth failed (check config token)
+```
+
+Diagnostic message instead of crashing or silent omission.
+
+### Watch mode mechanics
+
+- `setInterval(N * 1000)` driving the render
+- Render: clear (`\x1B[2J\x1B[0f`), fetch fresh, format, write
+- Fetch errors don't abort the loop — they render the offline state and keep going
+- `process.on('SIGINT', ...)`: clear interval, exit 0
+- Validates N: `< 0.5 → error "minimum interval is 0.5s"`, `NaN → error`
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Daemon offline (ECONNREFUSED, stale PID) | Offline section above. Exit 1 (default/--quiet); --watch keeps polling. |
+| `/v1/status` returns 401 (auth) | `status: auth failed (check config token)` — explicit, not silent. |
+| `/v1/status` returns malformed JSON | `status: malformed response from daemon` + truncated raw to stderr. Exit 1. |
+| `WATCHDOG_PID_FILE` absent | Watchdog row omitted (silent — desired). |
+| Watchdog PID file present, process dead (split-brain) | `watchdog: ⚠ stale PID file (PID=N — process dead)`. Visible warning. |
+| `~/.claude/settings.json` missing or unparseable | `hooks: (no settings.json at <path>)` or `hooks: (unparseable)`. Existing behavior preserved. |
+| `forumMode: true` but `topics.json` unreadable | `topics: forumMode on, ⚠ topics.json unreadable`. |
+| `--watch` daemon transitions mid-loop | Next frame renders new state; loop continues. |
+| Concurrent `kuroboto stop` while status fetches | Likely ECONNRESET; treated as offline (same path). |
+| `--watch` invalid interval | `error: --watch interval must be ≥ 0.5s`, exit 2. |
+| Terminal without ANSI support (legacy cmd.exe pre-Windows-10) | Clear-screen sequence won't render — output will accumulate. Acceptable: target environments (Windows Terminal, PowerShell 7+, Unix terminals) all support ANSI. Documented limitation, not a bug. |
+| Network stack out of FDs (rare) | fetch throws; offline path. |
+
+## Audit
+
+No new audit entries. Status is purely a read operation and does not mutate state.
+
+## Test plan
+
+### Unit (`statusFormat.test.ts`)
+
+Helpers:
+- `humanizeDuration(0)` → `0s`; `(47000)` → `47s`; `(2_850_000)` → `47m`; `(8_100_000)` → `2h15m`; `(90_000_000)` → `1d1h`.
+- `formatCountdown(now+1000)` → `1s`; `(now+90_000_000)` → `1d1h`; `(now-5000)` → `(expirou há 5s)`; `(now-30_000_000)` → `(expirou há 8h20m)`.
+- `truncatePath('C:/short')` → `C:/short`; long path → `…/last/segments`.
+
+Formatters (each fed canonical fixtures):
+- `formatHumanReadable`: snapshot of fully-populated daemon, snapshot of empty states, snapshot of daemon-offline.
+- `formatJson`: snapshot of full payload — schema stability gate.
+- `formatQuiet`: alive → `daemon: alive`, code 0. Dead → `daemon: dead`, code 1.
+
+### Integration / anti-regression (`statusCommand.test.ts`)
+
+Each test name carries the bug reference so a future refactor can't quietly regress it.
+
+1. **`'kuroboto status mostra gaming armed (bug confirmado em uso 2026-04-29)'`** — daemon mock returns `gaming: { active: true, until: null }`; assert output contains `gaming: armed (sem timer)`. The literal regression of the reported bug.
+2. **`'mode vem do daemon, não do disco (consistência runtime vs state.json)'`** — daemon mock returns `mode: 'away'`; disk has `here`; assert output shows `away`. Closes the latent race in current `status.ts`.
+3. **`'inject clients listam após bindSessionByCwd race'`** — register a client, bind a session by cwd, assert output's `inject clients:` block lists the slug + cwd.
+4. **`'daemon offline → fallback parcial sem crash'`** — fetch throws ECONNREFUSED; assert output has `daemon: dead`, `mode: here (from disk — daemon offline)`, the trailing `(daemon offline — ...)` note, and exit code 1.
+5. **`'WATCHDOG_PID_FILE ausente → linha watchdog não aparece (decoupled from Spec G)'`** — no watchdog file present; assert output has zero `watchdog:` references.
+6. **`'--watch tolera daemon caindo mid-loop sem crash'`** — first frame OK, second frame mock returns 503, third frame mock returns OK. Assert 3 frames rendered, no thrown error, loop continued.
+7. **`'--json schema snapshot estável'`** — fully-populated fixture → JSON output match snapshot. Test failure forces explicit review of any schema change.
+8. **`'forumMode on com topics.json vazio → "0 mapeados" sem crash'`** — TopicManager mock with empty cache; assert `topics: forumMode on, 0 mapeados`.
+9. **`'status durante stop concorrente → trata como offline graceful'`** — fetch returns ECONNRESET mid-call; assert same offline path as case 4.
+
+### Manual smoke (post-merge)
+
+1. `kuroboto status` in each state combination: idle / gaming on / 1+ sleeps / forumMode on / inject clients registered. Visually confirm.
+2. `kuroboto status --json | jq .gaming.active` — pipe-friendly.
+3. `kuroboto status --watch 2` — watch transitions (start a sleep mid-watch, expect frame update; Ctrl+C clean).
+4. `kuroboto stop && kuroboto status` — full offline render.
+5. `kuroboto status --quiet; echo $?` — exit code on alive vs dead.
+6. After Spec G merges, re-run #1 and verify `watchdog: alive (PID=N)` row appears without any code change in this spec.
+
+## Out of scope (follow-ups)
+
+- **Status push notifications** — daemon proactively notifies on state change. Already covered (selectively) by Telegram; full push duplicates that surface.
+- **Status history** — `kuroboto status --history` showing last N runs/states. Useful for forensics; not the bug being solved here.
+- **Per-machine remote view** — `kuroboto status --remote=mac` for multi-machine setup. Belongs after forumMode v2 + per-host slug prefix work, when the multi-machine substrate is real.
+- **Pretty TUI** — full-screen ncurses-style dashboard. `--watch` text repaint covers the live use case at a fraction of complexity.
+
+## Tasks (milestones)
+
+1. **M1**: Add `GET /v1/status` to `routes.ts`. Add `TopicManager.size()`. **Do not** shrink `/v1/health` yet — the CLI still consumes `pending`/`mode`/`gaming` from it via `cli/util.ts`. Add a unit test for the new endpoint shape.
+2. **M2**: `statusFormat.ts` (pure) + `statusFormat.test.ts` (helpers + formatter snapshots). Mergeable standalone — no daemon or CLI changes ride on this.
+3. **M3**: Refactor `cli/status.ts` consuming M1 + M2. Update `cli/util.ts` (`HealthData` narrows; new `StatusData`; new `fetchStatus`). **Atomically with this CLI change**, shrink `/v1/health` to `{ ok, uptimeSec }` in `routes.ts` — the shrink and its consumer-side update must land in the same PR so no intermediate state breaks the CLI. Add flags. Watch loop. All 9 anti-regression integration tests.
+
+The three milestones are deliberately ordered so each is mergeable on its own without user-facing breakage — M1 only adds; M2 is pure utility; M3 contains the breaking shrink atomically with its consumer update.

--- a/docs/specs/sleep-mode.md
+++ b/docs/specs/sleep-mode.md
@@ -1,6 +1,6 @@
 # Sleep Mode
 
-> Status: implementing in `feat/sleep-mode`
+> Status: shipped (v0.2). Parallel sessions added later via Spec D — see `parallel-sleeps.md`. Sections below describing single-session behavior (Max one, GET returns object, 409 on second start) are superseded by that spec; the daemon now holds up to `policy.maxConcurrentSleeps` sessions (default 6) and 409 became 429 on capacity.
 
 ## Problem
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -65,11 +65,17 @@ program
 
 program
   .command('start')
-  .description('Start the daemon')
+  .description('Start the daemon (under watchdog supervision when --detach)')
   .option('-d, --detach', 'Run as detached background process', false)
-  .action(async (opts: { detach: boolean }) => {
+  .option(
+    '--no-watchdog',
+    'Skip the watchdog supervisor and spawn the daemon directly (debug/legacy)',
+    false,
+  )
+  .action(async (opts: { detach: boolean; watchdog: boolean }) => {
     try {
-      await startCommand(opts);
+      // Commander inverts `--no-watchdog` into `opts.watchdog: false`
+      await startCommand({ detach: opts.detach, noWatchdog: opts.watchdog === false });
     } catch (e) {
       console.error(`start failed: ${(e as Error).message}`);
       process.exit(1);

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -11,6 +11,12 @@ import { checkHealth, sleep } from './util.js';
 
 export interface StartOptions {
   detach?: boolean;
+  /**
+   * When true, skip the watchdog and spawn the daemon directly (legacy
+   * pre-Spec-G behavior). Useful for debugging — see the daemon's own
+   * stdout/stderr without the watchdog supervision layer in between.
+   */
+  noWatchdog?: boolean;
 }
 
 export async function startCommand(opts: StartOptions): Promise<void> {
@@ -20,7 +26,7 @@ export async function startCommand(opts: StartOptions): Promise<void> {
     return;
   }
   if (opts.detach) {
-    await startDetached();
+    await startDetached(opts);
     return;
   }
   await startForeground();
@@ -33,9 +39,11 @@ async function startForeground(): Promise<void> {
   await new Promise<void>(() => {});
 }
 
-async function startDetached(): Promise<void> {
+async function startDetached(opts: StartOptions): Promise<void> {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  const daemonEntry = path.join(here, '..', 'daemon', 'index.js');
+  const entry = opts.noWatchdog
+    ? path.join(here, '..', 'daemon', 'index.js')
+    : path.join(here, '..', 'watchdog', 'index.js');
 
   // Truncate before each start so a stale crash log from an earlier run
   // doesn't get surfaced as the cause of a new failure.
@@ -44,7 +52,7 @@ async function startDetached(): Promise<void> {
   const out = openSync(STARTUP_LOG_FILE, 'a');
   const err = openSync(STARTUP_LOG_FILE, 'a');
 
-  const child = spawn(process.execPath, [daemonEntry], {
+  const child = spawn(process.execPath, [entry], {
     detached: true,
     stdio: ['ignore', out, err],
     windowsHide: true,
@@ -60,7 +68,8 @@ async function startDetached(): Promise<void> {
   while (Date.now() < deadline) {
     const r = await checkHealth();
     if (r.ok) {
-      console.log(chalk.green(`daemon iniciado (PID=${child.pid})`));
+      const label = opts.noWatchdog ? 'daemon' : 'watchdog';
+      console.log(chalk.green(`daemon iniciado (${label} PID=${child.pid})`));
       return;
     }
     if (exitInfo !== null) {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -3,17 +3,41 @@ import path from 'node:path';
 import os from 'node:os';
 import chalk from 'chalk';
 import { readPid, isProcessAlive, checkHealth } from './util.js';
-import { CONFIG_FILE } from '../config/paths.js';
+import { CONFIG_FILE, WATCHDOG_PID_FILE } from '../config/paths.js';
 import { loadMode } from '../daemon/state.js';
 
 export async function statusCommand(): Promise<void> {
   console.log(chalk.bold('kuroboto status'));
   console.log(`  config: ${CONFIG_FILE}`);
 
+  const watchdogPid = await readWatchdogPidFile();
+  const watchdogAlive = watchdogPid !== null && isProcessAlive(watchdogPid);
+  const watchdogLabel =
+    watchdogPid === null
+      ? chalk.dim('(none)')
+      : watchdogAlive
+        ? chalk.green(`alive (PID=${watchdogPid})`)
+        : chalk.red(`dead (stale PID=${watchdogPid})`);
+  console.log(`  watchdog: ${watchdogLabel}`);
+
   const pid = await readPid();
   const alive = pid !== null && isProcessAlive(pid);
-  const pidLabel = pid === null ? '(none)' : alive ? chalk.green(`alive (PID=${pid})`) : chalk.red(`dead (stale PID=${pid})`);
+  const pidLabel =
+    pid === null
+      ? chalk.dim('(none)')
+      : alive
+        ? chalk.green(`alive (PID=${pid})`)
+        : chalk.red(`dead (stale PID=${pid})`);
   console.log(`  daemon: ${pidLabel}`);
+
+  // Split-brain: watchdog dead but daemon alive — happens if the watchdog
+  // was killed by hand. The daemon will keep running but no one is
+  // supervising it, so the next crash falls back to the original Bug C.
+  if (watchdogPid !== null && !watchdogAlive && alive) {
+    console.log(
+      `  ${chalk.yellow('!! split-brain: watchdog gone but daemon still up — kuroboto stop && kuroboto start --detach to recover')}`,
+    );
+  }
 
   const health = await checkHealth();
   if (health.ok) {
@@ -33,6 +57,16 @@ export async function statusCommand(): Promise<void> {
     console.log(`  hooks: ${chalk.yellow('not installed — run `kuroboto init`')}`);
   } else {
     console.log(`  hooks: ${chalk.green(installed.join(', '))}`);
+  }
+}
+
+async function readWatchdogPidFile(): Promise<number | null> {
+  try {
+    const raw = await fsp.readFile(WATCHDOG_PID_FILE, 'utf-8');
+    const pid = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -1,7 +1,26 @@
+import fsp from 'node:fs/promises';
 import chalk from 'chalk';
+import { WATCHDOG_PID_FILE } from '../config/paths.js';
 import { readPid, isProcessAlive, sleep } from './util.js';
 
 export async function stopCommand(): Promise<void> {
+  const watchdogPid = await readWatchdogPid();
+  if (watchdogPid !== null && isProcessAlive(watchdogPid)) {
+    process.kill(watchdogPid, 'SIGTERM');
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      if (!isProcessAlive(watchdogPid)) {
+        console.log(chalk.green('watchdog + daemon parados'));
+        return;
+      }
+      await sleep(200);
+    }
+    console.error(chalk.red('watchdog não parou em 10s'));
+    process.exitCode = 1;
+    return;
+  }
+
+  // Legacy / --no-watchdog path: kill the daemon directly.
   const pid = await readPid();
   if (!pid || !isProcessAlive(pid)) {
     console.log(chalk.yellow('nenhum daemon rodando'));
@@ -18,4 +37,14 @@ export async function stopCommand(): Promise<void> {
   }
   console.error(chalk.red('daemon não parou em 10s'));
   process.exitCode = 1;
+}
+
+async function readWatchdogPid(): Promise<number | null> {
+  try {
+    const raw = await fsp.readFile(WATCHDOG_PID_FILE, 'utf-8');
+    const pid = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -10,3 +10,5 @@ export const AUDIT_FILE = path.join(CONFIG_DIR, 'audit.jsonl');
 export const TOPICS_FILE = path.join(CONFIG_DIR, 'topics.json');
 export const STARTUP_LOG_FILE = path.join(CONFIG_DIR, 'daemon.startup.log');
 export const CRASH_LOG_FILE = path.join(CONFIG_DIR, 'daemon.crash.log');
+export const WATCHDOG_PID_FILE = path.join(CONFIG_DIR, 'watchdog.pid');
+export const WATCHDOG_LOG_FILE = path.join(CONFIG_DIR, 'watchdog.log');

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,5 +1,6 @@
 import fsp from 'node:fs/promises';
 import os from 'node:os';
+import path from 'node:path';
 import { type Server } from 'node:http';
 import { spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
 import type { Channel } from '../channels/Channel.js';
@@ -26,6 +27,7 @@ import { validateTmuxAvailable } from '../inject/validate.js';
 import { InjectClients } from './injectClients.js';
 import { appendAudit } from './audit.js';
 import { topicContextSystem } from './topicContext.js';
+import { scanOrphanWorktrees } from './orphanWorktrees.js';
 
 export interface RunningDaemon {
   stop(): Promise<void>;
@@ -190,7 +192,84 @@ export async function startDaemon(initialConfig: ConfigT): Promise<RunningDaemon
     // best-effort
   }
 
+  // Spec G v1: surface sleep worktrees that look orphaned after a watchdog
+  // respawn or hard restart. Best-effort — failures don't block startup.
+  void announceOrphanedWorktrees(config, channel, logger);
+
   return { stop };
+}
+
+async function announceOrphanedWorktrees(
+  config: ConfigT,
+  channel: Channel,
+  logger: Logger,
+): Promise<void> {
+  try {
+    const workRoot = expandHome(config.policy.sleepWorktreeDir);
+    const orphans = await scanOrphanWorktrees({
+      workRoot,
+      log: (msg, fields) => logger.info(msg, fields),
+      listOpenSleepBranches: () => listOpenSleepBranchesViaGh(logger),
+    });
+    if (orphans.length === 0) return;
+    for (const o of orphans) {
+      await channel
+        .sendNotification(
+          `⚠️ sleep ${o.slug} ficou órfão durante restart; investigar manualmente`,
+          topicContextSystem(),
+        )
+        .catch(() => {
+          // best-effort
+        });
+    }
+  } catch (e) {
+    logger.warn('orphan worktree scan failed', { err: (e as Error).message });
+  }
+}
+
+function expandHome(dir: string): string {
+  if (dir.startsWith('~/') || dir === '~') {
+    return path.join(os.homedir(), dir.slice(1).replace(/^[\\/]/, ''));
+  }
+  return dir;
+}
+
+async function listOpenSleepBranchesViaGh(logger: Logger): Promise<Set<string>> {
+  return new Promise((resolve) => {
+    const child = nodeSpawn(
+      'gh',
+      ['pr', 'list', '--state', 'open', '--json', 'headRefName', '--limit', '100'],
+      { shell: false, windowsHide: true },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (b) => (stdout += b.toString()));
+    child.stderr?.on('data', (b) => (stderr += b.toString()));
+    child.on('error', (e) => {
+      logger.warn('gh pr list spawn error', { err: e.message });
+      resolve(new Set());
+    });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        logger.warn('gh pr list non-zero', { code, stderr: stderr.trim().slice(0, 200) });
+        resolve(new Set());
+        return;
+      }
+      try {
+        const prs = JSON.parse(stdout) as Array<{ headRefName: string }>;
+        const slugs = new Set<string>();
+        for (const pr of prs) {
+          if (pr.headRefName?.startsWith('sleep/')) {
+            slugs.add(pr.headRefName.slice('sleep/'.length));
+          }
+        }
+        resolve(slugs);
+      } catch (e) {
+        logger.warn('gh pr list parse failed', { err: (e as Error).message });
+        resolve(new Set());
+      }
+    });
+  });
 }
 
 async function ensureNoExistingDaemon(): Promise<void> {

--- a/src/daemon/orphanWorktrees.ts
+++ b/src/daemon/orphanWorktrees.ts
@@ -1,0 +1,84 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Scope-limited v1 of sleep recovery (Spec G). When the daemon restarts —
+ * whether from a clean stop or after the watchdog respawns it — any sleep
+ * sessions that died alongside the previous daemon leave behind worktrees
+ * but no in-memory record. We can't safely re-attach (their stdout pipes
+ * are gone), but we can spot the leftovers and tell the user.
+ *
+ * A worktree is "orphaned" when:
+ *   - it lives under workRoot/
+ *   - its filesystem mtime is older than 5 minutes (no recent activity)
+ *   - its corresponding sleep/<slug> branch has no open PR
+ *
+ * The third condition is checked via `gh` so that branches a v2 implementation
+ * already submitted PRs for are not flagged. v1 is observational: we surface
+ * the slug and let the user reclaim manually with `kuroboto sleeping cancel`
+ * or `kuroboto sleeping cleanup`.
+ */
+
+export interface OrphanScanDeps {
+  workRoot: string;
+  /** Returns the set of branch names (without `sleep/` prefix) that have an open PR. */
+  listOpenSleepBranches: () => Promise<Set<string>>;
+  log?: (msg: string, fields?: Record<string, unknown>) => void;
+  /** "Now" injection for tests — defaults to Date.now(). */
+  now?: () => number;
+}
+
+export interface OrphanWorktree {
+  slug: string;
+  worktreePath: string;
+  /** Filesystem mtime ms — useful for diagnostics. */
+  mtimeMs: number;
+}
+
+const ORPHAN_INACTIVITY_MS = 5 * 60 * 1000;
+
+/**
+ * Scan workRoot for orphaned sleep worktrees. Returns the list of slugs
+ * that look orphaned. Errors during the scan are swallowed and logged —
+ * a partial scan is better than blocking daemon startup.
+ */
+export async function scanOrphanWorktrees(deps: OrphanScanDeps): Promise<OrphanWorktree[]> {
+  const log = deps.log ?? (() => {});
+  const now = deps.now ?? Date.now;
+
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(deps.workRoot);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      log('orphan scan: readdir failed', { err: (e as Error).message });
+    }
+    return [];
+  }
+
+  let openBranches: Set<string>;
+  try {
+    openBranches = await deps.listOpenSleepBranches();
+  } catch (e) {
+    log('orphan scan: failed to list open PRs (assuming none)', { err: (e as Error).message });
+    openBranches = new Set();
+  }
+
+  const cutoff = now() - ORPHAN_INACTIVITY_MS;
+  const out: OrphanWorktree[] = [];
+  for (const slug of entries) {
+    const dir = path.join(deps.workRoot, slug);
+    let stat;
+    try {
+      stat = await fsp.stat(dir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    if (stat.mtimeMs > cutoff) continue;
+    if (openBranches.has(slug)) continue;
+    out.push({ slug, worktreePath: dir, mtimeMs: stat.mtimeMs });
+  }
+  return out;
+}

--- a/src/watchdog/index.ts
+++ b/src/watchdog/index.ts
@@ -1,0 +1,516 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import {
+  spawn as nodeSpawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { loadConfig } from '../config/load.js';
+import {
+  PID_FILE,
+  WATCHDOG_PID_FILE,
+  WATCHDOG_LOG_FILE,
+  STARTUP_LOG_FILE,
+} from '../config/paths.js';
+import { appendAudit } from '../daemon/audit.js';
+import { nextBackoff, shouldRespawn } from './policy.js';
+import { sendWatchdogNotification } from './notify.js';
+
+/**
+ * The watchdog: a small supervisor process that spawns the daemon as its
+ * own child, listens for `child.on('exit')`, and respawns with exponential
+ * backoff. Bug C — daemon dies silently and stays dead — is solved here
+ * because parent-child `exit` fires for every cause of child death (JS
+ * crash, SIGKILL, OOM, segfault, lid close → child clean up). The watchdog
+ * deliberately stays small (~200 LOC, no Telegram polling, no HTTP server,
+ * no business logic) so its own failure surface is minimal.
+ */
+
+export interface RunWatchdogDeps {
+  /** Override daemon entry path — tests point this at a daemon-mock script. */
+  daemonEntry?: string;
+  /** Override spawn — tests pass in a fake. */
+  spawn?: (cmd: string, args: string[], opts: SpawnOptions) => ChildProcess;
+  /** Override fetch — tests stub /health responses. */
+  fetchImpl?: typeof fetch;
+  /** Override clock — tests inject deterministic now/setTimeout. */
+  now?: () => number;
+  /** Override delay — tests skip real waits. */
+  sleep?: (ms: number) => Promise<void>;
+  /** When true, skip writing to WATCHDOG_LOG_FILE (used by tests). */
+  silent?: boolean;
+  /** Override config path discovery — tests pass a synthetic config. */
+  loadConfigImpl?: () => Promise<{
+    channel: { token: string; chatId: number; forumMode?: boolean };
+    daemon: { port: number };
+  }>;
+  /** Hook fired after each respawn — used by tests + future v2 sleep recovery. */
+  onDaemonRespawn?: (pid: number | undefined) => void;
+  /** Hook fired when the watchdog gives up, exits, or hits a terminal state. */
+  onTerminal?: (reason: 'startup-failure' | 'gave-up' | 'sigterm') => void;
+  /** Override paths — tests redirect PID/log writes to a temp dir. */
+  paths?: {
+    pidFile?: string;
+    daemonPidFile?: string;
+    logFile?: string;
+    startupLog?: string;
+  };
+  /** Override audit append — tests use a no-op or capture. */
+  auditImpl?: (entry: AuditEntry) => Promise<void>;
+  /** Override notification sender — tests capture instead of hitting Telegram. */
+  notifyImpl?: (text: string) => Promise<boolean>;
+  /** Override SIGTERM/SIGINT registration — tests use a controllable hook. */
+  signalRegistrar?: (handler: (sig: NodeJS.Signals) => void) => void;
+}
+
+interface AuditEntry {
+  source: string;
+  decision: 'allow' | 'deny';
+  reason: string;
+}
+
+const HEALTHY_STABILITY_MS = 30_000;
+const HEALTH_POLL_INTERVAL_MS = 250;
+const HEALTH_INITIAL_TIMEOUT_MS = 10_000;
+const STOP_GRACE_MS = 5_000;
+
+interface WatchdogRuntimeState {
+  attempt: number;
+  everHealthy: boolean;
+  respawnTimestamps: number[];
+  /**
+   * Set once a fresh daemon has been continuously healthy for
+   * HEALTHY_STABILITY_MS — then we reset attempt and respawnTimestamps so
+   * the full backoff budget is restored for any future crash.
+   */
+  stabilityTimer: NodeJS.Timeout | null;
+}
+
+export async function runWatchdog(deps: RunWatchdogDeps = {}): Promise<number> {
+  const pidFile = deps.paths?.pidFile ?? WATCHDOG_PID_FILE;
+  const daemonPidFile = deps.paths?.daemonPidFile ?? PID_FILE;
+  const logFile = deps.paths?.logFile ?? WATCHDOG_LOG_FILE;
+  const startupLog = deps.paths?.startupLog ?? STARTUP_LOG_FILE;
+
+  await fsp.mkdir(path.dirname(pidFile), { recursive: true });
+
+  const log = makeLogger(deps, logFile);
+  log('watchdog starting');
+
+  const config = await (deps.loadConfigImpl ?? loadConfig)();
+  const port = config.daemon.port;
+  const channel = config.channel;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? Date.now;
+  const spawnFn = deps.spawn ?? nodeSpawn;
+  const daemonEntry = deps.daemonEntry ?? defaultDaemonEntry();
+  const notifyImpl =
+    deps.notifyImpl ??
+    ((text: string) =>
+      sendWatchdogNotification({
+        token: channel.token,
+        chatId: channel.chatId,
+        forumMode: channel.forumMode === true,
+        text,
+        log: (m) => log(m),
+      }));
+  const auditImpl =
+    deps.auditImpl ??
+    (async (entry: AuditEntry) => {
+      await appendAudit({
+        ts: new Date().toISOString(),
+        requestId: `watchdog:${new Date().toISOString()}`,
+        tool: 'watchdog',
+        cwd: null,
+        decision: entry.decision,
+        reason: entry.reason,
+        source: entry.source,
+        remember: false,
+      });
+    });
+
+  await fsp.writeFile(pidFile, String(process.pid));
+  log(`watchdog pid file written pid=${process.pid}`);
+
+  const state: WatchdogRuntimeState = {
+    attempt: 0,
+    everHealthy: false,
+    respawnTimestamps: [],
+    stabilityTimer: null,
+  };
+
+  let child: ChildProcess | null = null;
+  let stopping = false;
+
+  const cleanupPidFiles = async (): Promise<void> => {
+    await unlinkBest(pidFile);
+    await unlinkBest(daemonPidFile);
+  };
+
+  const appendAuditSafe = async (entry: AuditEntry): Promise<void> => {
+    try {
+      await auditImpl(entry);
+    } catch (e) {
+      log(`audit append failed: ${(e as Error).message}`);
+    }
+  };
+
+  const sendNotifSafe = async (text: string): Promise<void> => {
+    try {
+      await notifyImpl(text);
+    } catch (e) {
+      log(`notif failed: ${(e as Error).message}`);
+    }
+  };
+
+  const onTerminalNonRespawn = async (
+    reason: 'startup-failure' | 'gave-up',
+    info: ExitInfo,
+  ): Promise<void> => {
+    await appendAuditSafe({
+      source: reason === 'startup-failure' ? 'watchdog-startup-failure' : 'watchdog-gave-up',
+      decision: 'deny',
+      reason: reason === 'startup-failure' ? describeExit(info) : '5 retries in 60s',
+    });
+    if (reason === 'startup-failure') {
+      await sendNotifSafe(
+        `❌ daemon não respondeu em 10s — investigar config (${describeExit(info)})`,
+      );
+    } else {
+      await sendNotifSafe(
+        `❌ watchdog deu up — 5 falhas em 60s. Última: ${describeExit(info)}. Rode kuroboto ohayo quando puder.`,
+      );
+    }
+  };
+
+  const emitRespawnNotif = async (attemptNumber: number, info: ExitInfo): Promise<void> => {
+    await sendNotifSafe(`🔄 daemon respawnado (#${attemptNumber}) — ${describeExit(info)}`);
+  };
+
+  const handleStopSignal = async (sig: NodeJS.Signals): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    log(`watchdog received ${sig} — stopping daemon`);
+    deps.onTerminal?.('sigterm');
+    if (state.stabilityTimer) clearTimeout(state.stabilityTimer);
+    if (child && child.exitCode === null && !child.killed) {
+      try {
+        child.kill('SIGTERM');
+      } catch (e) {
+        log(`SIGTERM failed: ${(e as Error).message}`);
+      }
+      const killed = await waitForExit(child, STOP_GRACE_MS, sleep, now);
+      if (!killed) {
+        log('daemon did not exit on SIGTERM — escalating to SIGKILL');
+        try {
+          child.kill('SIGKILL');
+        } catch (e) {
+          log(`SIGKILL failed: ${(e as Error).message}`);
+        }
+      }
+    }
+    await cleanupPidFiles();
+    log('watchdog stopped cleanly');
+  };
+
+  const registerSignal = deps.signalRegistrar
+    ?? ((handler) => {
+      process.on('SIGTERM', () => handler('SIGTERM'));
+      process.on('SIGINT', () => handler('SIGINT'));
+    });
+  registerSignal((sig) => {
+    void handleStopSignal(sig).then(() => {
+      if (!deps.signalRegistrar) process.exit(0);
+    });
+  });
+
+  // -- main supervision loop --
+  while (!stopping) {
+    log(`spawning daemon (attempt #${state.attempt + 1})`);
+    let spawnedAt = now();
+    try {
+      child = spawnFn(process.execPath, [daemonEntry], {
+        // stdio shares the startup log so the parent CLI can tail any
+        // startup error (PR #23 path stays intact). We don't `detached: true`
+        // here — the daemon must be a child of the watchdog so `exit` fires.
+        stdio: ['ignore', openSafe(startupLog), openSafe(startupLog)],
+        windowsHide: true,
+      });
+    } catch (e) {
+      const detail = `spawn threw: ${(e as Error).message}`;
+      log(detail);
+      await appendAuditSafe({
+        source: 'watchdog-startup-failure',
+        decision: 'deny',
+        reason: detail,
+      });
+      await sendNotifSafe(`❌ watchdog não conseguiu iniciar daemon: ${detail}`);
+      deps.onTerminal?.('startup-failure');
+      await cleanupPidFiles();
+      return 1;
+    }
+
+    const exitPromise = waitForChildExit(child);
+    const healthy = await waitForHealthy({
+      port,
+      timeoutMs: HEALTH_INITIAL_TIMEOUT_MS,
+      pollIntervalMs: HEALTH_POLL_INTERVAL_MS,
+      fetchImpl,
+      sleep,
+      now,
+      exitPromise,
+    });
+
+    if (healthy === 'exited-before-healthy') {
+      const info = await exitPromise;
+      log(`daemon exited before healthy: code=${info.code} signal=${info.signal}`);
+      const decision = shouldRespawn({
+        everHealthy: state.everHealthy,
+        respawnTimestamps: state.respawnTimestamps.filter((ts) => now() - ts < 60_000),
+        now: now(),
+      });
+      if (!decision.respawn) {
+        await onTerminalNonRespawn(decision.reason, info);
+        deps.onTerminal?.(decision.reason);
+        await cleanupPidFiles();
+        return 1;
+      }
+      // /health never 200'd this cycle but we previously knew the daemon
+      // was healthy once — runtime crash. Record + backoff.
+      state.respawnTimestamps.push(now());
+      const wait = nextBackoff(state.attempt);
+      state.attempt += 1;
+      await appendAuditSafe({
+        source: 'watchdog-respawn',
+        decision: 'allow',
+        reason: describeExit(info),
+      });
+      await emitRespawnNotif(state.respawnTimestamps.length, info);
+      deps.onDaemonRespawn?.(child.pid);
+      log(`backoff ${wait}ms before respawn`);
+      await sleep(wait);
+      continue;
+    }
+
+    if (healthy === 'timeout') {
+      log('daemon /health did not return 200 within 10s');
+      // Kill the unhealthy child so it doesn't linger.
+      if (child.exitCode === null) {
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          // best-effort
+        }
+        const stopped = await waitForExit(child, STOP_GRACE_MS, sleep, now);
+        if (!stopped) {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            // best-effort
+          }
+        }
+      }
+      const info = await exitPromise.catch(() => ({ code: null, signal: null }));
+      // If `everHealthy` is true (rare: a prior cycle was healthy and this
+      // respawn just hung), treat as a runtime failure. Otherwise it's a
+      // genuine startup failure — bad config, port-in-use, etc.
+      const decision = shouldRespawn({
+        everHealthy: state.everHealthy,
+        respawnTimestamps: state.respawnTimestamps.filter((ts) => now() - ts < 60_000),
+        now: now(),
+      });
+      if (!decision.respawn) {
+        await onTerminalNonRespawn(decision.reason, info);
+        deps.onTerminal?.(decision.reason);
+        await cleanupPidFiles();
+        return 1;
+      }
+      state.respawnTimestamps.push(now());
+      const wait = nextBackoff(state.attempt);
+      state.attempt += 1;
+      await appendAuditSafe({
+        source: 'watchdog-respawn',
+        decision: 'allow',
+        reason: 'health-timeout',
+      });
+      await emitRespawnNotif(state.respawnTimestamps.length, info);
+      await sleep(wait);
+      continue;
+    }
+
+    // healthy === 'ok' — daemon is running. Mark and arm stability timer.
+    state.everHealthy = true;
+    log(`daemon healthy after ${now() - spawnedAt}ms (pid=${child.pid})`);
+    if (state.stabilityTimer) clearTimeout(state.stabilityTimer);
+    state.stabilityTimer = setTimeout(() => {
+      log('daemon stable ≥30s — resetting respawn counter');
+      state.attempt = 0;
+      state.respawnTimestamps = [];
+      state.stabilityTimer = null;
+    }, HEALTHY_STABILITY_MS);
+
+    // Wait for the running daemon to exit (could be never, in which case
+    // this resolves only when SIGTERM cascades through handleStopSignal).
+    const info = await exitPromise;
+    if (state.stabilityTimer) {
+      clearTimeout(state.stabilityTimer);
+      state.stabilityTimer = null;
+    }
+    if (stopping) break; // SIGTERM was the cause — exit cleanly.
+
+    log(`daemon exited unexpectedly: code=${info.code} signal=${info.signal}`);
+    const decision = shouldRespawn({
+      everHealthy: state.everHealthy,
+      respawnTimestamps: state.respawnTimestamps.filter((ts) => now() - ts < 60_000),
+      now: now(),
+    });
+    if (!decision.respawn) {
+      await onTerminalNonRespawn(decision.reason, info);
+      deps.onTerminal?.(decision.reason);
+      await cleanupPidFiles();
+      return 1;
+    }
+    state.respawnTimestamps.push(now());
+    const wait = nextBackoff(state.attempt);
+    state.attempt += 1;
+    await appendAuditSafe({
+      source: 'watchdog-respawn',
+      decision: 'allow',
+      reason: describeExit(info),
+    });
+    await emitRespawnNotif(state.respawnTimestamps.length, info);
+    deps.onDaemonRespawn?.(child.pid);
+    log(`backoff ${wait}ms before respawn`);
+    await sleep(wait);
+  }
+
+  await cleanupPidFiles();
+  return 0;
+}
+
+// ----- helpers -----
+
+interface ExitInfo {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+function waitForChildExit(child: ChildProcess): Promise<ExitInfo> {
+  return new Promise((resolve) => {
+    child.once('exit', (code, signal) => resolve({ code, signal }));
+  });
+}
+
+interface WaitForHealthyOpts {
+  port: number;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  fetchImpl: typeof fetch;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  exitPromise: Promise<ExitInfo>;
+}
+
+type HealthyResult = 'ok' | 'timeout' | 'exited-before-healthy';
+
+async function waitForHealthy(opts: WaitForHealthyOpts): Promise<HealthyResult> {
+  const deadline = opts.now() + opts.timeoutMs;
+  let exited = false;
+  void opts.exitPromise.then(() => {
+    exited = true;
+  });
+  while (opts.now() < deadline) {
+    if (exited) return 'exited-before-healthy';
+    const ok = await pingHealth(opts.port, opts.fetchImpl);
+    if (ok) return 'ok';
+    await opts.sleep(opts.pollIntervalMs);
+  }
+  return 'timeout';
+}
+
+async function pingHealth(port: number, fetchImpl: typeof fetch): Promise<boolean> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 1_000);
+  try {
+    const res = await fetchImpl(`http://127.0.0.1:${port}/v1/health`, { signal: ctrl.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function waitForExit(
+  child: ChildProcess,
+  graceMs: number,
+  sleep: (ms: number) => Promise<void>,
+  now: () => number,
+): Promise<boolean> {
+  const deadline = now() + graceMs;
+  while (now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) return true;
+    await sleep(50);
+  }
+  return false;
+}
+
+function describeExit(info: ExitInfo): string {
+  if (info.signal) return `signal ${info.signal}`;
+  if (info.code !== null) return `exit code ${info.code}`;
+  return 'unknown exit';
+}
+
+function defaultDaemonEntry(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, '..', 'daemon', 'index.js');
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeLogger(deps: RunWatchdogDeps, logFile: string): (msg: string) => void {
+  if (deps.silent) return () => {};
+  return (msg: string) => {
+    const line = `${new Date().toISOString()} ${msg}\n`;
+    try {
+      fs.appendFileSync(logFile, line);
+    } catch {
+      // best-effort — surface to stderr too so detached startup capture sees it
+    }
+    process.stderr.write(`[watchdog] ${msg}\n`);
+  };
+}
+
+function openSafe(file: string): number {
+  try {
+    return fs.openSync(file, 'a');
+  } catch {
+    // If the startup log can't be opened (e.g. tests with no fs), fall back
+    // to /dev/null-equivalent so spawn doesn't throw.
+    return fs.openSync(process.platform === 'win32' ? 'nul' : '/dev/null', 'a');
+  }
+}
+
+async function unlinkBest(file: string): Promise<void> {
+  try {
+    await fsp.unlink(file);
+  } catch {
+    // best-effort
+  }
+}
+
+const invokedAsMain =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsMain) {
+  runWatchdog()
+    .then((code) => process.exit(code))
+    .catch((e) => {
+      process.stderr.write(`[watchdog] fatal: ${(e as Error).message}\n`);
+      process.exit(1);
+    });
+}

--- a/src/watchdog/notify.ts
+++ b/src/watchdog/notify.ts
@@ -1,0 +1,104 @@
+import fsp from 'node:fs/promises';
+import { TOPICS_FILE } from '../config/paths.js';
+
+/**
+ * Minimal Telegram sender for the watchdog. Cannot reuse TelegramChannel
+ * because the daemon may be dead and the watchdog must remain independent.
+ * Best-effort: failures are reported via the optional log callback and
+ * never thrown — the watchdog's state machine must keep running even if
+ * Telegram is unreachable.
+ */
+export interface WatchdogNotifyOpts {
+  token: string;
+  chatId: number;
+  forumMode: boolean;
+  /** Telegram message body. */
+  text: string;
+  /** Per-call HTTP timeout. */
+  timeoutMs?: number;
+  /** Optional logger so callers can persist failures to watchdog.log. */
+  log?: (msg: string) => void;
+  /**
+   * Override the on-disk topics file lookup — used in tests. Production
+   * passes nothing so the standard TOPICS_FILE path is used.
+   */
+  topicsFile?: string;
+  /** Override fetch for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Send a one-shot Telegram notification from the watchdog. Routes to the
+ * `kuroboto-system` topic when forumMode is on AND the topic was already
+ * created (cached in topics.json); falls back to the main chat otherwise.
+ *
+ * Returns true on apparent success, false on any failure (network, HTTP,
+ * Telegram API rejection). Never throws.
+ */
+export async function sendWatchdogNotification(opts: WatchdogNotifyOpts): Promise<boolean> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+
+  let threadId: number | undefined;
+  if (opts.forumMode) {
+    threadId = await readSystemThreadId(opts.topicsFile ?? TOPICS_FILE, opts.log);
+  }
+
+  try {
+    const body: Record<string, unknown> = { chat_id: opts.chatId, text: opts.text };
+    if (threadId !== undefined) body.message_thread_id = threadId;
+
+    const url = `https://api.telegram.org/bot${opts.token}/sendMessage`;
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      opts.log?.(`telegram sendMessage HTTP ${res.status}`);
+      return false;
+    }
+    const json = (await res.json().catch(() => null)) as
+      | { ok: boolean; description?: string }
+      | null;
+    if (!json?.ok) {
+      opts.log?.(`telegram sendMessage rejected: ${json?.description ?? 'unknown'}`);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    opts.log?.(`telegram sendMessage failed: ${(e as Error).message}`);
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Read the cached `kuroboto-system` thread id from topics.json. Returns
+ * undefined when the file doesn't exist, is malformed, or doesn't contain
+ * a system topic entry — caller falls back to the main chat in those cases.
+ */
+async function readSystemThreadId(file: string, log?: (m: string) => void): Promise<number | undefined> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(file, 'utf-8');
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') log?.(`topics.json read failed: ${(e as Error).message}`);
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    log?.(`topics.json malformed: ${(e as Error).message}`);
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  const v = (parsed as Record<string, unknown>)['kuroboto-system'];
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}

--- a/src/watchdog/policy.ts
+++ b/src/watchdog/policy.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure functions for the watchdog state machine. Kept here so they can be
+ * unit-tested without spawning real processes or mocking fs/network.
+ */
+
+const BACKOFF_LADDER_MS = [1000, 2000, 4000, 8000, 16000, 30000];
+const MAX_BACKOFF_MS = 30000;
+
+/**
+ * Backoff delay before respawning after the Nth failed attempt (0-indexed).
+ * Caps at 30s so a long-running broken state still retries occasionally.
+ */
+export function nextBackoff(attempt: number): number {
+  if (attempt < 0) return BACKOFF_LADDER_MS[0];
+  if (attempt >= BACKOFF_LADDER_MS.length) return MAX_BACKOFF_MS;
+  return BACKOFF_LADDER_MS[attempt];
+}
+
+export interface RespawnState {
+  /** True once /v1/health has returned 200 at least once for the current daemon process. */
+  everHealthy: boolean;
+  /** Timestamps (ms epoch) of every respawn within the rolling window. */
+  respawnTimestamps: number[];
+  /** "now" injected for testability. Defaults to Date.now() when absent. */
+  now?: number;
+}
+
+export type RespawnDecision =
+  | { respawn: true; reason: 'runtime-crash' }
+  | { respawn: false; reason: 'startup-failure' | 'gave-up' };
+
+const RESPAWN_WINDOW_MS = 60_000;
+const MAX_RESPAWNS_IN_WINDOW = 5;
+
+/**
+ * Decide whether to respawn after the daemon child exited.
+ *
+ * - If `everHealthy` is false, the daemon never reached /health 200 → treat
+ *   as a startup failure (bad config, port-in-use). Do not loop.
+ * - If 5+ respawns happened in the last 60s, give up — something is broken
+ *   that won't self-resolve.
+ * - Otherwise → respawn.
+ */
+export function shouldRespawn(state: RespawnState): RespawnDecision {
+  if (!state.everHealthy) {
+    return { respawn: false, reason: 'startup-failure' };
+  }
+  const now = state.now ?? Date.now();
+  const recent = state.respawnTimestamps.filter((ts) => now - ts < RESPAWN_WINDOW_MS);
+  if (recent.length >= MAX_RESPAWNS_IN_WINDOW) {
+    return { respawn: false, reason: 'gave-up' };
+  }
+  return { respawn: true, reason: 'runtime-crash' };
+}
+
+export const RESPAWN_LIMITS = {
+  windowMs: RESPAWN_WINDOW_MS,
+  maxInWindow: MAX_RESPAWNS_IN_WINDOW,
+} as const;

--- a/test/integration/watchdogBugC.test.ts
+++ b/test/integration/watchdogBugC.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration test for the watchdog process running against a real Node child
+ * process — the closest practical anti-regression for Bug C from the
+ * 2026-04-29 sessions, where the daemon would die silently and stay dead until
+ * the user noticed and ran `kuroboto ohayo`.
+ *
+ * The "daemon mock" is a tiny inline Node script that opens an HTTP server on
+ * the configured port and answers `/v1/health`. We then SIGKILL it and assert
+ * the watchdog's `child.on('exit')` listener fires and respawns it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { runWatchdog } from '../../src/watchdog/index.js';
+
+let tmpDir: string;
+let chosenPort: number;
+
+async function pickPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (typeof addr === 'object' && addr) {
+        const port = addr.port;
+        server.close(() => resolve(port));
+      } else {
+        reject(new Error('no addr'));
+      }
+    });
+    server.on('error', reject);
+  });
+}
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wd-bugc-'));
+  chosenPort = await pickPort();
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+function tmpPaths() {
+  return {
+    pidFile: path.join(tmpDir, 'watchdog.pid'),
+    daemonPidFile: path.join(tmpDir, 'daemon.pid'),
+    logFile: path.join(tmpDir, 'watchdog.log'),
+    startupLog: path.join(tmpDir, 'startup.log'),
+  };
+}
+
+const baseConfig = () => ({
+  channel: { token: 'x', chatId: 1, forumMode: false },
+  daemon: { port: chosenPort },
+});
+
+/** Body of the daemon-mock script, written to a tmp .mjs file per-test. */
+function mockDaemonScript(opts: { port: number; exitAfterMs?: number; exitCode?: number }): string {
+  return `
+import http from 'node:http';
+const server = http.createServer((req, res) => {
+  if (req.url === '/v1/health') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, uptimeSec: 1, pending: 0 }));
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
+server.listen(${opts.port}, '127.0.0.1');
+${opts.exitAfterMs !== undefined ? `setTimeout(() => process.exit(${opts.exitCode ?? 1}), ${opts.exitAfterMs});` : ''}
+`;
+}
+
+describe('watchdog ↔ real daemon child (Bug C anti-regression)', () => {
+  it('respawns after the daemon child exits — the bug-C path', async () => {
+    // Daemon-mock: serves /health, then exits with code 1 after 800ms,
+    // simulating an unhealthy process death (our real signal-driven kill
+    // behaves identically from the watchdog's POV).
+    const scriptPath = path.join(tmpDir, 'daemon-mock.mjs');
+    await fsp.writeFile(scriptPath, mockDaemonScript({ port: chosenPort, exitAfterMs: 800, exitCode: 1 }));
+
+    const respawnPids: Array<number | undefined> = [];
+    let terminalReason: string | null = null;
+
+    // Run the watchdog with a deadline — if it doesn't terminate on its own
+    // we trigger SIGTERM after the second respawn or after 8 seconds.
+    const completed = runWatchdog({
+      paths: tmpPaths(),
+      daemonEntry: scriptPath,
+      loadConfigImpl: async () => baseConfig(),
+      silent: true,
+      auditImpl: async () => {},
+      notifyImpl: async () => true,
+      onDaemonRespawn: (pid) => {
+        respawnPids.push(pid);
+      },
+      onTerminal: (r) => {
+        terminalReason = r;
+      },
+      // Inject a no-op signalRegistrar so we can trigger SIGTERM ourselves.
+      signalRegistrar: (h) => {
+        signalHandler = h;
+      },
+    });
+
+    let signalHandler: ((sig: NodeJS.Signals) => void) | null = null;
+
+    // Wait for at least one respawn or 8s — whichever comes first.
+    const deadline = Date.now() + 8_000;
+    while (Date.now() < deadline && respawnPids.length < 1) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    // Trigger SIGTERM to break the loop cleanly.
+    signalHandler?.('SIGTERM');
+    await completed;
+
+    expect(respawnPids.length).toBeGreaterThanOrEqual(1);
+    expect(terminalReason).toBe('sigterm');
+  }, 15_000);
+
+  it('does NOT respawn when the daemon never reaches healthy (avoids infinite loop on bad config)', async () => {
+    // Daemon-mock that exits immediately on startup.
+    const scriptPath = path.join(tmpDir, 'daemon-fails-fast.mjs');
+    await fsp.writeFile(scriptPath, `process.exit(1);`);
+
+    const respawnPids: Array<number | undefined> = [];
+    let terminalReason: string | null = null;
+
+    const exitCode = await runWatchdog({
+      paths: tmpPaths(),
+      daemonEntry: scriptPath,
+      loadConfigImpl: async () => baseConfig(),
+      silent: true,
+      auditImpl: async () => {},
+      notifyImpl: async () => true,
+      onDaemonRespawn: (pid) => {
+        respawnPids.push(pid);
+      },
+      onTerminal: (r) => {
+        terminalReason = r;
+      },
+      signalRegistrar: () => {
+        /* no-op — we don't need to send signals here */
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(terminalReason).toBe('startup-failure');
+    // No respawns — startup failure short-circuits.
+    expect(respawnPids.length).toBe(0);
+  }, 15_000);
+});

--- a/test/unit/cli/status.test.ts
+++ b/test/unit/cli/status.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { captureIO, stubFetch, jsonResponse, TEST_CONFIG } from '../../helpers/cliHarness.js';
+
+let tmpDir: string;
+
+vi.mock('../../../src/config/paths.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...real,
+    PID_FILE: '__OVERRIDDEN_BY_BEFOREEACH__',
+    WATCHDOG_PID_FILE: '__OVERRIDDEN_BY_BEFOREEACH__',
+  };
+});
+
+vi.mock('../../../src/config/load.js', () => ({
+  loadConfig: vi.fn(async () => TEST_CONFIG),
+}));
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-status-'));
+  const paths = await import('../../../src/config/paths.js');
+  // @ts-expect-error overriding for tests
+  paths.PID_FILE = path.join(tmpDir, 'daemon.pid');
+  // @ts-expect-error overriding for tests
+  paths.WATCHDOG_PID_FILE = path.join(tmpDir, 'watchdog.pid');
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+function spawnIdleNode(): { pid: number; close: () => void } {
+  const child = spawn(
+    process.execPath,
+    ['-e', "process.on('SIGTERM',()=>process.exit(0)); setInterval(()=>{},1000);"],
+    { stdio: 'ignore', windowsHide: true },
+  );
+  if (!child.pid) throw new Error('failed to spawn idle node');
+  return {
+    pid: child.pid,
+    close: () => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe('cli/status — watchdog awareness', () => {
+  it('shows both watchdog and daemon as alive when both PID files reference live procs', async () => {
+    stubFetch(() => jsonResponse({ ok: true, uptimeSec: 5, pending: 0 }));
+    const io = captureIO();
+    const watchdog = spawnIdleNode();
+    const daemon = spawnIdleNode();
+    try {
+      const paths = await import('../../../src/config/paths.js');
+      await fsp.writeFile(paths.WATCHDOG_PID_FILE, String(watchdog.pid));
+      await fsp.writeFile(paths.PID_FILE, String(daemon.pid));
+
+      const { statusCommand } = await import('../../../src/cli/status.js');
+      await statusCommand();
+
+      const out = io.out();
+      expect(out).toMatch(new RegExp(`watchdog: alive \\(PID=${watchdog.pid}\\)`));
+      expect(out).toMatch(new RegExp(`daemon: alive \\(PID=${daemon.pid}\\)`));
+      expect(out).not.toContain('split-brain');
+    } finally {
+      watchdog.close();
+      daemon.close();
+    }
+  });
+
+  it('flags split-brain when the watchdog PID is stale but the daemon is alive', async () => {
+    stubFetch(() => jsonResponse({ ok: true, uptimeSec: 5, pending: 0 }));
+    const io = captureIO();
+    const daemon = spawnIdleNode();
+    try {
+      const paths = await import('../../../src/config/paths.js');
+      // PID 1 on Unix / 0 on Windows is a problematic stand-in. Use a guaranteed-dead
+      // PID by spawning one and reaping it.
+      const dead = spawnIdleNode();
+      dead.close();
+      await new Promise((r) => setTimeout(r, 100));
+      await fsp.writeFile(paths.WATCHDOG_PID_FILE, String(dead.pid));
+      await fsp.writeFile(paths.PID_FILE, String(daemon.pid));
+
+      const { statusCommand } = await import('../../../src/cli/status.js');
+      await statusCommand();
+
+      const out = io.out();
+      expect(out).toContain('split-brain');
+    } finally {
+      daemon.close();
+    }
+  });
+
+  it('shows daemon-only when no watchdog PID file exists (legacy / --no-watchdog)', async () => {
+    stubFetch(() => jsonResponse({ ok: true, uptimeSec: 5, pending: 0 }));
+    const io = captureIO();
+    const daemon = spawnIdleNode();
+    try {
+      const paths = await import('../../../src/config/paths.js');
+      await fsp.writeFile(paths.PID_FILE, String(daemon.pid));
+
+      const { statusCommand } = await import('../../../src/cli/status.js');
+      await statusCommand();
+
+      const out = io.out();
+      expect(out).toContain('watchdog: (none)');
+      expect(out).toMatch(new RegExp(`daemon: alive \\(PID=${daemon.pid}\\)`));
+      expect(out).not.toContain('split-brain');
+    } finally {
+      daemon.close();
+    }
+  });
+});

--- a/test/unit/cli/stop.test.ts
+++ b/test/unit/cli/stop.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { captureIO } from '../../helpers/cliHarness.js';
+
+let tmpDir: string;
+
+vi.mock('../../../src/config/paths.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...real,
+    PID_FILE: '__OVERRIDDEN_BY_BEFOREEACH__',
+    WATCHDOG_PID_FILE: '__OVERRIDDEN_BY_BEFOREEACH__',
+  };
+});
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kuroboto-stop-'));
+  // Re-stub the constants per-test so each test gets a fresh tmp path.
+  const paths = await import('../../../src/config/paths.js');
+  // @ts-expect-error overriding for tests
+  paths.PID_FILE = path.join(tmpDir, 'daemon.pid');
+  // @ts-expect-error overriding for tests
+  paths.WATCHDOG_PID_FILE = path.join(tmpDir, 'watchdog.pid');
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Spawn a node process that lives until SIGTERM, returning its PID. */
+function spawnIdleNode(): { pid: number; close: () => void } {
+  const child = spawn(
+    process.execPath,
+    ['-e', "process.on('SIGTERM',()=>process.exit(0)); setInterval(()=>{},1000);"],
+    { stdio: 'ignore', windowsHide: true },
+  );
+  if (!child.pid) throw new Error('failed to spawn idle node');
+  return {
+    pid: child.pid,
+    close: () => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe('cli/stop — watchdog-aware routing', () => {
+  it('SIGTERMs the watchdog when its PID file is present (priority over daemon PID)', async () => {
+    const io = captureIO();
+    const watchdog = spawnIdleNode();
+    const daemon = spawnIdleNode();
+    try {
+      const paths = await import('../../../src/config/paths.js');
+      await fsp.writeFile(paths.WATCHDOG_PID_FILE, String(watchdog.pid));
+      await fsp.writeFile(paths.PID_FILE, String(daemon.pid));
+
+      const { stopCommand } = await import('../../../src/cli/stop.js');
+      await stopCommand();
+
+      // Watchdog should be killed; daemon was untouched (real watchdog would
+      // cascade-kill it, but this test substitutes a no-op idle process).
+      await waitForExit(watchdog.pid, 5_000);
+      expect(io.out()).toContain('watchdog + daemon parados');
+    } finally {
+      watchdog.close();
+      daemon.close();
+    }
+  });
+
+  it('falls back to the legacy direct-daemon kill when no watchdog PID file exists', async () => {
+    const io = captureIO();
+    const daemon = spawnIdleNode();
+    try {
+      const paths = await import('../../../src/config/paths.js');
+      await fsp.writeFile(paths.PID_FILE, String(daemon.pid));
+      // No watchdog PID file → take the legacy path.
+
+      const { stopCommand } = await import('../../../src/cli/stop.js');
+      await stopCommand();
+
+      await waitForExit(daemon.pid, 5_000);
+      expect(io.out()).toContain('daemon parado');
+    } finally {
+      daemon.close();
+    }
+  });
+
+  it('reports cleanly when neither PID file exists', async () => {
+    const io = captureIO();
+    const { stopCommand } = await import('../../../src/cli/stop.js');
+    await stopCommand();
+    expect(io.out()).toContain('nenhum daemon rodando');
+  });
+});
+
+async function waitForExit(pid: number, ms: number): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`pid ${pid} still alive after ${ms}ms`);
+}

--- a/test/unit/orphanWorktrees.test.ts
+++ b/test/unit/orphanWorktrees.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { scanOrphanWorktrees } from '../../src/daemon/orphanWorktrees.js';
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'orphan-test-'));
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function makeStaleDir(name: string): Promise<string> {
+  const dir = path.join(tmpRoot, name);
+  await fsp.mkdir(dir, { recursive: true });
+  // Force the mtime to 1 hour ago so the freshness filter doesn't keep it.
+  const past = new Date(Date.now() - 60 * 60 * 1000);
+  await fsp.utimes(dir, past, past);
+  return dir;
+}
+
+describe('scanOrphanWorktrees', () => {
+  it('returns empty when the workRoot does not exist', async () => {
+    const result = await scanOrphanWorktrees({
+      workRoot: path.join(tmpRoot, 'does-not-exist'),
+      listOpenSleepBranches: async () => new Set(),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('flags a stale directory whose branch has no open PR', async () => {
+    await makeStaleDir('feature-abc-123456');
+    const result = await scanOrphanWorktrees({
+      workRoot: tmpRoot,
+      listOpenSleepBranches: async () => new Set(),
+    });
+    expect(result.map((o) => o.slug)).toEqual(['feature-abc-123456']);
+  });
+
+  it('skips a directory that is fresh (mtime within last 5 min)', async () => {
+    const dir = path.join(tmpRoot, 'fresh-slug-aaaaaa');
+    await fsp.mkdir(dir, { recursive: true });
+    // mtime defaults to now — within 5min window
+    const result = await scanOrphanWorktrees({
+      workRoot: tmpRoot,
+      listOpenSleepBranches: async () => new Set(),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('skips a stale directory when its branch has an open PR (v2 implementation already handled it)', async () => {
+    await makeStaleDir('staged-feature-bbbbbb');
+    const result = await scanOrphanWorktrees({
+      workRoot: tmpRoot,
+      listOpenSleepBranches: async () => new Set(['staged-feature-bbbbbb']),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('survives gh failure — assumes no open branches and still flags stale ones', async () => {
+    await makeStaleDir('orphaned-cccccc');
+    const result = await scanOrphanWorktrees({
+      workRoot: tmpRoot,
+      listOpenSleepBranches: async () => {
+        throw new Error('gh missing');
+      },
+    });
+    expect(result.map((o) => o.slug)).toEqual(['orphaned-cccccc']);
+  });
+});

--- a/test/unit/watchdog/lifecycle.test.ts
+++ b/test/unit/watchdog/lifecycle.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { runWatchdog } from '../../../src/watchdog/index.js';
+
+/**
+ * A controllable fake ChildProcess. Tests can call `simulateExit(...)` to
+ * trigger the same `'exit'` event the watchdog reacts to.
+ */
+class FakeChild extends EventEmitter {
+  public exitCode: number | null = null;
+  public signalCode: NodeJS.Signals | null = null;
+  public killed = false;
+  public stdin = null;
+  public stdout = null;
+  public stderr = null;
+  public killCalls: Array<NodeJS.Signals | undefined> = [];
+  constructor(public pid: number) {
+    super();
+  }
+  kill(sig?: NodeJS.Signals): boolean {
+    this.killCalls.push(sig);
+    this.killed = true;
+    // Simulate immediate cooperative exit on SIGTERM unless test
+    // overrides via .ignoreSignals = true
+    if (sig === 'SIGTERM' && !this.ignoreSignals) {
+      queueMicrotask(() => this.simulateExit(0, sig));
+    }
+    return true;
+  }
+  ignoreSignals = false;
+  simulateExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit('exit', code, signal);
+  }
+}
+
+interface SpawnedRecord {
+  child: FakeChild;
+  args: string[];
+  opts: SpawnOptions;
+}
+
+interface HarnessOpts {
+  /** Stage 'ok' → /health returns 200; 'fail' → never 200. Tests can mutate per cycle. */
+  healthBehavior?: 'ok' | 'fail';
+}
+
+function makeHarness(opts: HarnessOpts = {}) {
+  const spawned: SpawnedRecord[] = [];
+  let healthBehavior = opts.healthBehavior ?? 'ok';
+  let nextPid = 10_000;
+
+  const fakeSpawn = (
+    _cmd: string,
+    args: string[],
+    spawnOpts: SpawnOptions,
+  ): ChildProcess => {
+    const child = new FakeChild(nextPid++);
+    spawned.push({ child, args, opts: spawnOpts });
+    return child as unknown as ChildProcess;
+  };
+
+  const fakeFetch: typeof fetch = async () => {
+    if (healthBehavior === 'ok') {
+      return new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    throw new Error('econnrefused');
+  };
+
+  const audits: Array<{ source: string; decision: string; reason: string }> = [];
+  const notifs: string[] = [];
+  const terminalEvents: string[] = [];
+  const respawnPids: Array<number | undefined> = [];
+  let signalHandler: ((sig: NodeJS.Signals) => void) | null = null;
+
+  const sleeps: number[] = [];
+  // Skip real waits but keep ordering — use queueMicrotask so async control
+  // flow still yields between operations.
+  const fakeSleep = (ms: number): Promise<void> => {
+    sleeps.push(ms);
+    return new Promise((r) => queueMicrotask(r));
+  };
+
+  const setHealth = (b: 'ok' | 'fail') => {
+    healthBehavior = b;
+  };
+
+  return {
+    spawned,
+    audits,
+    notifs,
+    terminalEvents,
+    respawnPids,
+    sleeps,
+    setHealth,
+    triggerSignal: (sig: NodeJS.Signals) => signalHandler?.(sig),
+    deps: {
+      spawn: fakeSpawn,
+      fetchImpl: fakeFetch,
+      sleep: fakeSleep,
+      silent: true,
+      auditImpl: async (e: { source: string; decision: 'allow' | 'deny'; reason: string }) => {
+        audits.push(e);
+      },
+      notifyImpl: async (text: string) => {
+        notifs.push(text);
+        return true;
+      },
+      onTerminal: (r: 'startup-failure' | 'gave-up' | 'sigterm') => {
+        terminalEvents.push(r);
+      },
+      onDaemonRespawn: (pid: number | undefined) => {
+        respawnPids.push(pid);
+      },
+      signalRegistrar: (handler: (sig: NodeJS.Signals) => void) => {
+        signalHandler = handler;
+      },
+    },
+  };
+}
+
+const baseConfig = {
+  channel: { token: 't', chatId: 1, forumMode: false },
+  daemon: { port: 47891 },
+};
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'watchdog-test-'));
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+function tmpPaths() {
+  return {
+    pidFile: path.join(tmpDir, 'watchdog.pid'),
+    daemonPidFile: path.join(tmpDir, 'daemon.pid'),
+    logFile: path.join(tmpDir, 'watchdog.log'),
+    startupLog: path.join(tmpDir, 'startup.log'),
+  };
+}
+
+describe('runWatchdog — startup failure (everHealthy === false)', () => {
+  it('does not respawn when /health never 200s on the first cycle — exits non-zero', async () => {
+    const h = makeHarness({ healthBehavior: 'fail' });
+
+    // Drive the timeout: as the watchdog polls /health, advance fake clock
+    // past the 10s deadline by overriding `now`. We don't use real time.
+    let t = 0;
+    const now = () => {
+      t += 600; // each tick advances 600ms — with 10s deadline this exits ~17 polls in
+      return t;
+    };
+
+    const exitCode = await runWatchdog({
+      ...h.deps,
+      now,
+      paths: tmpPaths(),
+      loadConfigImpl: async () => baseConfig,
+      daemonEntry: '/fake/daemon.js',
+    });
+
+    expect(exitCode).toBe(1);
+    expect(h.terminalEvents).toContain('startup-failure');
+    // Audit + notif paint the user-visible error path.
+    expect(h.audits.some((a) => a.source === 'watchdog-startup-failure')).toBe(true);
+    expect(h.notifs.some((n) => n.includes('investigar config'))).toBe(true);
+  });
+});
+
+describe('runWatchdog — runtime crash (Bug C path)', () => {
+  it('respawns the daemon after a runtime exit and restores health', async () => {
+    const h = makeHarness({ healthBehavior: 'ok' });
+    let t = 0;
+    const now = () => {
+      // advance just enough each call so health polls don't time out
+      t += 50;
+      return t;
+    };
+
+    // After the first daemon becomes healthy, kill it externally.
+    setTimeout(() => {
+      const first = h.spawned[0]?.child;
+      if (first) first.simulateExit(null, 'SIGKILL');
+    }, 30);
+    // After the second daemon comes up, signal SIGTERM to break the loop.
+    setTimeout(() => h.triggerSignal('SIGTERM'), 100);
+
+    await runWatchdog({
+      ...h.deps,
+      now,
+      paths: tmpPaths(),
+      loadConfigImpl: async () => baseConfig,
+      daemonEntry: '/fake/daemon.js',
+    });
+
+    expect(h.spawned.length).toBeGreaterThanOrEqual(2);
+    expect(h.audits.some((a) => a.source === 'watchdog-respawn')).toBe(true);
+    expect(h.notifs.some((n) => n.includes('respawnado'))).toBe(true);
+    // SIGTERM cascade kills the second daemon.
+    expect(h.terminalEvents).toContain('sigterm');
+  });
+});
+
+describe('runWatchdog — gave-up after rapid burst', () => {
+  it('stops respawning after 5 failures inside the 60s window', async () => {
+    const h = makeHarness({ healthBehavior: 'ok' });
+
+    // Make every spawned daemon "go healthy then crash 1ms later" by
+    // hooking into spawn to wire up a quick exit.
+    const realSpawn = h.deps.spawn;
+    const wrappedSpawn = (cmd: string, args: string[], opts: SpawnOptions): ChildProcess => {
+      const child = realSpawn(cmd, args, opts) as unknown as FakeChild;
+      // Crash shortly after becoming healthy. The harness's `now` advances
+      // synthetically; we trigger via setTimeout so the loop has a turn.
+      setTimeout(() => child.simulateExit(1, null), 5);
+      return child as unknown as ChildProcess;
+    };
+
+    let t = 0;
+    const now = () => {
+      // Advance time slowly so all 5 respawns fall inside the 60s window.
+      t += 100;
+      return t;
+    };
+
+    const exitCode = await runWatchdog({
+      ...h.deps,
+      spawn: wrappedSpawn,
+      now,
+      paths: tmpPaths(),
+      loadConfigImpl: async () => baseConfig,
+      daemonEntry: '/fake/daemon.js',
+    });
+
+    expect(exitCode).toBe(1);
+    expect(h.terminalEvents).toContain('gave-up');
+    expect(h.audits.some((a) => a.source === 'watchdog-gave-up')).toBe(true);
+    expect(h.notifs.some((n) => n.includes('watchdog deu up'))).toBe(true);
+  });
+});
+
+describe('runWatchdog — clean SIGTERM shutdown', () => {
+  it('kills the daemon child on SIGTERM and removes both PID files', async () => {
+    const h = makeHarness({ healthBehavior: 'ok' });
+    let t = 0;
+    const now = () => {
+      t += 50;
+      return t;
+    };
+
+    // Trigger SIGTERM after the first daemon becomes healthy.
+    setTimeout(() => h.triggerSignal('SIGTERM'), 50);
+
+    const paths = tmpPaths();
+    // Pre-create the daemon PID file so cleanup has something to unlink.
+    await fsp.writeFile(paths.daemonPidFile, '12345');
+
+    await runWatchdog({
+      ...h.deps,
+      now,
+      paths,
+      loadConfigImpl: async () => baseConfig,
+      daemonEntry: '/fake/daemon.js',
+    });
+
+    expect(h.terminalEvents).toContain('sigterm');
+    // Both PID files are gone after clean shutdown.
+    await expect(fsp.access(paths.pidFile)).rejects.toThrow();
+    await expect(fsp.access(paths.daemonPidFile)).rejects.toThrow();
+    // SIGTERM was forwarded to the child first.
+    const firstChild = h.spawned[0].child;
+    expect(firstChild.killCalls).toContain('SIGTERM');
+  });
+});
+
+describe('runWatchdog — PID file lifecycle', () => {
+  it('writes the watchdog PID file at startup and removes it on terminal exit', async () => {
+    const h = makeHarness({ healthBehavior: 'fail' });
+    const paths = tmpPaths();
+
+    let t = 0;
+    const now = () => {
+      t += 600;
+      return t;
+    };
+
+    await runWatchdog({
+      ...h.deps,
+      now,
+      paths,
+      loadConfigImpl: async () => baseConfig,
+      daemonEntry: '/fake/daemon.js',
+    });
+
+    // After give-up, PID file is removed.
+    await expect(fsp.access(paths.pidFile)).rejects.toThrow();
+  });
+});

--- a/test/unit/watchdog/policy.test.ts
+++ b/test/unit/watchdog/policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { nextBackoff, shouldRespawn, RESPAWN_LIMITS } from '../../../src/watchdog/policy.js';
+
+describe('watchdog/policy nextBackoff', () => {
+  it('follows the documented exponential ladder for attempts 0..6', () => {
+    const got = [0, 1, 2, 3, 4, 5, 6].map((a) => nextBackoff(a));
+    expect(got).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+  });
+
+  it('clamps far-future attempts at the 30s ceiling', () => {
+    expect(nextBackoff(50)).toBe(30000);
+    expect(nextBackoff(1_000_000)).toBe(30000);
+  });
+
+  it('treats negative attempts as the first attempt (defensive)', () => {
+    expect(nextBackoff(-1)).toBe(1000);
+  });
+});
+
+describe('watchdog/policy shouldRespawn', () => {
+  it('refuses to respawn when /health never returned 200 — that is a startup failure', () => {
+    const decision = shouldRespawn({ everHealthy: false, respawnTimestamps: [] });
+    expect(decision).toEqual({ respawn: false, reason: 'startup-failure' });
+  });
+
+  it(`gives up after ${RESPAWN_LIMITS.maxInWindow} respawns in the rolling 60s window`, () => {
+    const now = 1_000_000;
+    const tooMany = [now - 50_000, now - 40_000, now - 30_000, now - 20_000, now - 10_000];
+    const decision = shouldRespawn({
+      everHealthy: true,
+      respawnTimestamps: tooMany,
+      now,
+    });
+    expect(decision).toEqual({ respawn: false, reason: 'gave-up' });
+  });
+
+  it('counts only respawns inside the window — older ones drop off', () => {
+    const now = 1_000_000;
+    const fourRecentPlusOldOnes = [
+      now - 120_000,
+      now - 90_000,
+      now - 50_000,
+      now - 40_000,
+      now - 30_000,
+      now - 20_000,
+    ];
+    const decision = shouldRespawn({
+      everHealthy: true,
+      respawnTimestamps: fourRecentPlusOldOnes,
+      now,
+    });
+    expect(decision).toEqual({ respawn: true, reason: 'runtime-crash' });
+  });
+
+  it('respawns on the happy path: healthy at least once, no recent burst', () => {
+    const decision = shouldRespawn({ everHealthy: true, respawnTimestamps: [], now: 1_000_000 });
+    expect(decision).toEqual({ respawn: true, reason: 'runtime-crash' });
+  });
+
+  it('respawns when the caller has reset the timestamp list — encodes the "healthy ≥30s resets the counter" contract', () => {
+    // The watchdog is responsible for clearing respawnTimestamps after the
+    // daemon stays healthy ≥30s. From the policy's perspective, an empty
+    // list means "fresh budget" regardless of how many crashes happened
+    // historically.
+    const decision = shouldRespawn({
+      everHealthy: true,
+      respawnTimestamps: [],
+      now: 1_000_000,
+    });
+    expect(decision).toEqual({ respawn: true, reason: 'runtime-crash' });
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation via `kuroboto sleeping` (sleep mode).

## Original prompt

```
Execute this implementation plan. Follow it task-by-task. Run tests, commit per task, and create a final summary at the end.

You are running unattended in a sleep session. Emit progress markers so the dev can
follow along without seeing every tool call. Use this exact format, one per line, on
a line by itself:

[[KUROBOTO]] <one-line update>

Emit a marker:
- after each task is committed: "[[KUROBOTO]] task N done: <what changed>"
- when you hit a blocker that needs human intervention: "[[KUROBOTO]] blocked: <why>"
- at the very end as the final summary: "[[KUROBOTO]] summary: <bullets>"

Keep markers short — one line each, no markdown. They land directly in Telegram.

# Bug C watchdog — daemon auto-recovery

> Status: planned. Spec G. Targets the long-standing "Bug C" — daemon dies silently and stays dead until the user notices and runs `kuroboto ohayo`. PR #26 covered JS exceptions via `installCrashHandlers`; this spec covers everything that bypasses Node-level handlers (external SIGKILL, OOM killer, OS sleep/hibernate, segfault, power loss).

## Problem

The daemon is a single long-lived Node process. Today it dies for several reasons:

1. **JS exception** — covered by `installCrashHandlers` in PR #26: writes `daemon.crash.log` before exit. Solved.
2. **External SIGKILL** — Windows logoff, `taskkill /F`, OOM killer, force-quit, `kill -9`. Bypasses every Node handler. No log, no signal, daemon just vanishes.
3. **OS sleep / hibernate** — laptop closes lid; on wake, Telegram polling connection is dead and never recovers in some cases. Process is alive but functionally dead.
4. **Native crash** — segfault inside libuv or a native dependency. No JS-level recovery.
5. **Power loss** — same as SIGKILL from the daemon's perspective.

Observed at least 3× in the 2026-04-29 session: daemon disappeared between 10–30 min after start with **no entry** in `daemon.log` (no shutdown line) and **no entry** in `daemon.crash.log` (PR #26's coverage). The only evidence was the *absence* of activity. User had to manually re-run `kuroboto ohayo` each time, losing whatever in-flight Telegram polling state existed.

The fix is a separate **watchdog process** that supervises the daemon, detects death instantly via parent-child `child.on('exit')`, and respawns with bounded retries.

## Solution

`kuroboto start --detach` spawns a watchdog process (detached). The watchdog spawns the daemon as **its own child**, listens for `exit`, and respawns with exponential backoff. The watchdog stays simple (~200 LOC, no Telegram polling, no HTTP server, no business logic) so its own failure surface is minimal.

Auto-recovery is **default-on**. There is no "opt-in flag" — Bug C is the entire reason the watchdog exists; making it opt-in would underdeliver on the feature. An opt-out flag `--no-watchdog` is provided for debugging (foreground / direct daemon spawn, current behavior).

In-flight sleeps that die alongside the daemon are **out of scope for v1**. This spec focuses on daemon-level recovery only. Sleep recovery (persistence, re-attach) is deferred to a follow-up spec — see "Future / v2 roadmap" below — and informed by empirical data this v1 will produce.

## Architecture

```
kuroboto start --detach
        │ spawn detached
        ▼
┌──────────────────┐  child.spawn(daemon)   ┌─────────────────────┐
│ watchdog process │ ──────────────────────▶│ daemon process      │
│ (~200 LOC)       │  child.on('exit')      │ (existing lifecycle)│
│  - parent-child  │ ◀──────────────────────┤                     │
│  - backoff       │  poll /v1/health       │ HTTP :47891         │
│  - notify        │ ◀──────────────────────┤                     │
└──────┬───────────┘                        └─────────────────────┘
       │ writes
       ▼
~/.config/kuroboto/watchdog.pid
~/.config/kuroboto/watchdog.log
```

State machine (watchdog):

```
   [STARTING_DAEMON] ──spawn ok──▶ [WAITING_HEALTHY] ──/health 200──▶ [RUNNING]
          │                              │                                 │
          │ spawn fail                   │ timeout 10s                     │ child exit
          ▼                              ▼                                 ▼
   [GIVING_UP]                    [GIVING_UP]                    everHealthy?
                                                                          │
                                                       ┌──────────────────┴────────────────┐
                                                       ▼                                   ▼
                                                  no → [GIVING_UP]                 yes → backoff,
                                                                                          re-spawn,
                                                                                          back to
                                                                                  [STARTING_DAEMON]
```

`everHealthy` is a single boolean per watchdog lifetime: once the daemon's `/v1/health` returns 200 even one time, every subsequent crash is treated as runtime (respawn-eligible). A daemon that never reached healthy is a startup failure (config wrong, port in use) and should not loop.

## Files

**Create:**
- `src/watchdog/index.ts` — entry point. Reads config (port, channel for notifications), spawns daemon as child, manages state machine, handles SIGTERM cleanup.
- `src/watchdog/policy.ts` — pure functions, easy to unit test:
  - `nextBackoff(attempt: number): number` — returns ms (1000, 2000, 4000, 8000, 16000, 30000, 30000…).
  - `shouldRespawn(state: WatchdogState): { respawn: boolean; reason: string }` — encapsulates the everHealthy / max-retries / window logic.
- `src/watchdog/notify.ts` — minimal Telegram sender (subset of `TelegramApi.sendMessage`, plus topic context for `kuroboto-system`). Cannot reuse `TelegramChannel` because the daemon may be dead and the watchdog must remain independent. Best-effort: failures log to watchdog.log and continue.
- `test/unit/watchdog/policy.test.ts`
- `test/unit/watchdog/lifecycle.test.ts`
- `test/integration/watchdog-bugC.test.ts`
- `test/integration/watchdog-startup.test.ts`
- `test/integration/watchdog-stop.test.ts`

**Modify:**
- `src/cli/start.ts` — `startDetached` now spawns the watchdog (not the daemon directly). The `--no-watchdog` flag preserves the legacy direct-spawn path for debug/foreground. Foreground `startForeground` is unchanged.
- `src/cli/stop.ts` — read `WATCHDOG_PID_FILE` first; if present, SIGTERM the watchdog and let it clean up the daemon. If absent (legacy or `--no-watchdog`), fall back to current direct-daemon-kill path.
- `src/cli/status.ts` — show both processes. Detect and clearly flag the split-brain case where watchdog is dead but daemon is alive (rare; happens if the watchdog was killed by hand).
- `src/config/paths.ts` — add `WATCHDOG_PID_FILE = path.join(CONFIG_DIR, 'watchdog.pid')` and `WATCHDOG_LOG_FILE = path.join(CONFIG_DIR, 'watchdog.log')`.
- `src/daemon/lifecycle.ts` — at startup, scan `~/.kuroboto/worktrees/sleep-*` for orphaned worktrees (see "Sleep behavior on crash" below). Notify if found.

## Behavior details

### Startup flow

1. `kuroboto start --detach` runs `checkHealth()`. If daemon already alive → "já está rodando", return.
2. Otherwise spawn the **watchdog** detached, sharing `STARTUP_LOG_FILE` for stdout/stderr (same path used by PR #23 to surface startup errors).
3. Watchdog writes `WATCHDOG_PID_FILE`.
4. Watchdog spawns the daemon as its child, again sharing `STARTUP_LOG_FILE` stdio so any startup error is captured for the parent CLI to tail.
5. Watchdog enters `WAITING_HEALTHY`: polls `http://127.0.0.1:<port>/v1/health` every 250ms for up to 10s.
6. On 200 within 10s → `everHealthy = true`, state → `RUNNING`. Telegram notif `✅ kuroboto online` is sent by the daemon itself (existing behavior). No additional notif from the watchdog on first start.
7. On 10s timeout without 200 → `GIVING_UP`. Watchdog sends notif (best-effort) `❌ daemon não respondeu em 10s — investigar config`, exits non-zero. The CLI parent times out its own wait, reads `STARTUP_LOG_FILE` tail, and prints the error — same UX as PR #23 today.

### Runtime crash flow (Bug C)

1. Daemon dies (any cause: SIGKILL, OOM, segfault, escaped JS exception).
2. Watchdog receives `child.on('exit', (code, signal) => ...)` instantly.
3. `shouldRespawn` consults state:
   - `everHealthy === false` → `{ respawn: false, reason: 'startup-failure' }`. Notif + exit. (Already covered by startup flow above; this path is for the rare case where /health 200'd then immediately died — still treat as runtime since `everHealthy === true`.)
   - 5 respawns within the last 60s (rolling window — count of respawn timestamps where `now - ts < 60_000`) and none reached "healthy ≥30s consecutive" → `{ respawn: false, reason: 'gave-up' }`. Notif `❌ watchdog deu up — 5 falhas em 60s. Última: <signal/code>. Rode kuroboto ohayo quando puder.`. Exits.
   - Otherwise → `{ respawn: true }`. Increment attempt, wait `nextBackoff(attempt)`, spawn again. State → `STARTING_DAEMON`.
4. Per respawn: notif `🔄 daemon respawnado (#N) — exit code <X> / signal <Y>` to the `kuroboto-system` topic if forumMode is on; main chat otherwise.
5. New daemon healthy ≥30s consecutively → reset `attempt = 0`. The 30s threshold means "the daemon stabilized" and unlocks the full backoff budget for any future crash.

### Stop flow

1. `kuroboto stop` reads `WATCHDOG_PID_FILE`. If present → SIGTERM the watchdog. Wait up to 10s for both PID files to disappear.
2. Watchdog SIGTERM handler: SIGTERM the daemon child; wait up to 5s; SIGKILL fallback. Delete `WATCHDOG_PID_FILE` and `PID_FILE`. Exit cleanly.
3. If `WATCHDOG_PID_FILE` is absent (legacy install pre-watchdog, or `--no-watchdog` was used): fall back to current `stop.ts` behavior (read `PID_FILE`, SIGTERM the daemon, polling).

### Sleep behavior on crash (v1 scope)

Sleeps spawned via `SleepingOrchestrator` are children of the **daemon**, not of the watchdog. When the daemon dies, sleep behavior is platform-dependent:

- **Windows**: child cascade-dies via job object inheritance — sleep is killed too. Worktree remains, branch `sleep/<slug>` exists, no PR opened.
- **Linux/macOS**: child may survive (re-parented to init/launchd) but its stdout pipe is orphaned, so `[[KUROBOTO]]` markers are lost. The respawned daemon has no in-memory record of the sleep.

v1 does not attempt to attach to or persist these. Instead, the **respawned daemon scans worktrees on startup**:

- Look for directories matching `~/.kuroboto/worktrees/sleep-*`.
- For each, check the corresponding `sleep/<slug>` branch: if no open PR exists for it AND the worktree's mtime is older than 5 minutes (indicating no recent activity), notify `⚠️ sleep <slug> ficou órfão durante restart; investigar manualmente`.
- The user runs `kuroboto sleeping cancel <slug>` (existing) or `kuroboto sleeping cleanup` (existing, fixed in PR #28) to reclaim.

This is the **scope-limited v1 path**. Empirical observation in production will tell us whether sleeps cascade-die universally on Windows, frequently survive on Linux, etc. — input for v2 design.

### Configuration

No new config keys. `--no-watchdog` is a CLI flag on `start --detach` only. The watchdog reads `~/.config/kuroboto/config.json` once at its own startup (chatId/token/port) and **does not reload across respawns**. If the user edits config while the watchdog is running, they should `kuroboto stop && kuroboto start --detach` to pick it up — same model as the daemon today. Avoiding mid-flight reload keeps the watchdog's state machine deterministic.

## Failure modes

| Failure | Behavior |
|---|---|
| Daemon startup crash (port in use, bad token, broken config) | Watchdog stays in `WAITING_HEALTHY`, times out at 10s, notifies, exits != 0. CLI parent surfaces tail of `STARTUP_LOG_FILE` (PR #23 path). |
| Daemon JS uncaughtException/unhandledRejection | `installCrashHandlers` (PR #26) writes `daemon.crash.log` and exits 1. Watchdog detects exit, respawns. The two coverage paths cooperate. |
| Daemon SIGKILL (Windows logoff, taskkill /F, OOM) | Watchdog `child.on('exit', signal: 'SIGKILL')`. Respawns. Exact bug-C path. |
| Daemon hang (deadlock, infinite loop, stuck in syscall) | **Not covered by v1.** Watchdog only reacts to `exit`. Detection requires active health-check + force-kill — separate feature, see backlog. |
| Watchdog hits 5 respawns in 60s | Notif (Telegram + desktop best-effort), append `daemon.crash.log` "watchdog gave up after N attempts", exit. `kuroboto status` thereafter shows everything dead. User runs `kuroboto ohayo`. |
| Watchdog itself crashes | Daemon child cascade-dies (Windows) or is orphaned (Unix). PID files become stale. `kuroboto status` detects (alive PID check) and shows the state. No auto-recovery — watchdog is simple enough that this should be rare; if it happens repeatedly, that's a bug to fix in code, not patch in process. |
| Telegram unreachable during respawn notif | Notif fail logged to `watchdog.log`. Desktop notif fallback (best-effort, swallows errors). Watchdog logic continues unaffected. |
| Port already in use when daemon respawns | Daemon fails startup (bind error). Watchdog sees daemon's exit before /health ever 200's during this respawn cycle. Already-true `everHealthy` from prior cycle still allows another retry, but if 5 of these happen in 60s → gives up. Reasonable: port-in-use is a real condition that won't self-resolve, and gave-up notif tells the user. |
| Stale `WATCHDOG_PID_FILE` from a crashed prior run | `start.ts` checks `isProcessAlive` on the recorded PID before spawning a new watchdog (mirrors current `ensureNoExistingDaemon` logic). Stale → unlink and proceed. |

## Audit

Three new `source` values in `audit.jsonl` (file at `AUDIT_FILE`, written via existing `appendAudit`):

- `watchdog-respawn` — `decision: 'allow'`, `reason: 'exit code N'` or `'signal SIGKILL'`. Per respawn.
- `watchdog-gave-up` — `decision: 'deny'`, `reason: 'N retries in window M'`. Once per gave-up event.
- `watchdog-startup-failure` — `decision: 'deny'`, `reason: '...'`. When daemon never reaches healthy.

Audit entries from the watchdog use a `requestId` of `watchdog:<isotimestamp>` so they don't collide with daemon's permission-decision entries.

## Out of scope (follow-ups)

- **Sleep persistence and recovery (v2)** — persist active sleeps to `~/.config/kuroboto/sleeps.json` (PID, slug, started, expectedEnd). Respawned daemon reads file, checks each PID with `process.kill(pid, 0)`, marks alive ones as "recovered (markers lost)" or dead ones as failed. Cross-platform behavior (cascade vs orphan) gathered from v1 production data informs the design. Watchdog v1 should expose an `onDaemonRespawn(pid)` interface so v2 can plug in non-invasively. Tracking entry: `docs/specs-backlog.md` — "Spec G2 — sleep recovery".
- **Hang detection** — daemon alive but unresponsive (stuck in deadlock, infinite loop). Requires the watchdog to actively poll `/health` continuously, not just rely on `exit`, and force-SIGKILL when N consecutive polls fail. v1 deliberately ignores this case — it's a real but separate failure mode and folding it in here would double the watchdog's complexity.
- **Self-watchdog** — supervising the watchdog itself with another process. Explicitly rejected: the watchdog is small enough that "watch the watchdog" adds more failure surface than it removes. If the watchdog crashes, the user runs `kuroboto ohayo`.
- **OS service integration (NSSM/systemd/launchd)** — wrapping the daemon as a real OS-managed service. Powerful but requires admin/root, OS-specific install steps, and breaks the `npm i -g kuroboto` simplicity. Not aligned with the project's "single binary, user-mode" stance.

## Test plan

### Unit (`policy.test.ts`)

- `nextBackoff(0..6)` returns `[1000, 2000, 4000, 8000, 16000, 30000, 30000]`.
- `shouldRespawn` with `everHealthy: false` → `{ respawn: false, reason: 'startup-failure' }`.
- `shouldRespawn` with 5 attempts in last 60s and none reached healthy ≥30s → `{ respawn: false, reason: 'gave-up' }`.
- `shouldRespawn` with attempts that include a "healthy ≥30s" reset → counter is back to 0, respawn allowed.
- `shouldRespawn` happy path → `{ respawn: true }`.

### Unit (`lifecycle.test.ts` — mock `spawn`, mock `fetch`, mock `fs`)

- Watchdog spawns daemon, child exits before /health ever 200's → does not respawn, exits non-zero.
- Watchdog spawns daemon, /health 200's, child exits later → respawns after correct backoff delay.
- Watchdog SIGTERM handler → SIGTERM-then-SIGKILL the child, deletes both PID files.
- Watchdog crash notif goes to `kuroboto-system` topic when `forumMode: true`, main chat otherwise.

### Integration / anti-regression

Each of these references a real bug or PR; the test name carries the reference so a future refactor doesn't silently regress it.

**`watchdog-bugC.test.ts`** — covers the original Bug C from the 2026-04-29 sessions:

- `'respawns after external SIGKILL (bug C from 2026-04-29 sessions)'` — spawn a real foreground daemon process, then `process.kill(daemonPid, 'SIGKILL')`. Assert the watchdog (under test) detects the exit, waits ~1s backoff, respawns, and the new daemon's `/health` returns 200 within 10s.
- `'respawns after daemon JS crash + crashHandlers fired (bug C path 2 — PR #26 integration)'` — spawn a daemon-mock that throws after 2s. Assert (a) `daemon.crash.log` contains the entry (PR #26 path still works) AND (b) the watchdog respawned (new path). Cross-coverage of the two.
- `'does NOT respawn when daemon never becomes healthy (avoids infinite loop on bad config)'` — daemon-mock that exits immediately on startup. Assert watchdog gives up without retrying, and `daemon.crash.log` mentions startup failure.
- `'gives up after 5 rapid respawns in 60s window'` — daemon-mock that exits 1s after each healthy check. Assert: 5 respawns happen, then `watchdog-gave-up` audit entry, then watchdog exit non-zero.

**`watchdog-startup.test.ts`** — covers PR #23 regression:

- `'surfaces startup errors via STARTUP_LOG_FILE (PR #23 regression coverage)'` — start with a config that fails to bind (port already in use). Assert the CLI parent receives the error with tail of `STARTUP_LOG_FILE` formatted the same way as today.
- `'falls back to direct daemon spawn with --no-watchdog flag'` — assert legacy path: no watchdog process, only daemon, behaves like pre-spec.

**`watchdog-stop.test.ts`** — covers stop-flow correctness:

- `'kuroboto stop kills both watchdog and daemon, cleans both PID files'`.
- `'kuroboto stop with stale watchdog PID file falls back to direct daemon kill (legacy path)'`.
- `'kuroboto stop times out after 10s if watchdog hangs'` — error path; assert clear error to user.

### Manual smoke (post-merge)

1. `kuroboto start --detach` → `kuroboto status` shows `watchdog: alive (PID=A)` and `daemon: alive (PID=B)`.
2. `taskkill /F /PID <B>` (Windows) or `kill -9 <B>` (Unix) → Telegram receives `🔄 daemon respawnado (#1)` within ~1–2 seconds; status reports a new daemon PID.
3. Loop-kill the daemon 6× rapidly within 60s → after the 5th, `❌ watchdog deu up` notif arrives, status shows everything dead.
4. `kuroboto stop` → both processes terminate in order, PID files cleaned.
5. Edit config to set `daemon.port` to an in-use port. `kuroboto start --detach` → expect clear startup error with log tail, no infinite respawn loop.
6. `kuroboto start --detach --no-watchdog` → only daemon spawns; legacy behavior preserved; status correctly shows `watchdog: (none)` without flagging it as a problem.

## Tasks (milestones)

1. **M1**: `policy.ts` (pure) + `policy.test.ts`. `paths.ts` adds `WATCHDOG_PID_FILE` and `WATCHDOG_LOG_FILE`. No daemon code touched yet. Mergeable on its own.
2. **M2**: `index.ts` (watchdog runtime) + `notify.ts` (minimal Telegram client) + `lifecycle.test.ts`. Functional standalone — can be exercised manually by running it directly. No CLI integration yet.
3. **M3**: Wire into `start.ts`, `stop.ts`, `status.ts`. Daemon-side worktree-orphan scan in `lifecycle.ts`. All anti-regression integration tests. Manual smoke. PR.

```

## Test plan

- [ ] Review the diff against the original prompt
- [ ] Run the test suite locally
- [ ] Smoke-test the new behavior end-to-end

_Generated by kuroboto sleep mode._