### PR TITLE
fix(daemon): permission timeout returns ask, not deny

### DIFF
--- a/src/daemon/pending.ts
+++ b/src/daemon/pending.ts
@@ -34,7 +34,13 @@ export class PendingMap {
       const e = this.entries.get(requestId);
       if (e) {
         this.entries.delete(requestId);
-        e.resolve({ decision: 'deny', reason: 'timeout' });
+        // Resolve as 'ask' (not 'deny') so the hook surfaces no decision and
+        // Claude Code falls back to its native permission UI. Denying on
+        // timeout used to surface as "PreToolUse hook blocking error: timeout"
+        // — confusing for desk users who simply hadn't seen the Telegram
+        // prompt yet. Remote workflow is unaffected: replies arriving inside
+        // the window still hit `resolve()` with the real decision.
+        e.resolve({ decision: 'ask', reason: 'timeout' });
       }
     }, timeoutMs);
     this.entries.set(requestId, {

--- a/src/daemon/routes.ts
+++ b/src/daemon/routes.ts
@@ -516,7 +516,7 @@ export function registerRoutes(app: Express, ctx: DaemonContext): void {
 }
 
 function deriveSource(d: Decision): string {
-  if (d.decision === 'deny' && d.reason === 'timeout') return 'timeout';
+  if (d.reason === 'timeout') return 'timeout';
   if (d.decision === 'ask' && d.reason === 'channel unavailable') return 'channel-error';
   return 'telegram';
 }

--- a/test/integration/daemon.test.ts
+++ b/test/integration/daemon.test.ts
@@ -259,7 +259,7 @@ describe('daemon HTTP', () => {
     expect(res.body).toEqual({ decision: 'allow', reason: 'tap' });
   });
 
-  it('POST /v1/permission in away mode resolves with timeout deny when nobody responds', async () => {
+  it('POST /v1/permission in away mode resolves with timeout ask when nobody responds', async () => {
     const { ctx: shortCtx } = makeContext({
       mode: 'away',
       policy: { permissionTimeoutMs: 200 },
@@ -268,7 +268,7 @@ describe('daemon HTTP', () => {
       .post('/v1/permission')
       .set('X-Kuroboto-Token', TEST_TOKEN)
       .send({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: {} });
-    expect(res.body).toEqual({ decision: 'deny', reason: 'timeout' });
+    expect(res.body).toEqual({ decision: 'ask', reason: 'timeout' });
   });
 
   it('POST /v1/permission falls back to ask when sendPrompt throws (channel unavailable)', async () => {

--- a/test/unit/pending.test.ts
+++ b/test/unit/pending.test.ts
@@ -9,11 +9,15 @@ describe('PendingMap', () => {
     expect(await promise).toEqual({ decision: 'allow' });
   });
 
-  it('returns timeout deny when nobody resolves in time', async () => {
+  it('returns timeout ask when nobody resolves in time', async () => {
+    // On timeout we ask Claude Code to fall back to its native permission UI
+    // rather than denying the tool call. Denying surfaces as a "hook blocking
+    // error: timeout" and prevents desk users from approving via the CC UI
+    // when the Telegram side missed the prompt.
     const map = new PendingMap();
     const { promise } = map.create(50);
     const decision = await promise;
-    expect(decision).toEqual({ decision: 'deny', reason: 'timeout' });
+    expect(decision).toEqual({ decision: 'ask', reason: 'timeout' });
   });
 
   it('drainAll denies every pending entry with the given reason', async () => {


### PR DESCRIPTION
## Summary
- `/v1/permission` timeout now resolves with `{decision:'ask',reason:'timeout'}` instead of `{decision:'deny',reason:'timeout'}`.
- Effect: the PreToolUse hook exits with no `permissionDecision`, so Claude Code falls back to its native permission flow (allowlist + UI). Pre-fix it surfaced as **"PreToolUse hook blocking error: timeout"** and bricked every Bash command not in the kuroboto allowlist for desk users who hadn't seen the Telegram prompt in time.
- Remote-only workflow unchanged: replies inside the window still hit `pending.resolve()` with the real decision. Only the "no reply" fallback semantics shift.
- `deriveSource` updated so audit entries keep `source: 'timeout'` regardless of the new decision shape.

## Test plan
- [x] Unit (`test/unit/pending.test.ts`): timeout path resolves to `decision: 'ask'`
- [x] Integration (`test/integration/daemon.test.ts`): away-mode `/v1/permission` timeout returns `{decision:'ask',reason:'timeout'}`
- [x] Full suite: 525 passed, 1 skipped, 0 failed
- [x] Manual repro: `kuroboto hook pre-tool` with a non-allowlisted Bash payload exits with empty stdout (= 'ask' path) after 55s. Pre-fix it wrote `{\"permissionDecision\":\"deny\"}` and CC bricked the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)